### PR TITLE
t1126: create SalesRecord on product_change, additional_product, and …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## v0.5.0
 
+## 2026-04-24 — t1126 SalesRecord creation for product change, additional product, and retention flows
+
+- Product change, additional product, and retention discount views now always create a `SalesRecord` (type PARTIAL) so sales appear in the manager sales filter — they were previously invisible there
+- In the ladiaria `edit_subscription` view, multiple products added in one session now produce a single PARTIAL `SalesRecord` instead of one per product
+- The validate-sale form (`can_be_commissioned` checkbox) now defaults to checked for all sale types; an explanatory note was added so managers understand the commission implications
+- Fixed an `AttributeError` bug: `SalesRecord.TYPES.PARTIAL` corrected to `SalesRecord.SALE_TYPE.PARTIAL` in `book_additional_product`
+- No migrations required
+- **Author:** Tanya Tree + Claude Sonnet 4.6
+
 ## 2026-04-08 — t0243 Canceled invoices report view in invoicing app
 
 - A new `CanceledInvoicesReportView` is available in the base CRM, replacing the function view that previously existed only in the ladiaria customisation layer

--- a/docs/en/devnotes/2026-04-24-t1126-salesrecord-partial-flows.md
+++ b/docs/en/devnotes/2026-04-24-t1126-salesrecord-partial-flows.md
@@ -1,0 +1,164 @@
+# SalesRecord Creation for Product Change, Additional Product, and Retention Flows
+
+- **Date:** 2026-04-24
+- **Author:** Tanya Tree + Claude Sonnet 4.6
+- **Ticket:** t1126
+- **Type:** Bug Fix | Enhancement
+- **Component:** Support — Subscriptions, Sales Registry
+- **Impact:** Data Integrity, Operator Workflow, Commission Calculation
+
+## 🎯 Summary
+
+The `SalesRecordFilterManagersView` (the manager sales filter at `support/sales_record_filter/`) was not showing sales made through product change, additional product, or retention discount flows because those views never created `SalesRecord` objects. Only new-subscription and edit-subscription flows created records. This ticket fixes all three missing flows in both the base app and the ladiaria customisation layer, standardises how partial sales records are created in the ladiaria `edit_subscription` view (one record per session instead of one per product), fixes an `AttributeError` bug caused by a wrong attribute path, and improves the validate-sale UX by defaulting the commission checkbox to checked with an explanatory note.
+
+## ✨ Changes
+
+### 1. SalesRecord creation added to `product_change` (base and ladiaria)
+
+**Files:** `support/views/subscriptions.py`, `utopia_crm_ladiaria/views/subscriptions.py`
+
+Both `product_change` (base) and `ladiaria_product_change` now create one PARTIAL `SalesRecord` on the new subscription, containing only the newly activated type-`S` products. The price is the difference between the new and old subscription prices, matching the pattern already used by `book_additional_product`.
+
+```python
+sf = SalesRecord.objects.create(
+    subscription=new_subscription,
+    seller_id=seller_id,
+    price=new_subscription.get_price_for_full_period() - old_subscription.get_price_for_full_period(),
+    sale_type=SalesRecord.SALE_TYPE.PARTIAL,
+)
+sf.products.add(*new_products_list)  # only type "S" products
+if not seller_id:
+    sf.set_generic_seller()
+```
+
+### 2. SalesRecord creation added to `add_retention_discount` (base and ladiaria)
+
+**Files:** `support/views/subscriptions.py`, `utopia_crm_ladiaria/views/retention.py`
+
+Both `add_retention_discount` (base) and `ladiaria_add_retention_discount` now create one PARTIAL `SalesRecord`. Retention discount products (type `D`, `P`, or `A`) are intentionally excluded — only newly added subscription products (type `S`) are linked to the record, because discount products have no independent sale value.
+
+### 3. `edit_subscription` partial sales: one record per session (ladiaria)
+
+**File:** `utopia_crm_ladiaria/views/subscriptions.py` — `LadiariaSubscriptionMixin.process_subscription_products`
+
+Previously, each newly added product inside an edit-subscription POST created its own `SalesRecord` with default type FULL. This was inconsistent with the other partial-sale flows and produced cluttered records when adding two or more products at once.
+
+The method was refactored: the per-product record creation was removed from inside the loop; instead, all newly added type-`S` products are collected and a single PARTIAL `SalesRecord` is created after the loop, with the price set to the sum of the individual product prices:
+
+```python
+if self.edit_subscription and added_subscription_products:
+    price = sum(p.price for p in added_subscription_products)
+    sf = SalesRecord.objects.create(
+        subscription=subscription,
+        seller_id=self.user_seller_id,
+        price=price,
+        sale_type=SalesRecord.SALE_TYPE.PARTIAL,
+        campaign=self.campaign,
+    )
+    sf.products.add(*added_subscription_products)
+    if not self.user_seller_id:
+        sf.set_generic_seller()
+```
+
+No record is created if no new subscription products were added (e.g. the user only updated addresses).
+
+### 4. Bug fix: `SalesRecord.TYPES.PARTIAL` → `SalesRecord.SALE_TYPE.PARTIAL`
+
+**File:** `support/views/subscriptions.py` — `book_additional_product`
+
+The attribute `SalesRecord.TYPES` does not exist; the correct path is `SalesRecord.SALE_TYPE`. The existing call would raise an `AttributeError` at runtime. Fixed to use `SalesRecord.SALE_TYPE.PARTIAL`.
+
+### 5. Validate-sale form: `can_be_commissioned` defaults to checked
+
+**Files:** `support/views/all_views.py`, `support/templates/validate_subscription_sales_record.html`
+
+`ValidateSubscriptionSalesRecord.get_initial` previously forced `can_be_commissioned=False` for any non-FULL sale, which meant partial sales (product changes, retentions) would never appear as commissionable by default. The explicit override was removed; the field now relies on the model's own default (`True`).
+
+An explanatory note was added below the checkbox in the template:
+
+> "If checked, the seller will receive commission for this sale. Uncheck to exclude it from commission calculations (e.g. retention discounts or non-commissionable changes)."
+
+### 6. Unit tests extended
+
+**Files:** `utopia_crm_ladiaria/tests/test_seller_registry.py`, `utopia_crm_ladiaria/tests/test_product_change_views.py`, `utopia_crm_ladiaria/tests/test_retention_view.py`
+
+- **`TestSellerRegistryFullSalesRecord`** (13 new cases): covers new-subscription FULL records (count, products, seller, price, type) and edit-subscription PARTIAL records (one per session, only new products, correct price sum, type, discount products excluded, no-seller flow).
+- **`TestProductChangeSalesRecord`** (8 new cases): covers `ladiaria_product_change` and `ladiaria_book_additional_product` — record created, correct products, seller assigned, type PARTIAL.
+- **`TestRetentionDiscountSalesRecord`** (7 new cases): covers `ladiaria_add_retention_discount` — record created, discount products excluded, type-S products included, seller assigned, type PARTIAL, no record on failed validation.
+
+## 📁 Files Modified
+
+- **`support/views/subscriptions.py`** — Added `SalesRecord` creation to `product_change` and `add_retention_discount`; fixed `TYPES.PARTIAL` bug in `book_additional_product`
+- **`support/views/all_views.py`** — Removed forced `can_be_commissioned=False` in `ValidateSubscriptionSalesRecord.get_initial`
+- **`support/templates/validate_subscription_sales_record.html`** — Added explanatory note for the `can_be_commissioned` checkbox
+- **`utopia_crm_ladiaria/views/subscriptions.py`** — Added `SalesRecord` creation to `ladiaria_product_change`; refactored `process_subscription_products` to create one PARTIAL record per edit session
+- **`utopia_crm_ladiaria/views/retention.py`** — Added `SalesRecord` creation to `ladiaria_add_retention_discount`
+- **`utopia_crm_ladiaria/tests/test_seller_registry.py`** — New `TestSellerRegistryFullSalesRecord` class with 13 test cases
+- **`utopia_crm_ladiaria/tests/test_product_change_views.py`** — New `TestProductChangeSalesRecord` class with 8 test cases
+- **`utopia_crm_ladiaria/tests/test_retention_view.py`** — New `TestRetentionDiscountSalesRecord` class with 7 test cases
+
+## 📚 Technical Details
+
+- Only type-`S` (subscription) products are linked to `SalesRecord.products` in partial flows. Discount products (type `D`, `P`, `A`) are explicitly filtered out because they do not represent independently sold items and would distort commission calculations.
+- `set_generic_seller()` is always called when no seller ID is available, consistent with all other `SalesRecord` creation points in the codebase.
+- The base app views (`product_change`, `add_retention_discount`) were also fixed even though they are overridden by ladiaria URLs, to keep the base package correct for other deployments.
+- All 55 tests across the three test files pass after the changes.
+
+## 🧪 Manual Testing
+
+1. **Happy path — product change by a seller creates a visible sales record:**
+   - Log in as a user with an associated `Seller`.
+   - Open a contact with an active subscription and go to the product change view.
+   - Select a new product to add and submit.
+   - Navigate to `support/sales_record_filter/` as a manager.
+   - **Verify:** The new PARTIAL sales record appears in the list, linked to the new subscription and showing only the newly added product(s).
+
+2. **Happy path — retention discount creates a sales record with only type-S products:**
+   - Apply a retention discount (type `D`) plus one new subscription product (type `S`) via the retention view.
+   - Check the sales filter.
+   - **Verify:** The record shows the type-`S` product; the discount product does not appear.
+
+3. **Happy path — validate-sale form defaults to commissionable:**
+   - Open the validate-sale page for a PARTIAL sale.
+   - **Verify:** The `can_be_commissioned` checkbox is checked by default.
+   - Read the explanatory note below it.
+   - **Verify:** The note explains what enabling/disabling the checkbox implies.
+
+4. **Edge case — edit subscription adding two products creates one record, not two:**
+   - Edit an existing subscription and add two new products in the same POST.
+   - Check `SalesRecord.objects.filter(subscription=...)`.
+   - **Verify:** Exactly one record exists; both products are linked to it; the price equals the sum of both product prices.
+
+5. **Edge case — edit subscription with no new products creates no record:**
+   - Edit an existing subscription and change only an address (no new products).
+   - **Verify:** No new `SalesRecord` is created.
+
+6. **Edge case — product change by a user without a seller still creates a record:**
+   - Log in as a superuser with no associated `Seller`.
+   - Run a product change.
+   - **Verify:** A `SalesRecord` is created with a generic seller (or seller set via `set_generic_seller()`).
+
+## 📝 Deployment Notes
+
+- No database migrations required.
+- No configuration changes required.
+- After deploying, existing subscriptions that went through product-change or retention flows before this fix will not retroactively have `SalesRecord` entries. If historical records are needed for those subscriptions, they can be created manually via the existing `SalesRecordCreateView` (`support/create_sales_record/<subscription_id>/`).
+
+## 🎓 Design Decisions
+
+Discount products are excluded from `SalesRecord.products` because a retention discount applied to a subscription is not a sale — it is a price reduction. Including it would inflate product counts in commission calculations and campaign statistics. The seller is still recorded on the record (and commissions can be calculated at validation time) based on the subscription price difference, which already accounts for discounts.
+
+One PARTIAL record per edit session (rather than one per product) aligns with how the other partial-sale views work and avoids cluttering the manager sales filter with multiple near-identical records when a seller adds a bundle of products at once. The price is the sum of the individual product prices, which is correct for a monthly subscription where each product has an independent price.
+
+## 🚀 Future Improvements
+
+- The `SalesRecordFilterManagersView` could expose a "sale type" filter column so managers can distinguish FULL vs PARTIAL records at a glance without opening each one.
+- Consider surfacing the `can_be_commissioned` default differently based on sale type (e.g. a visual warning for retention records) rather than relying solely on the manager to uncheck it.
+
+---
+
+- **Date:** 2026-04-24
+- **Author:** Tanya Tree + Claude Sonnet 4.6
+- **Branch:** t1126
+- **Type:** Bug Fix | Enhancement
+- **Modules affected:** Support, Sales Registry

--- a/docs/es/devnotes/2026-04-24-t1126-salesrecord-flujos-parciales.md
+++ b/docs/es/devnotes/2026-04-24-t1126-salesrecord-flujos-parciales.md
@@ -1,0 +1,164 @@
+# Creación de SalesRecord en flujos de cambio de producto, producto adicional y retención
+
+- **Fecha:** 2026-04-24
+- **Autor:** Tanya Tree + Claude Sonnet 4.6
+- **Ticket:** t1126
+- **Tipo:** Corrección | Mejora
+- **Componente:** Support — Suscripciones, Registro de Ventas
+- **Impacto:** Integridad de Datos, Flujo de Trabajo de Operadores, Cálculo de Comisiones
+
+## 🎯 Resumen
+
+El `SalesRecordFilterManagersView` (el filtro de ventas para gestores en `support/sales_record_filter/`) no mostraba ventas realizadas a través de los flujos de cambio de producto, producto adicional o descuento de retención, porque esas vistas nunca creaban objetos `SalesRecord`. Solo los flujos de nueva suscripción y edición de suscripción creaban registros. Este ticket corrige los tres flujos faltantes en el paquete base y en la capa de personalización de ladiaria, estandariza la creación de registros de venta parcial en la vista `edit_subscription` de ladiaria (un registro por sesión en lugar de uno por producto), corrige un bug de `AttributeError` causado por una ruta de atributo incorrecta, y mejora la UX del formulario de validación de ventas poniendo el checkbox de comisión marcado por defecto con una nota explicativa.
+
+## ✨ Cambios
+
+### 1. Creación de SalesRecord en `product_change` (base y ladiaria)
+
+**Archivos:** `support/views/subscriptions.py`, `utopia_crm_ladiaria/views/subscriptions.py`
+
+Tanto `product_change` (base) como `ladiaria_product_change` ahora crean un `SalesRecord` PARTIAL en la nueva suscripción, conteniendo solo los productos de tipo `S` recién activados. El precio es la diferencia entre el precio de la nueva y la vieja suscripción, siguiendo el mismo patrón que ya usaba `book_additional_product`.
+
+```python
+sf = SalesRecord.objects.create(
+    subscription=new_subscription,
+    seller_id=seller_id,
+    price=new_subscription.get_price_for_full_period() - old_subscription.get_price_for_full_period(),
+    sale_type=SalesRecord.SALE_TYPE.PARTIAL,
+)
+sf.products.add(*new_products_list)  # solo productos tipo "S"
+if not seller_id:
+    sf.set_generic_seller()
+```
+
+### 2. Creación de SalesRecord en `add_retention_discount` (base y ladiaria)
+
+**Archivos:** `support/views/subscriptions.py`, `utopia_crm_ladiaria/views/retention.py`
+
+Tanto `add_retention_discount` (base) como `ladiaria_add_retention_discount` ahora crean un `SalesRecord` PARTIAL. Los productos de descuento de retención (tipo `D`, `P` o `A`) se excluyen intencionalmente — solo se vinculan al registro los nuevos productos de suscripción (tipo `S`), porque los productos de descuento no tienen valor de venta independiente.
+
+### 3. Ventas parciales en `edit_subscription`: un registro por sesión (ladiaria)
+
+**Archivo:** `utopia_crm_ladiaria/views/subscriptions.py` — `LadiariaSubscriptionMixin.process_subscription_products`
+
+Anteriormente, cada producto nuevo agregado dentro de un POST de edición de suscripción creaba su propio `SalesRecord` con tipo FULL por defecto. Esto era inconsistente con los otros flujos de venta parcial y generaba registros repetidos al agregar dos o más productos al mismo tiempo.
+
+El método fue refactorizado: la creación del registro por producto fue eliminada del interior del loop; en su lugar, todos los productos de tipo `S` recién agregados se acumulan y se crea un único `SalesRecord` PARTIAL después del loop, con el precio igual a la suma de los precios individuales:
+
+```python
+if self.edit_subscription and added_subscription_products:
+    price = sum(p.price for p in added_subscription_products)
+    sf = SalesRecord.objects.create(
+        subscription=subscription,
+        seller_id=self.user_seller_id,
+        price=price,
+        sale_type=SalesRecord.SALE_TYPE.PARTIAL,
+        campaign=self.campaign,
+    )
+    sf.products.add(*added_subscription_products)
+    if not self.user_seller_id:
+        sf.set_generic_seller()
+```
+
+No se crea ningún registro si no se agregaron productos de suscripción nuevos (por ejemplo, si el usuario solo actualizó direcciones).
+
+### 4. Corrección de bug: `SalesRecord.TYPES.PARTIAL` → `SalesRecord.SALE_TYPE.PARTIAL`
+
+**Archivo:** `support/views/subscriptions.py` — `book_additional_product`
+
+El atributo `SalesRecord.TYPES` no existe; la ruta correcta es `SalesRecord.SALE_TYPE`. La llamada existente lanzaría un `AttributeError` en tiempo de ejecución. Corregido a `SalesRecord.SALE_TYPE.PARTIAL`.
+
+### 5. Formulario de validación: `can_be_commissioned` marcado por defecto
+
+**Archivos:** `support/views/all_views.py`, `support/templates/validate_subscription_sales_record.html`
+
+`ValidateSubscriptionSalesRecord.get_initial` anteriormente forzaba `can_be_commissioned=False` para cualquier venta no FULL, lo que significaba que las ventas parciales (cambios de producto, retenciones) nunca aparecerían como comisionables por defecto. El override explícito fue eliminado; el campo ahora usa el valor por defecto del modelo (`True`).
+
+Se agregó una nota explicativa debajo del checkbox en el template:
+
+> "Si está marcado, el vendedor recibirá comisión por esta venta. Desmarcarlo excluye la venta de los cálculos de comisión (ej. descuentos de retención o cambios no comisionables)."
+
+### 6. Tests unitarios extendidos
+
+**Archivos:** `utopia_crm_ladiaria/tests/test_seller_registry.py`, `utopia_crm_ladiaria/tests/test_product_change_views.py`, `utopia_crm_ladiaria/tests/test_retention_view.py`
+
+- **`TestSellerRegistryFullSalesRecord`** (13 casos nuevos): cubre registros FULL de nueva suscripción (cantidad, productos, vendedor, precio, tipo) y registros PARTIAL de edición (uno por sesión, solo productos nuevos, suma de precios correcta, tipo, productos de descuento excluidos, flujo sin vendedor).
+- **`TestProductChangeSalesRecord`** (8 casos nuevos): cubre `ladiaria_product_change` y `ladiaria_book_additional_product` — registro creado, productos correctos, vendedor asignado, tipo PARTIAL.
+- **`TestRetentionDiscountSalesRecord`** (7 casos nuevos): cubre `ladiaria_add_retention_discount` — registro creado, productos de descuento excluidos, productos tipo S incluidos, vendedor asignado, tipo PARTIAL, sin registro cuando falla la validación.
+
+## 📁 Archivos Modificados
+
+- **`support/views/subscriptions.py`** — Creación de `SalesRecord` agregada a `product_change` y `add_retention_discount`; corregido bug `TYPES.PARTIAL` en `book_additional_product`
+- **`support/views/all_views.py`** — Eliminado el forzado de `can_be_commissioned=False` en `ValidateSubscriptionSalesRecord.get_initial`
+- **`support/templates/validate_subscription_sales_record.html`** — Nota explicativa agregada para el checkbox `can_be_commissioned`
+- **`utopia_crm_ladiaria/views/subscriptions.py`** — Creación de `SalesRecord` agregada a `ladiaria_product_change`; refactorización de `process_subscription_products` para crear un registro PARTIAL por sesión de edición
+- **`utopia_crm_ladiaria/views/retention.py`** — Creación de `SalesRecord` agregada a `ladiaria_add_retention_discount`
+- **`utopia_crm_ladiaria/tests/test_seller_registry.py`** — Nueva clase `TestSellerRegistryFullSalesRecord` con 13 casos de test
+- **`utopia_crm_ladiaria/tests/test_product_change_views.py`** — Nueva clase `TestProductChangeSalesRecord` con 8 casos de test
+- **`utopia_crm_ladiaria/tests/test_retention_view.py`** — Nueva clase `TestRetentionDiscountSalesRecord` con 7 casos de test
+
+## 📚 Detalles Técnicos
+
+- Solo los productos de tipo `S` (suscripción) se vinculan a `SalesRecord.products` en los flujos parciales. Los productos de descuento (tipo `D`, `P`, `A`) se filtran explícitamente porque no representan ítems vendidos de forma independiente y distorsionarían los cálculos de comisión.
+- `set_generic_seller()` siempre se llama cuando no hay seller ID disponible, de forma consistente con todos los demás puntos de creación de `SalesRecord` en el código.
+- Las vistas del paquete base (`product_change`, `add_retention_discount`) también fueron corregidas aunque son sobreescritas por las URLs de ladiaria, para mantener el paquete base correcto para otros despliegues.
+- Los 55 tests en los tres archivos de test pasan correctamente después de los cambios.
+
+## 🧪 Pruebas Manuales
+
+1. **Caso exitoso — cambio de producto por un vendedor crea un registro visible:**
+   - Iniciar sesión como usuario con un `Seller` asociado.
+   - Abrir un contacto con suscripción activa e ir a la vista de cambio de producto.
+   - Seleccionar un producto nuevo para agregar y enviar el formulario.
+   - Navegar a `support/sales_record_filter/` como gestor.
+   - **Verificar:** El nuevo registro PARTIAL aparece en la lista, vinculado a la nueva suscripción y mostrando solo el/los producto(s) recién agregado(s).
+
+2. **Caso exitoso — descuento de retención crea registro solo con productos tipo S:**
+   - Aplicar un descuento de retención (tipo `D`) más un nuevo producto de suscripción (tipo `S`) desde la vista de retención.
+   - Revisar el filtro de ventas.
+   - **Verificar:** El registro muestra el producto tipo `S`; el producto de descuento no aparece.
+
+3. **Caso exitoso — formulario de validación tiene comisión marcada por defecto:**
+   - Abrir la página de validación de venta para una venta PARTIAL.
+   - **Verificar:** El checkbox `can_be_commissioned` está marcado por defecto.
+   - Leer la nota explicativa debajo del checkbox.
+   - **Verificar:** La nota explica qué implica activar/desactivar el checkbox.
+
+4. **Caso borde — editar suscripción agregando dos productos crea un solo registro:**
+   - Editar una suscripción existente y agregar dos productos nuevos en el mismo POST.
+   - Revisar `SalesRecord.objects.filter(subscription=...)`.
+   - **Verificar:** Existe exactamente un registro; ambos productos están vinculados a él; el precio es igual a la suma de los precios de ambos productos.
+
+5. **Caso borde — editar suscripción sin agregar productos no crea registro:**
+   - Editar una suscripción existente y cambiar solo una dirección (sin productos nuevos).
+   - **Verificar:** No se crea ningún `SalesRecord` nuevo.
+
+6. **Caso borde — cambio de producto por usuario sin vendedor igual crea registro:**
+   - Iniciar sesión como superusuario sin `Seller` asociado.
+   - Ejecutar un cambio de producto.
+   - **Verificar:** Se crea un `SalesRecord` con vendedor genérico (asignado vía `set_generic_seller()`).
+
+## 📝 Notas de Despliegue
+
+- No se requieren migraciones de base de datos.
+- No se requieren cambios de configuración.
+- Tras el despliegue, las suscripciones existentes que pasaron por flujos de cambio de producto o retención antes de esta corrección no tendrán entradas `SalesRecord` retroactivas. Si se necesitan registros históricos para esas suscripciones, pueden crearse manualmente usando la vista existente `SalesRecordCreateView` (`support/create_sales_record/<subscription_id>/`).
+
+## 🎓 Decisiones de Diseño
+
+Los productos de descuento se excluyen de `SalesRecord.products` porque un descuento de retención aplicado a una suscripción no es una venta — es una reducción de precio. Incluirlo inflaría los conteos de productos en los cálculos de comisión y estadísticas de campaña. El vendedor sigue registrado en el record (y las comisiones pueden calcularse en el momento de la validación) en base a la diferencia de precio de la suscripción, que ya contempla los descuentos.
+
+Un registro PARTIAL por sesión de edición (en lugar de uno por producto) se alinea con el funcionamiento de los demás flujos de venta parcial y evita llenar el filtro de ventas con múltiples registros casi idénticos cuando un vendedor agrega un conjunto de productos al mismo tiempo. El precio es la suma de los precios individuales, lo cual es correcto para una suscripción mensual donde cada producto tiene un precio independiente.
+
+## 🚀 Mejoras Futuras
+
+- El `SalesRecordFilterManagersView` podría exponer una columna de filtro por "tipo de venta" para que los gestores distingan registros FULL vs PARTIAL de un vistazo sin tener que abrir cada uno.
+- Considerar mostrar el default de `can_be_commissioned` de forma diferente según el tipo de venta (ej. una advertencia visual para registros de retención) en lugar de depender solo de que el gestor lo desmarque manualmente.
+
+---
+
+- **Fecha:** 2026-04-24
+- **Autor:** Tanya Tree + Claude Sonnet 4.6
+- **Branch:** t1126
+- **Tipo de cambio:** Corrección | Mejora
+- **Módulos afectados:** Support, Registro de Ventas

--- a/support/templates/validate_subscription_sales_record.html
+++ b/support/templates/validate_subscription_sales_record.html
@@ -290,6 +290,9 @@
                   {% render_field form.can_be_commissioned class="form-check-input" %}
                   <label for="can_be_commissioned_id" class="form-check-label">{% trans "Can be commissioned" %}</label>
                 </div>
+                <small class="text-muted">
+                  {% trans "If checked, the seller will receive commission for this sale. Uncheck to exclude it from commission calculations (e.g. retention discounts or non-commissionable changes)." %}
+                </small>
               </div>
             </div>
             <div class="text-right">

--- a/support/views/all_views.py
+++ b/support/views/all_views.py
@@ -2857,10 +2857,8 @@ class ValidateSubscriptionSalesRecord(BreadcrumbsMixin, UpdateView):
 
     def get_initial(self):
         initial = super().get_initial()
-        if self.object.sale_type != SalesRecord.SALE_TYPE.FULL:
-            initial["can_be_commissioned"] = False
-            initial["subscription"] = self.object.subscription
-            initial["seller"] = self.object.seller
+        initial["subscription"] = self.object.subscription
+        initial["seller"] = self.object.seller
         return initial
 
     def get_success_url(self):

--- a/support/views/subscriptions.py
+++ b/support/views/subscriptions.py
@@ -953,14 +953,29 @@ def product_change(request, subscription_id):
                             new_sp.order = sp.order
                         new_sp.save()
             # after this, we need to add the new products, that will have to be reviewed by an agent
+            seller = getattr(request.user, 'seller', None)
+            seller_id = seller.id if seller else None
+            new_products_list = []
             for product_id in new_products_ids_list:
                 product = Product.objects.get(pk=product_id)
                 if product not in new_subscription.products.all():
                     new_subscription.add_product(
                         product=product,
                         address=None,
+                        seller_id=seller_id,
                         track_as_added=True,
                     )
+                    if product.type == "S":
+                        new_products_list.append(product)
+            sf = SalesRecord.objects.create(
+                subscription=new_subscription,
+                seller_id=seller_id,
+                price=new_subscription.get_price_for_full_period() - old_subscription.get_price_for_full_period(),
+                sale_type=SalesRecord.SALE_TYPE.PARTIAL,
+            )
+            sf.products.add(*new_products_list)
+            if not seller_id:
+                sf.set_generic_seller()
             # After that, we'll set the unsubscription date to this new subscription
             success_text = format_lazy(
                 "Unsubscription for {name} booked for {end_date}",
@@ -1083,7 +1098,7 @@ def book_additional_product(request, subscription_id):
                 subscription=new_subscription,
                 seller=seller_id,
                 price=new_subscription.get_price_for_full_period() - old_subscription.get_price_for_full_period(),
-                sale_type=SalesRecord.TYPES.PARTIAL,
+                sale_type=SalesRecord.SALE_TYPE.PARTIAL,
                 campaign=campaign_obj,
             )
             sf.products.add(*new_products_list)
@@ -1323,6 +1338,7 @@ def add_retention_discount(request, subscription_id):
                     )
 
             # Add new subscription products
+            new_products_list = []
             for product_id in new_products_ids_list:
                 product = Product.objects.get(pk=product_id)
                 if product not in new_subscription.products.all():
@@ -1331,6 +1347,17 @@ def add_retention_discount(request, subscription_id):
                         seller_id=seller_id,
                         address=None,
                     )
+                    if product.type == "S":
+                        new_products_list.append(product)
+            sf = SalesRecord.objects.create(
+                subscription=new_subscription,
+                seller_id=seller_id,
+                price=new_subscription.get_price_for_full_period() - old_subscription.get_price_for_full_period(),
+                sale_type=SalesRecord.SALE_TYPE.PARTIAL,
+            )
+            sf.products.add(*new_products_list)
+            if not seller_id:
+                sf.set_generic_seller()
 
             # Set old subscription's unsubscription type and reason to RETENTION
             old_subscription.inactivity_reason = Subscription.InactivityReasonChoices.RETENTION


### PR DESCRIPTION
…retention flows

- product_change and add_retention_discount (base) now create a PARTIAL SalesRecord
- fix AttributeError: SalesRecord.TYPES.PARTIAL → SalesRecord.SALE_TYPE.PARTIAL in book_additional_product
- ValidateSubscriptionSalesRecord: can_be_commissioned defaults to True for all sale types; add explanatory note in template