### PR TITLE
closes #43

### DIFF
--- a/fixtures/default_groups.json
+++ b/fixtures/default_groups.json
@@ -376,11 +376,6 @@
         "invoiceitem"
       ],
       [
-        "change_operation",
-        "invoicing",
-        "operation"
-      ],
-      [
         "add_issue",
         "support",
         "issue"

--- a/local_settings_sample.py
+++ b/local_settings_sample.py
@@ -65,7 +65,7 @@ else:
     pass
 
 # Replace with your own allowed hosts.
-ALLOWED_HOSTS = ["127.0.0.1"]
+ALLOWED_HOSTS = ["localhost"]
 
 WEB_UPDATE_USER_ENABLED = False
 
@@ -95,7 +95,8 @@ STATES = (("State 1", "State 1"), ("State 2", "State 2"))
 
 # Add your payment methods for subscriptions here. This is required for the program to work.
 SUBSCRIPTION_PAYMENT_METHODS = (
-    ("O", "Other")("D", "Debit card"),
+    ("O", "Other"),
+    ("D", "Debit card"),
     ("S", "Cash payment"),
 )
 
@@ -138,7 +139,7 @@ MAILTRAIN_API_URL = MAILTRAIN_URL + "api/"
 MAILTRAIN_API_KEY = "your_secret_key"
 
 # Use this if you have a custom app that you want to load the URLs from
-URLS_CUSTOM_MODULE = 'your.module.urls'
+# URLS_CUSTOM_MODULE = 'your.module.urls'
 
 # Set this to true if you want to require route for billing. Useful for when you explicitly require to send the invoice
 # via logistics.


### PR DESCRIPTION
- Non-existing model fixture entry removed
- In ALLOWED_HOSTS sample local setting, 'localhost' is better than 127.0.0.1 because INSTALL.md points to a 'runserver' without ip, then 'localhost' is the default host
- Syntax error fix in sample setting
- Commented a sample setting that should raise error if not configured