### PR TITLE
t1141: Seller Attendance Filter view with CSV export

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: django\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-06 16:16-0300\n"
+"POT-Creation-Date: 2026-05-06 16:37-0300\n"
 "PO-Revision-Date: 2026-04-30 17:18-0300\n"
 "Last-Translator: tanyatree\n"
 "Language-Team: \n"
@@ -61,9 +61,11 @@ msgstr "Anunciante"
 #: support/templates/sales_record_filter.html:141
 #: support/templates/seller_console.html:270
 #: support/templates/support/seller_attendance.html:49
+#: support/templates/support/seller_attendance_filter.html:118
 #: support/templates/validate_subscription_sales_record.html:334
 #: support/templates/validate_subscription_sales_record.html:380
-#: support/views/all_views.py:2291 support/views/all_views.py:2898
+#: support/views/all_views.py:2292 support/views/all_views.py:2899
+#: support/views/all_views.py:3421
 msgid "Seller"
 msgstr "Vendedor"
 
@@ -97,8 +99,9 @@ msgstr "Facturar a"
 #: support/templates/invoicing_issues.html:57
 #: support/templates/seller_console.html:391
 #: support/templates/support/seller_attendance.html:19
+#: support/templates/support/seller_attendance_filter.html:117
 #: support/templates/unsubscription_statistics.html:47
-#: support/views/all_views.py:2897
+#: support/views/all_views.py:2898 support/views/all_views.py:3420
 msgid "Date"
 msgstr "Fecha"
 
@@ -174,7 +177,7 @@ msgstr "Bajo"
 #: support/templates/seller_console_list_campaigns.html:24
 #: support/templates/seller_console_special_routes.html:22
 #: support/templates/seller_performance_by_time.html:74
-#: support/views/all_views.py:1863
+#: support/views/all_views.py:1864
 msgid "Name"
 msgstr "Nombre"
 
@@ -235,8 +238,8 @@ msgstr "Otros contactos"
 #: support/templates/seller_console_never_paid_issues.html:29
 #: support/templates/seller_console_special_routes.html:25
 #: support/templates/subscriptions/subscription_end_date_list.html:88
-#: support/views/all_views.py:1864 support/views/all_views.py:2285
-#: support/views/all_views.py:2748 support/views/contacts.py:153
+#: support/views/all_views.py:1865 support/views/all_views.py:2286
+#: support/views/all_views.py:2749 support/views/contacts.py:153
 msgid "Email"
 msgstr "Email"
 
@@ -263,8 +266,8 @@ msgstr "Email"
 #: support/templates/seller_console.html:218
 #: support/templates/seller_console_never_paid_issues.html:30
 #: support/templates/subscriptions/subscription_end_date_list.html:89
-#: support/templates/view_issue.html:341 support/views/all_views.py:1866
-#: support/views/all_views.py:2286 support/views/all_views.py:2749
+#: support/templates/view_issue.html:341 support/views/all_views.py:1867
+#: support/views/all_views.py:2287 support/views/all_views.py:2750
 #: support/views/contacts.py:154
 msgid "Phone"
 msgstr "Teléfono"
@@ -409,7 +412,7 @@ msgstr "Precio"
 #: support/templates/sales_record_filter.html:144
 #: support/templates/subscriptions/corporate_subscription.html:45
 #: support/templates/validate_subscription_sales_record.html:236
-#: support/views/all_views.py:2019
+#: support/views/all_views.py:2020
 msgid "Start date"
 msgstr "Fecha de comienzo"
 
@@ -430,7 +433,7 @@ msgstr "Fecha de fin"
 msgid "Ad"
 msgstr "Anuncio"
 
-#: advertisement/models.py:185 support/views/all_views.py:2294
+#: advertisement/models.py:185 support/views/all_views.py:2295
 msgid "Date created"
 msgstr "Fecha de creación"
 
@@ -536,7 +539,7 @@ msgstr "Completado"
 #: support/templates/contact_detail/tabs/_tasks.html:13
 #: support/templates/list_issues.html:253
 #: support/templates/scheduled_task_filter.html:87
-#: support/templates/view_issue.html:325 support/views/all_views.py:685
+#: support/templates/view_issue.html:325 support/views/all_views.py:686
 #: support/views/scheduled_tasks.py:235
 msgid "Creation date"
 msgstr "Fecha de emisión"
@@ -795,9 +798,11 @@ msgstr "Dirección"
 #: support/templates/scheduled_activities.html:166
 #: support/templates/seller_console_never_paid_issues.html:32
 #: support/templates/support/seller_attendance.html:50
+#: support/templates/support/seller_attendance_filter.html:119
 #: support/templates/validate_subscription_sales_record.html:225
-#: support/templates/view_issue.html:189 support/views/all_views.py:693
-#: support/views/all_views.py:2023 support/views/all_views.py:2288
+#: support/templates/view_issue.html:189 support/views/all_views.py:694
+#: support/views/all_views.py:2024 support/views/all_views.py:2289
+#: support/views/all_views.py:3422
 msgid "Status"
 msgstr "Estado"
 
@@ -1707,27 +1712,27 @@ msgstr "Redacción"
 #: logistics/views.py:367 logistics/views.py:1583 support/location.py:190
 #: support/templates/campaign_management_menu.html:93
 #: support/templates/tag_contacts.html:12 support/views/activities.py:27
-#: support/views/all_views.py:166 support/views/all_views.py:252
-#: support/views/all_views.py:288 support/views/all_views.py:538
-#: support/views/all_views.py:610 support/views/all_views.py:749
-#: support/views/all_views.py:855 support/views/all_views.py:957
-#: support/views/all_views.py:1173 support/views/all_views.py:1307
-#: support/views/all_views.py:1487 support/views/all_views.py:2187
-#: support/views/all_views.py:2210 support/views/all_views.py:2565
-#: support/views/all_views.py:2690 support/views/all_views.py:2730
-#: support/views/all_views.py:2777 support/views/all_views.py:2870
-#: support/views/all_views.py:3076 support/views/all_views.py:3251
-#: support/views/campaign_management.py:51 support/views/contacts.py:57
-#: support/views/contacts.py:245 support/views/contacts.py:475
-#: support/views/contacts.py:543 support/views/contacts.py:560
-#: support/views/contacts.py:893 support/views/contacts.py:1139
-#: support/views/contacts.py:1237 support/views/seller_console.py:60
-#: support/views/seller_console.py:132 support/views/subscriptions.py:1429
-#: support/views/subscriptions.py:1616 support/views/subscriptions.py:2016
-#: support/views/subscriptions.py:2106 templates/admin/change_form.html:27
-#: templates/admin/change_list.html:38 templates/admin/index.html:68
-#: templates/admin/object_history.html:17 templates/components/_header.html:12
-#: templates/components/_sidebar.html:41
+#: support/views/all_views.py:167 support/views/all_views.py:253
+#: support/views/all_views.py:289 support/views/all_views.py:539
+#: support/views/all_views.py:611 support/views/all_views.py:750
+#: support/views/all_views.py:856 support/views/all_views.py:958
+#: support/views/all_views.py:1174 support/views/all_views.py:1308
+#: support/views/all_views.py:1488 support/views/all_views.py:2188
+#: support/views/all_views.py:2211 support/views/all_views.py:2566
+#: support/views/all_views.py:2691 support/views/all_views.py:2731
+#: support/views/all_views.py:2778 support/views/all_views.py:2871
+#: support/views/all_views.py:3077 support/views/all_views.py:3252
+#: support/views/all_views.py:3396 support/views/campaign_management.py:51
+#: support/views/contacts.py:57 support/views/contacts.py:245
+#: support/views/contacts.py:475 support/views/contacts.py:543
+#: support/views/contacts.py:560 support/views/contacts.py:893
+#: support/views/contacts.py:1139 support/views/contacts.py:1237
+#: support/views/seller_console.py:60 support/views/seller_console.py:132
+#: support/views/subscriptions.py:1429 support/views/subscriptions.py:1616
+#: support/views/subscriptions.py:2016 support/views/subscriptions.py:2106
+#: templates/admin/change_form.html:27 templates/admin/change_list.html:38
+#: templates/admin/index.html:68 templates/admin/object_history.html:17
+#: templates/components/_header.html:12 templates/components/_sidebar.html:41
 msgid "Home"
 msgstr "Inicio"
 
@@ -1972,8 +1977,8 @@ msgstr "Por Periodicidad"
 msgid "Fixed Price"
 msgstr "Precio Fijo"
 
-#: core/models.py:207 invoicing/filters.py:22 support/filters.py:23
-#: support/filters.py:167 support/templates/scheduled_activities.html:98
+#: core/models.py:207 invoicing/filters.py:22 support/filters.py:33
+#: support/filters.py:177 support/templates/scheduled_activities.html:98
 msgid "Custom"
 msgstr "Personalizado"
 
@@ -2186,8 +2191,8 @@ msgstr "Teléfono extensión"
 #: support/templates/seller_console.html:221
 #: support/templates/seller_console_never_paid_issues.html:31
 #: support/templates/seller_console_special_routes.html:27
-#: support/views/all_views.py:1867 support/views/all_views.py:2287
-#: support/views/all_views.py:2750 support/views/contacts.py:155
+#: support/views/all_views.py:1868 support/views/all_views.py:2288
+#: support/views/all_views.py:2751 support/views/contacts.py:155
 msgid "Mobile"
 msgstr "Celular"
 
@@ -2624,7 +2629,7 @@ msgstr "Baja parcial"
 #: support/templates/seller_console_list_campaigns.html:162
 #: support/templates/validate_subscription_sales_record.html:209
 #: support/templates/validate_subscription_sales_record.html:384
-#: support/views/all_views.py:2901
+#: support/views/all_views.py:2902
 msgid "Campaign"
 msgstr "Campaña"
 
@@ -2707,14 +2712,14 @@ msgstr "Adenda de baja"
 
 #: core/models.py:1711
 #: invoicing/templates/bill_subscriptions_for_one_contact.html:66
-#: support/filters.py:369 support/filters.py:403 support/models.py:445
+#: support/filters.py:379 support/filters.py:413 support/models.py:445
 #: support/models.py:478 support/templates/reactivate_subscription.html:42
 #: support/templates/sales_record_create.html:29
 #: support/templates/sales_record_filter.html:97
 #: support/templates/sales_record_filter.html:146
 #: support/templates/sales_record_filter.html:218
 #: support/templates/validate_subscription_sales_record.html:147
-#: support/views/all_views.py:2900
+#: support/views/all_views.py:2901
 msgid "Products"
 msgstr "Productos"
 
@@ -2752,7 +2757,7 @@ msgid "Free subscription requested by"
 msgstr "Suscripción gratuita a pedido de"
 
 #: core/models.py:1738 support/templates/sales_record_filter.html:110
-#: support/views/all_views.py:2904
+#: support/views/all_views.py:2905
 msgid "Validated"
 msgstr "Validado"
 
@@ -3151,8 +3156,8 @@ msgstr "Hola %(first_name)s, elige donde quieres ir"
 #: support/templates/seller_console_list_campaigns.html:25
 #: support/templates/subscriptions/subscription_end_date_list.html:10
 #: support/templates/upload_payment_certificate.html:9
-#: support/views/all_views.py:1308 support/views/all_views.py:1488
-#: support/views/all_views.py:2944 templates/components/_sidebar.html:48
+#: support/views/all_views.py:1309 support/views/all_views.py:1489
+#: support/views/all_views.py:2945 templates/components/_sidebar.html:48
 msgid "Contacts"
 msgstr "Contactos"
 
@@ -3170,14 +3175,14 @@ msgstr "Ir a contactos"
 #: support/templates/campaign_management_menu.html:88
 #: support/templates/campaign_management_menu.html:94
 #: support/templates/support/seller_attendance.html:7
-#: support/views/all_views.py:167 support/views/all_views.py:253
-#: support/views/all_views.py:289 support/views/all_views.py:539
-#: support/views/all_views.py:2188 support/views/all_views.py:2211
-#: support/views/all_views.py:2566 support/views/all_views.py:2691
-#: support/views/all_views.py:2731 support/views/all_views.py:2871
-#: support/views/all_views.py:3077 support/views/all_views.py:3252
-#: support/views/campaign_management.py:52 support/views/contacts.py:561
-#: support/views/contacts.py:894
+#: support/views/all_views.py:168 support/views/all_views.py:254
+#: support/views/all_views.py:290 support/views/all_views.py:540
+#: support/views/all_views.py:2189 support/views/all_views.py:2212
+#: support/views/all_views.py:2567 support/views/all_views.py:2692
+#: support/views/all_views.py:2732 support/views/all_views.py:2872
+#: support/views/all_views.py:3078 support/views/all_views.py:3253
+#: support/views/all_views.py:3397 support/views/campaign_management.py:52
+#: support/views/contacts.py:561 support/views/contacts.py:894
 #: templates/components/sidebar_items/_campaign_management.html:21
 msgid "Campaign Management"
 msgstr "Gestión de campañas"
@@ -3252,7 +3257,7 @@ msgid "Completed with errors"
 msgstr "Completado con errores"
 
 #: invoicing/filters.py:16 logistics/templates/list_routes.html:38
-#: support/filters.py:15 support/filters.py:163
+#: support/filters.py:25 support/filters.py:173
 #: support/templates/community_console.html:108
 #: support/templates/community_console.html:216
 #: support/templates/community_console.html:355
@@ -3268,23 +3273,23 @@ msgstr "Completado con errores"
 msgid "Today"
 msgstr "Hoy"
 
-#: invoicing/filters.py:17 support/filters.py:16 util/dates.py:84
+#: invoicing/filters.py:17 support/filters.py:26 util/dates.py:84
 msgid "Yesterday"
 msgstr "Ayer"
 
-#: invoicing/filters.py:18 support/filters.py:17
+#: invoicing/filters.py:18 support/filters.py:27
 msgid "Last 7 days"
 msgstr "Últimos 7 días"
 
-#: invoicing/filters.py:19 support/filters.py:19
+#: invoicing/filters.py:19 support/filters.py:29
 msgid "Last 30 days"
 msgstr "Últimos 30 días"
 
-#: invoicing/filters.py:20 support/filters.py:20
+#: invoicing/filters.py:20 support/filters.py:30
 msgid "This month"
 msgstr "Este mes"
 
-#: invoicing/filters.py:21 support/filters.py:21
+#: invoicing/filters.py:21 support/filters.py:31
 msgid "Last month"
 msgstr "Mes anterior"
 
@@ -3589,7 +3594,7 @@ msgid "PROTECTED CLIENT"
 msgstr "CLIENTE PROTEGIDO"
 
 #: invoicing/templates/bill_subscriptions_for_one_contact.html:35
-#: support/filters.py:31
+#: support/filters.py:41
 msgid "Issue Date"
 msgstr "Fecha de emisión"
 
@@ -3638,8 +3643,8 @@ msgstr "Rango de fecha de anulación"
 #: invoicing/templates/canceled_invoices_report.html:25
 #: invoicing/templates/contact_invoices.html:98
 #: invoicing/templates/invoice_filter.html:103
-#: invoicing/templates/print.html:38 support/filters.py:38
-#: support/filters.py:56
+#: invoicing/templates/print.html:38 support/filters.py:48
+#: support/filters.py:66
 msgid "From"
 msgstr "De"
 
@@ -3706,8 +3711,8 @@ msgid "Item invoices"
 msgstr "Facturas del ítem"
 
 #: invoicing/templates/contact_invoices.html:99
-#: invoicing/templates/invoice_filter.html:107 support/filters.py:44
-#: support/filters.py:62
+#: invoicing/templates/invoice_filter.html:107 support/filters.py:54
+#: support/filters.py:72
 msgid "To"
 msgstr "Para"
 
@@ -3839,9 +3844,9 @@ msgstr "Filtros"
 
 #: invoicing/templates/invoice_filter.html:80 invoicing/views.py:294
 #: support/templates/scheduled_activities.html:164
-#: support/views/all_views.py:688 support/views/all_views.py:2021
-#: support/views/all_views.py:2117 support/views/all_views.py:2284
-#: support/views/all_views.py:2747 support/views/scheduled_tasks.py:233
+#: support/views/all_views.py:689 support/views/all_views.py:2022
+#: support/views/all_views.py:2118 support/views/all_views.py:2285
+#: support/views/all_views.py:2748 support/views/scheduled_tasks.py:233
 msgid "Contact name"
 msgstr "Nombre de contacto"
 
@@ -3976,7 +3981,7 @@ msgstr "La factura {} fue creada con éxito"
 #: logistics/views.py:1612 support/location.py:93 support/location.py:191
 #: support/location.py:239 support/views/activities.py:150
 #: support/views/activities.py:201 support/views/activities.py:226
-#: support/views/all_views.py:2649 support/views/contacts.py:58
+#: support/views/all_views.py:2650 support/views/contacts.py:58
 #: support/views/contacts.py:246 support/views/contacts.py:476
 #: support/views/contacts.py:544 support/views/contacts.py:1140
 #: support/views/contacts.py:1238 support/views/scheduled_tasks.py:66
@@ -4147,7 +4152,7 @@ msgid "No day"
 msgstr "Sin día"
 
 #: logistics/filters.py:23 logistics/filters.py:29
-#: logistics/templates/order_routes_list.html:38 support/filters.py:164
+#: logistics/templates/order_routes_list.html:38 support/filters.py:174
 #: support/templates/community_console.html:117
 #: support/templates/community_console.html:217
 #: support/templates/community_console.html:356
@@ -4377,7 +4382,7 @@ msgstr "Filtrar por producto"
 #: logistics/templates/change_route.html:48
 #: logistics/templates/print_routes_simple.html:51
 #: logistics/templates/print_unordered_subscriptions_form.html:33
-#: support/views/all_views.py:955
+#: support/filters.py:450 support/views/all_views.py:956
 msgid "All"
 msgstr "Todos"
 
@@ -4659,7 +4664,7 @@ msgstr "Suscripciones activas"
 #: logistics/templates/merge_compare_addresses.html:347
 #: logistics/templates/route_details.html:135 support/models.py:205
 #: support/templates/contact_detail/detail.html:137
-#: support/templates/history_extended.html:129 support/views/all_views.py:611
+#: support/templates/history_extended.html:129 support/views/all_views.py:612
 #: templates/components/sidebar_items/_support.html:23
 msgid "Issues"
 msgstr "Incidencias"
@@ -4746,6 +4751,7 @@ msgstr "Actividades agendadas"
 #: support/templates/campaign_statistics_list.html:48
 #: support/templates/sales_record_filter.html:126
 #: support/templates/scheduled_activities.html:47
+#: support/templates/support/seller_attendance_filter.html:99
 #: support/templates/tag_analysis.html:35
 #: support/templates/unsubscription_statistics.html:41
 #: support/templates/unsubscription_statistics.html:65
@@ -5708,84 +5714,116 @@ msgstr "Problemas para ser entregado"
 msgid "Delivered in a specific way"
 msgstr "Entregado de una manera específica"
 
-#: support/filters.py:18
+#: support/filters.py:28
 msgid "Next 7 days"
 msgstr "Siguientes 7 días"
 
-#: support/filters.py:22 support/templates/community_console.html:126
+#: support/filters.py:32 support/templates/community_console.html:126
 msgid "No date set"
 msgstr "Sin fecha asignada"
 
-#: support/filters.py:32
+#: support/filters.py:42
 msgid "When the issue was created"
 msgstr "Cuándo se creó la incidencia"
 
-#: support/filters.py:49
+#: support/filters.py:59
 msgid "Next Action Date"
 msgstr "Fecha de próxima acción"
 
-#: support/filters.py:50
+#: support/filters.py:60
 msgid "When the next action is scheduled"
 msgstr "Para cuándo se agendó la siguiente acción de la incidencia"
 
-#: support/filters.py:71 support/forms.py:493 support/forms.py:560
+#: support/filters.py:81 support/forms.py:493 support/forms.py:560
 #: support/forms.py:622 support/models.py:199
 #: support/templates/contact_detail/tabs/_campaigns.html:110
 #: support/templates/contact_detail/tabs/_issues.html:16
 #: support/templates/list_issues.html:167
-#: support/templates/list_issues.html:264 support/views/all_views.py:691
+#: support/templates/list_issues.html:264 support/views/all_views.py:692
 msgid "Resolution"
 msgstr "Resolución"
 
-#: support/filters.py:75 support/templates/list_issues.html:218
+#: support/filters.py:85 support/templates/list_issues.html:218
 msgid "Unassigned only"
 msgstr "Solo sin asignar"
 
-#: support/filters.py:80 support/templates/list_issues.html:224
+#: support/filters.py:90 support/templates/list_issues.html:224
 msgid "Exclude finished"
 msgstr "Excluir finalizadas"
 
-#: support/filters.py:162 support/templates/scheduled_activities.html:83
+#: support/filters.py:172 support/templates/scheduled_activities.html:83
 msgid "Past (overdue)"
 msgstr "Pasado (vencido)"
 
-#: support/filters.py:165 support/templates/scheduled_activities.html:92
+#: support/filters.py:175 support/templates/scheduled_activities.html:92
 msgid "Past + Today"
 msgstr "Pasado + Hoy"
 
-#: support/filters.py:166 support/templates/scheduled_activities.html:95
+#: support/filters.py:176 support/templates/scheduled_activities.html:95
 msgid "Today + Future"
 msgstr "Hoy + Futuro"
 
-#: support/filters.py:181 support/templates/scheduled_activities.html:79
+#: support/filters.py:191 support/templates/scheduled_activities.html:79
 msgid "Activity Date"
 msgstr "Fecha de actividad"
 
-#: support/filters.py:187 support/templates/scheduled_activities.html:107
+#: support/filters.py:197 support/templates/scheduled_activities.html:107
 msgid "Date From"
 msgstr "Fecha desde"
 
-#: support/filters.py:193 support/templates/scheduled_activities.html:113
+#: support/filters.py:203 support/templates/scheduled_activities.html:113
 msgid "Date To"
 msgstr "Fecha hasta"
 
-#: support/filters.py:199 support/templates/scheduled_activities.html:122
+#: support/filters.py:209 support/templates/scheduled_activities.html:122
 msgid "Subscription End Date From"
 msgstr "Fecha de fin de suscripción mínima"
 
-#: support/filters.py:204 support/templates/scheduled_activities.html:128
+#: support/filters.py:214 support/templates/scheduled_activities.html:128
 msgid "Subscription End Date To"
 msgstr "Fecha de Fin de suscripción máxima"
 
-#: support/filters.py:351 support/filters.py:389
+#: support/filters.py:361 support/filters.py:399
 #: support/templates/sales_record_filter.html:77
 msgid "Subscription start date (min)"
 msgstr "Fecha de inicio de la suscripción (mínima)"
 
-#: support/filters.py:357 support/filters.py:395
+#: support/filters.py:367 support/filters.py:405
 #: support/templates/sales_record_filter.html:83
 msgid "Subscription start date (max)"
 msgstr "Fecha de inicio de la suscripción (máxima)"
+
+#: support/filters.py:451 support/filters.py:485 support/models.py:681
+#: support/models.py:685
+msgid "Justified"
+msgstr "Justificada"
+
+#: support/filters.py:452 support/models.py:685
+msgid "Unjustified"
+msgstr "Injustificada"
+
+#: support/filters.py:460 support/templates/seller_performance_by_time.html:56
+msgid "Date from"
+msgstr "Fecha desde"
+
+#: support/filters.py:466 support/templates/seller_performance_by_time.html:60
+msgid "Date to"
+msgstr "Fecha hasta"
+
+#: support/filters.py:471 support/templates/campaign_statistics_list.html:84
+msgid "Sellers"
+msgstr "Vendedores"
+
+#: support/filters.py:475 support/models.py:723
+#: support/templates/support/seller_attendance.html:51
+#: support/templates/support/seller_attendance_filter.html:120
+#: support/views/all_views.py:3423
+msgid "Absence reason"
+msgstr "Razón de inasistencia"
+
+#: support/filters.py:479
+msgid "Absences only"
+msgstr "Solo inasistencias"
 
 #: support/forms.py:47
 #, python-brace-format
@@ -5864,7 +5902,7 @@ msgstr "Selecciona un tipo de actividad"
 #: support/templates/invoicing_issues.html:118
 #: support/templates/list_issues.html:163
 #: support/templates/list_issues.html:273 support/templates/new_issue.html:347
-#: support/views/all_views.py:695 support/views/all_views.py:2028
+#: support/views/all_views.py:696 support/views/all_views.py:2029
 msgid "Assigned to"
 msgstr "Asignado a"
 
@@ -5886,14 +5924,14 @@ msgstr "{} no es una categoría de {}"
 #: support/templates/invoicing_issues.html:106
 #: support/templates/list_issues.html:159
 #: support/templates/list_issues.html:263 support/templates/view_issue.html:186
-#: support/views/all_views.py:690
+#: support/views/all_views.py:691
 msgid "Subcategory"
 msgstr "Subcategoría"
 
 #: support/forms.py:555 support/forms.py:617 support/models.py:177
 #: support/templates/invoicing_issues.html:108
-#: support/templates/list_issues.html:269 support/views/all_views.py:694
-#: support/views/all_views.py:2024
+#: support/templates/list_issues.html:269 support/views/all_views.py:695
+#: support/views/all_views.py:2025
 msgid "Next action date"
 msgstr "Fecha de próxima acción"
 
@@ -6112,7 +6150,7 @@ msgstr "Fecha de la incidencia"
 #: support/templates/list_issues.html:262 support/templates/new_issue.html:188
 #: support/templates/scheduled_task_filter.html:45
 #: support/templates/scheduled_task_filter.html:86
-#: support/templates/view_issue.html:184 support/views/all_views.py:689
+#: support/templates/view_issue.html:184 support/views/all_views.py:690
 #: support/views/scheduled_tasks.py:234
 msgid "Category"
 msgstr "Categoría"
@@ -6277,14 +6315,6 @@ msgstr "Acción de consola de ventas"
 msgid "Seller Console Actions"
 msgstr "Acciones de consola de ventas"
 
-#: support/models.py:681 support/models.py:685
-msgid "Justified"
-msgstr "Justificada"
-
-#: support/models.py:685
-msgid "Unjustified"
-msgstr "Injustificada"
-
 #: support/models.py:689
 msgid "absence reason"
 msgstr "razón de inasistencia"
@@ -6310,10 +6340,6 @@ msgstr "registro de asistencia"
 #: support/models.py:710
 msgid "attendance records"
 msgstr "registros de asistencia"
-
-#: support/models.py:723 support/templates/support/seller_attendance.html:51
-msgid "Absence reason"
-msgstr "Razón de inasistencia"
 
 #: support/models.py:725 support/templates/support/seller_attendance.html:52
 msgid "Shift start"
@@ -6801,6 +6827,7 @@ msgid "Search…"
 msgstr "Buscar..."
 
 #: support/templates/campaign_management_menu.html:113
+#: support/templates/support/seller_attendance_filter.html:102
 #: support/templates/tag_analysis.html:36
 msgid "Clear"
 msgstr "Limpiar"
@@ -6850,7 +6877,7 @@ msgid "Go to check"
 msgstr "Ir a revisar"
 
 #: support/templates/campaign_management_menu.html:161
-#: support/views/all_views.py:2732
+#: support/views/all_views.py:2733
 #: templates/components/sidebar_items/_campaign_management.html:44
 msgid "Tag Contacts"
 msgstr "Etiquetar contactos"
@@ -6864,7 +6891,7 @@ msgid "Go to tagging"
 msgstr "Ir a etiquetar"
 
 #: support/templates/campaign_management_menu.html:174
-#: support/views/all_views.py:168
+#: support/views/all_views.py:169
 #: templates/components/sidebar_items/_campaign_management.html:51
 msgid "Assign contacts by tag"
 msgstr "Asignar contactos por etiqueta"
@@ -6880,7 +6907,7 @@ msgstr "Ir a asignación"
 
 #: support/templates/campaign_management_menu.html:187
 #: support/templates/distribute_campaigns.html:13
-#: support/views/all_views.py:254 support/views/all_views.py:290
+#: support/views/all_views.py:255 support/views/all_views.py:291
 #: templates/components/sidebar_items/_campaign_management.html:58
 msgid "Assign contacts to sellers"
 msgstr "Asignar contactos a vendedores"
@@ -6917,7 +6944,7 @@ msgstr ""
 #: support/templates/campaign_statistics_detail.html:16
 #: support/templates/campaign_statistics_list.html:23
 #: support/templates/campaign_statistics_list.html:27
-#: support/views/all_views.py:2189 support/views/all_views.py:2212
+#: support/views/all_views.py:2190 support/views/all_views.py:2213
 #: templates/components/sidebar_items/_campaign_management.html:70
 msgid "Campaign statistics"
 msgstr "Estadísticas de campaña"
@@ -6931,7 +6958,7 @@ msgid "Go to statistics"
 msgstr "Ir a estadísticas"
 
 #: support/templates/campaign_management_menu.html:242
-#: support/views/all_views.py:2567
+#: support/views/all_views.py:2568
 #: templates/components/sidebar_items/_campaign_management.html:77
 msgid "Sellers performance"
 msgstr "Desempeño de los vendedores"
@@ -6945,7 +6972,7 @@ msgid "Go to performance"
 msgstr "Ir a rendimiento"
 
 #: support/templates/campaign_management_menu.html:255
-#: support/views/all_views.py:540
+#: support/views/all_views.py:541
 #: templates/components/sidebar_items/_campaign_management.html:84
 msgid "Release seller contacts"
 msgstr "Liberar contactos de vendedores"
@@ -6961,7 +6988,7 @@ msgid "Go to release"
 msgstr "Ir a liberar"
 
 #: support/templates/campaign_management_menu.html:268
-#: support/views/all_views.py:2692
+#: support/views/all_views.py:2693
 #: templates/components/sidebar_items/_campaign_management.html:91
 msgid "Upload do not call list"
 msgstr "Subir lista de “no llamar”"
@@ -6977,7 +7004,7 @@ msgstr "Ir a subir"
 #: support/templates/campaign_management_menu.html:281
 #: support/templates/sales_record_filter.html:4
 #: support/templates/sales_record_filter.html:52
-#: support/views/all_views.py:2872 support/views/all_views.py:2940
+#: support/views/all_views.py:2873 support/views/all_views.py:2941
 #: templates/components/sidebar_items/_campaign_management.html:98
 msgid "Sales Records"
 msgstr "Registros de ventas"
@@ -7004,7 +7031,7 @@ msgstr "Ir a remover"
 #: support/templates/campaign_management_menu.html:307
 #: support/templates/support/seller_attendance.html:4
 #: support/templates/support/seller_attendance.html:13
-#: support/views/all_views.py:3078 support/views/all_views.py:3253
+#: support/views/all_views.py:3079 support/views/all_views.py:3254
 #: templates/components/sidebar_items/_campaign_management.html:112
 msgid "Seller Attendance"
 msgstr "Asistencia de los vendedores"
@@ -7022,6 +7049,25 @@ msgstr "Ir a registro de asistencia"
 #: support/templates/campaign_management_menu.html:314
 msgid "Calendar"
 msgstr "Calendario"
+
+#: support/templates/campaign_management_menu.html:323
+#: support/templates/support/seller_attendance_filter.html:5
+#: support/templates/support/seller_attendance_filter.html:14
+#: support/views/all_views.py:3398
+msgid "Seller Attendance Filter"
+msgstr "Filtro de asistencias de vendedores"
+
+#: support/templates/campaign_management_menu.html:326
+msgid ""
+"Filter and export seller attendance records by date range, seller, and "
+"absence reason."
+msgstr ""
+"Filtrar y exportar registros de asistencia de vendedores por rango de "
+"fechas, vendedor y motivo de ausencia."
+
+#: support/templates/campaign_management_menu.html:328
+msgid "Go to filter"
+msgstr "Ir al filtro"
 
 #: support/templates/campaign_statistics_detail.html:25
 msgid "Campaign summary"
@@ -7102,6 +7148,7 @@ msgid "Clear filters"
 msgstr "Limpiar filtros"
 
 #: support/templates/campaign_statistics_detail.html:113
+#: support/templates/support/seller_attendance_filter.html:96
 msgid "Export CSV"
 msgstr "Exportar a CSV"
 
@@ -7146,10 +7193,6 @@ msgstr "Por vendedor"
 #: support/templates/campaign_statistics_list.html:86
 msgid "Can't find"
 msgstr "No se puede encontrar"
-
-#: support/templates/campaign_statistics_list.html:84
-msgid "Sellers"
-msgstr "Vendedores"
 
 #: support/templates/campaign_statistics_list.html:100
 #: support/templates/campaign_statistics_list.html:102
@@ -7435,10 +7478,10 @@ msgstr "Delimitador detectado"
 
 #: support/templates/check_for_existing_contacts.html:177
 #: support/templates/seller_console_never_paid_issues.html:26
-#: support/views/all_views.py:687 support/views/all_views.py:1862
-#: support/views/all_views.py:2020 support/views/all_views.py:2116
-#: support/views/all_views.py:2283 support/views/all_views.py:2746
-#: support/views/all_views.py:2896 support/views/scheduled_tasks.py:232
+#: support/views/all_views.py:688 support/views/all_views.py:1863
+#: support/views/all_views.py:2021 support/views/all_views.py:2117
+#: support/views/all_views.py:2284 support/views/all_views.py:2747
+#: support/views/all_views.py:2897 support/views/scheduled_tasks.py:232
 msgid "Contact ID"
 msgstr "ID de contacto"
 
@@ -7465,7 +7508,7 @@ msgid "The following entries had no matching contacts:"
 msgstr "Las siguientes entradas no tienen coincidencias:"
 
 #: support/templates/community_console.html:4
-#: support/templates/community_console.html:88 support/views/all_views.py:750
+#: support/templates/community_console.html:88 support/views/all_views.py:751
 #: templates/components/_sidebar.html:72
 msgid "Community console"
 msgstr "Panel de gestión de comunidad"
@@ -7651,7 +7694,7 @@ msgstr "Volver al panel"
 #: support/templates/community_manager_dashboard.html:343
 #: support/templates/community_manager_overview.html:4
 #: support/templates/community_manager_overview.html:81
-#: support/views/all_views.py:1175
+#: support/views/all_views.py:1176
 msgid "Team overview"
 msgstr "Vista general del equipo"
 
@@ -7780,8 +7823,8 @@ msgstr "incidencias usando distribución Round-robin?"
 
 #: support/templates/community_manager_dashboard.html:4
 #: support/templates/community_manager_dashboard.html:77
-#: support/views/all_views.py:856 support/views/all_views.py:958
-#: support/views/all_views.py:1174
+#: support/views/all_views.py:857 support/views/all_views.py:959
+#: support/views/all_views.py:1175
 msgid "Community manager dashboard"
 msgstr "Panel de supervisión de comunidad"
 
@@ -8579,7 +8622,7 @@ msgstr "Ingrese un celular local o internacional válido"
 
 #: support/templates/create_contact/tabs/_data.html:76
 #: support/templates/create_contact/tabs/_data.html:79
-#: support/templates/seller_console.html:183 support/views/all_views.py:1868
+#: support/templates/seller_console.html:183 support/views/all_views.py:1869
 msgid "Institutional phone"
 msgstr "Teléfono institucional"
 
@@ -8654,24 +8697,24 @@ msgstr "Ordenar por"
 #: support/templates/debtor_contacts.html:55
 #: support/templates/debtor_contacts.html:91
 #: support/templates/invoicing_issues.html:64
-#: support/templates/invoicing_issues.html:110 support/views/all_views.py:2025
-#: support/views/all_views.py:2119
+#: support/templates/invoicing_issues.html:110 support/views/all_views.py:2026
+#: support/views/all_views.py:2120
 msgid "Owed invoices"
 msgstr "Facturas vencidas"
 
 #: support/templates/debtor_contacts.html:56
 #: support/templates/debtor_contacts.html:93
 #: support/templates/invoicing_issues.html:65
-#: support/templates/invoicing_issues.html:113 support/views/all_views.py:2026
-#: support/views/all_views.py:2122
+#: support/templates/invoicing_issues.html:113 support/views/all_views.py:2027
+#: support/views/all_views.py:2123
 msgid "Debt amount"
 msgstr "Cantidad de deuda"
 
 #: support/templates/debtor_contacts.html:58
 #: support/templates/debtor_contacts.html:94
 #: support/templates/invoicing_issues.html:66
-#: support/templates/invoicing_issues.html:116 support/views/all_views.py:2027
-#: support/views/all_views.py:2123
+#: support/templates/invoicing_issues.html:116 support/views/all_views.py:2028
+#: support/views/all_views.py:2124
 msgid "Oldest invoice"
 msgstr "Factura más vieja"
 
@@ -8882,7 +8925,7 @@ msgstr "Creado"
 msgid "Extended history"
 msgstr "Historial extendido"
 
-#: support/templates/history_extended.html:8 support/views/all_views.py:2654
+#: support/templates/history_extended.html:8 support/views/all_views.py:2655
 #: templates/admin/change_form.html:68
 msgid "History"
 msgstr "Historial"
@@ -9319,10 +9362,12 @@ msgid "List of issues"
 msgstr "Listado de incidencias"
 
 #: support/templates/list_issues.html:32
+#: support/templates/support/seller_attendance_filter.html:23
 msgid "No results match"
 msgstr "No hay coincidencias"
 
 #: support/templates/list_issues.html:33
+#: support/templates/support/seller_attendance_filter.html:25
 msgid "Select an option"
 msgstr "Selecciona una opción"
 
@@ -9347,7 +9392,7 @@ msgstr ""
 "refiere la incidencia."
 
 #: support/templates/list_issues.html:288 support/templates/view_issue.html:336
-#: support/views/all_views.py:686
+#: support/views/all_views.py:687
 msgid "Issue date"
 msgstr "Fecha de incidencia"
 
@@ -9356,7 +9401,7 @@ msgid "Normalize address"
 msgstr "Normalizar dirección"
 
 #: support/templates/new_issue.html:4 support/templates/new_issue.html:144
-#: support/views/all_views.py:1310
+#: support/views/all_views.py:1311
 msgid "New issue"
 msgstr "Nueva incidencia"
 
@@ -9615,7 +9660,7 @@ msgstr "Liberar %(contacts_not_worked)s contactos"
 
 #: support/templates/sales_record_create.html:4
 #: support/templates/validate_subscription_sales_record.html:4
-#: support/views/all_views.py:2941 support/views/all_views.py:2949
+#: support/views/all_views.py:2942 support/views/all_views.py:2950
 msgid "Validate subscription"
 msgstr "Validar suscripción"
 
@@ -9779,6 +9824,7 @@ msgid "Contact Details"
 msgstr "Datos de contacto"
 
 #: support/templates/scheduled_activities.html:230
+#: support/templates/support/seller_attendance_filter.html:24
 msgid "Select..."
 msgstr "Seleccionar…"
 
@@ -9810,7 +9856,7 @@ msgstr "Todas las incidencias"
 #: support/templates/seller_console.html:4
 #: support/templates/seller_console.html:11
 #: support/templates/seller_console_list_campaigns.html:6
-#: support/views/activities.py:28 support/views/all_views.py:2778
+#: support/views/activities.py:28 support/views/all_views.py:2779
 #: templates/components/_sidebar.html:92
 msgid "Seller console"
 msgstr "Consola de vendedor"
@@ -10013,7 +10059,7 @@ msgid "Issue ID"
 msgstr "ID de incidencia"
 
 #: support/templates/seller_console_never_paid_issues.html:27
-#: support/views/all_views.py:2298 support/views/all_views.py:2899
+#: support/views/all_views.py:2299 support/views/all_views.py:2900
 msgid "Subscription start date"
 msgstr "Fecha de inicio de la suscripción"
 
@@ -10066,14 +10112,6 @@ msgstr "Contactos llamados"
 #: support/templates/seller_performance_by_time.html:45
 msgid "Contacted contacts"
 msgstr "Contactos contactados"
-
-#: support/templates/seller_performance_by_time.html:56
-msgid "Date from"
-msgstr "Fecha desde"
-
-#: support/templates/seller_performance_by_time.html:60
-msgid "Date to"
-msgstr "Fecha hasta"
 
 #: support/templates/seller_performance_by_time.html:88
 #: support/templates/seller_performance_by_time.html:108
@@ -10177,6 +10215,14 @@ msgstr "los turnos son requeridos."
 msgid "absence reason is required when marking as absent."
 msgstr ""
 "la razón de inasistencia es requerida cuando se marca una inasistencia."
+
+#: support/templates/support/seller_attendance_filter.html:93
+msgid "records"
+msgstr "registros"
+
+#: support/templates/support/seller_attendance_filter.html:133
+msgid "No records found."
+msgstr "No se encontraron registros."
 
 #: support/templates/tag_analysis.html:5 support/views/contacts.py:1141
 msgid "Tag Analysis"
@@ -10448,7 +10494,7 @@ msgstr ""
 "anterior (cambio de producto o retención)"
 
 #: support/templates/validate_subscription_sales_record.html:356
-#: support/views/all_views.py:2902
+#: support/views/all_views.py:2903
 msgid "Sale Type"
 msgstr "Tipo de venta"
 
@@ -10526,34 +10572,34 @@ msgstr ""
 msgid "Update activity"
 msgstr "Actualizar actividad"
 
-#: support/views/all_views.py:291
+#: support/views/all_views.py:292
 msgid "Assign sellers"
 msgstr "Asignar vendedores"
 
-#: support/views/all_views.py:692 support/views/all_views.py:2022
+#: support/views/all_views.py:693 support/views/all_views.py:2023
 msgid "Activities count"
 msgstr "Cantidad de actividades"
 
-#: support/views/all_views.py:794 support/views/all_views.py:894
-#: support/views/all_views.py:1240
+#: support/views/all_views.py:795 support/views/all_views.py:895
+#: support/views/all_views.py:1241
 msgid "Uncategorized"
 msgstr "Sin categoría"
 
-#: support/views/all_views.py:807 support/views/all_views.py:907
-#: support/views/all_views.py:1253
+#: support/views/all_views.py:808 support/views/all_views.py:908
+#: support/views/all_views.py:1254
 msgid "No subcategory"
 msgstr "Sin subcategoría"
 
-#: support/views/all_views.py:959
+#: support/views/all_views.py:960
 #, python-format
 msgid "Assign issues: %(subcategory)s"
 msgstr "Asignar incidencias: %(subcategory)s"
 
-#: support/views/all_views.py:1105
+#: support/views/all_views.py:1106
 msgid "No assignments specified."
 msgstr "No se especificaron asignaciones."
 
-#: support/views/all_views.py:1115
+#: support/views/all_views.py:1116
 #, python-format
 msgid ""
 "Requested %(requested)s assignments but only %(available)s issues are "
@@ -10562,7 +10608,7 @@ msgstr ""
 "Se solicitaron %(requested)s asignaciones pero solo hay %(available)s "
 "incidencias disponibles."
 
-#: support/views/all_views.py:1152
+#: support/views/all_views.py:1153
 #, python-format
 msgid ""
 "%(count)s issues were assigned successfully using round-robin distribution."
@@ -10570,164 +10616,164 @@ msgstr ""
 "%(count)s incidencias fueron asignadas de forma exitosa utilizando "
 "distribución Round-robin."
 
-#: support/views/all_views.py:1454
+#: support/views/all_views.py:1455
 msgid "See related issue"
 msgstr "Ver incidencia relacionada"
 
-#: support/views/all_views.py:1462
+#: support/views/all_views.py:1463
 #, python-brace-format
 msgid ""
 "Issue <a href=\"{url}\">#{issue_id}</a> created for contact {contact_name}"
 msgstr ""
 "Incidencia <a href=\"{url}\">#{issue_id}</a> fue creada para {contact_name}"
 
-#: support/views/all_views.py:1490
+#: support/views/all_views.py:1491
 #, python-brace-format
 msgid "Issue #{}"
 msgstr "Incidencia #{}"
 
-#: support/views/all_views.py:1589
+#: support/views/all_views.py:1590
 #, python-brace-format
 msgid "Issue #{issue_id} updated for contact {contact_name}"
 msgstr "Incidencia #{issue_id} actualizada para el contacto {contact_name}"
 
-#: support/views/all_views.py:1865
+#: support/views/all_views.py:1866
 msgid "id document"
 msgstr "documento de identidad"
 
-#: support/views/all_views.py:1892
+#: support/views/all_views.py:1893
 msgid "This filter has no mailtrain id. To use the sync function"
 msgstr "Error: Este filtro no tiene id de mailtrain"
 
-#: support/views/all_views.py:1950
+#: support/views/all_views.py:1951
 msgid "Envelope data has been saved."
 msgstr "Los datos de sobre fueron guardados."
 
-#: support/views/all_views.py:1970
+#: support/views/all_views.py:1971
 msgid "Payment certificate has been uploaded successfully"
 msgstr "El certificado de pago ha sido subido con éxito"
 
-#: support/views/all_views.py:2118 support/views/contacts.py:156
+#: support/views/all_views.py:2119 support/views/contacts.py:156
 msgid "Has active subscriptions"
 msgstr "Tiene suscripciones activas"
 
-#: support/views/all_views.py:2120
+#: support/views/all_views.py:2121
 msgid "Unfinished invoicing issues"
 msgstr "Incidencias de finanzas sin terminar"
 
-#: support/views/all_views.py:2121
+#: support/views/all_views.py:2122
 msgid "Finished invoicing issues"
 msgstr "Incidencias de finanzas terminadas"
 
-#: support/views/all_views.py:2289
+#: support/views/all_views.py:2290
 msgid "Campaign resolution"
 msgstr "Resolución de campaña"
 
-#: support/views/all_views.py:2290
+#: support/views/all_views.py:2291
 msgid "Resolution reason"
 msgstr "Razón de resolución"
 
-#: support/views/all_views.py:2292
+#: support/views/all_views.py:2293
 msgid "Date assigned"
 msgstr "Fecha de asignado"
 
-#: support/views/all_views.py:2293
+#: support/views/all_views.py:2294
 msgid "Last action date"
 msgstr "Fecha de última acción"
 
-#: support/views/all_views.py:2295
+#: support/views/all_views.py:2296
 msgid "Times contacted"
 msgstr "Veces contactado"
 
-#: support/views/all_views.py:2296
+#: support/views/all_views.py:2297
 msgid "Activity count"
 msgstr "Cantidad de actividades"
 
-#: support/views/all_views.py:2297
+#: support/views/all_views.py:2298
 msgid "Last console action"
 msgstr "Última acción de consola"
 
-#: support/views/all_views.py:2299
+#: support/views/all_views.py:2300
 msgid "Products sold"
 msgstr "Productos vendidos"
 
-#: support/views/all_views.py:2580
+#: support/views/all_views.py:2581
 msgid "Address information has been updated successfully"
 msgstr "La información de la dirección ha sido editada con éxito"
 
-#: support/views/all_views.py:2682
+#: support/views/all_views.py:2683
 msgid "Numbers have been uploaded successfully."
 msgstr "Los números fueron subidos con éxito."
 
-#: support/views/all_views.py:2779 templates/components/_sidebar.html:99
+#: support/views/all_views.py:2780 templates/components/_sidebar.html:99
 msgid "My Sales"
 msgstr "Mis ventas"
 
-#: support/views/all_views.py:2849
+#: support/views/all_views.py:2850
 msgid "You have no sales records."
 msgstr "No tienes registros de ventas."
 
-#: support/views/all_views.py:2877 support/views/all_views.py:2954
+#: support/views/all_views.py:2878 support/views/all_views.py:2955
 #: support/views/seller_console.py:157
 msgid "You are not authorized to see this page"
 msgstr "No tienes permiso para ver esta página"
 
-#: support/views/all_views.py:2880
+#: support/views/all_views.py:2881
 msgid "There are no sales records."
 msgstr "No hay registros de ventas."
 
-#: support/views/all_views.py:2903
+#: support/views/all_views.py:2904
 msgid "Total Commission"
 msgstr "Comisión total"
 
-#: support/views/all_views.py:2986
+#: support/views/all_views.py:2987
 msgid "The sale and subscription have been validated."
 msgstr "La venta y la suscripción fueron validadas."
 
-#: support/views/all_views.py:3002
+#: support/views/all_views.py:3003
 msgid "There was an error validating the sale and subscription."
 msgstr "Hubo un error validando la venta y la suscripción."
 
-#: support/views/all_views.py:3016
+#: support/views/all_views.py:3017
 msgid "This subscription has no sales record."
 msgstr "Esta suscripción no tiene registros de ventas."
 
-#: support/views/all_views.py:3019
+#: support/views/all_views.py:3020
 msgid "This subscription has already been validated."
 msgstr "Esta suscripción ya fue validada."
 
-#: support/views/all_views.py:3043
+#: support/views/all_views.py:3044
 msgid "This subscription already has a sales record."
 msgstr "Esta suscripción ya tiene un registro de ventas."
 
-#: support/views/all_views.py:3150
+#: support/views/all_views.py:3151
 msgid "There are no active absence reasons. Please create one before saving."
 msgstr ""
 "No hay razones de inasistencia activas. Por favor crea una antes de guardar."
 
-#: support/views/all_views.py:3166
+#: support/views/all_views.py:3167
 #, python-format
 msgid "%(seller)s: shift times are required."
 msgstr "%(seller)s: se requieren turnos."
 
-#: support/views/all_views.py:3171
+#: support/views/all_views.py:3172
 #, python-format
 msgid "%(seller)s: an absence reason is required when marking as absent."
 msgstr ""
 "%(seller)s: se requiere una razón de inasistencia cuando se marca una "
 "inasistencia."
 
-#: support/views/all_views.py:3179
+#: support/views/all_views.py:3180
 #, python-format
 msgid "%(seller)s: invalid time format."
 msgstr "%(seller)s: formato de hora inválido."
 
-#: support/views/all_views.py:3187
+#: support/views/all_views.py:3188
 #, python-format
 msgid "%(seller)s: selected absence reason is not valid."
 msgstr "%(seller)s: la razón de inasistencia seleccionada no es válida."
 
-#: support/views/all_views.py:3221
+#: support/views/all_views.py:3222
 msgid "Attendance saved successfully."
 msgstr "Asistencias guardadas con éxito."
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: django\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-06 16:37-0300\n"
+"POT-Creation-Date: 2026-05-06 16:44-0300\n"
 "PO-Revision-Date: 2026-04-30 17:18-0300\n"
 "Last-Translator: tanyatree\n"
 "Language-Team: \n"
@@ -5822,8 +5822,8 @@ msgid "Absence reason"
 msgstr "Razón de inasistencia"
 
 #: support/filters.py:479
-msgid "Absences only"
-msgstr "Solo inasistencias"
+msgid "Include present"
+msgstr "Incluir asistencias"
 
 #: support/forms.py:47
 #, python-brace-format
@@ -11704,6 +11704,9 @@ msgstr "La contraseña debe contener al menos 1 letra minúscula, a-z."
 #: validators.py:45
 msgid "Your password must contain at least 1 lowercase letter, a-z."
 msgstr "Tu contraseña debe contener al menos 1 letra minúscula, a-z."
+
+#~ msgid "Absences only"
+#~ msgstr "Solo inasistencias"
 
 #, python-format
 #~ msgid "Contact %(name)s (ID: %(id)s) added to campaign %(campaign)s"

--- a/locale/es_CO/LC_MESSAGES/django.po
+++ b/locale/es_CO/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-20 18:31-0300\n"
+"POT-Creation-Date: 2026-05-06 16:37-0300\n"
 "PO-Revision-Date: 2025-09-20 18:33-0300\n"
 "Last-Translator: TANYA <tanyatree@gmail.com>\n"
 "Language-Team: \n"
@@ -19,13 +19,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.7\n"
 
-#: advertisement/apps.py:8 core/choices.py:237
+#: advertisement/apps.py:8 core/choices.py:250
 #: templates/components/sidebar_items/_advertisement.html:10
 msgid "Advertisement"
 msgstr "Anuncio"
 
-#: advertisement/filters.py:27 advertisement/models.py:50
-#: advertisement/models.py:187 advertisement/models.py:252
+#: advertisement/filters.py:27 advertisement/models.py:51
+#: advertisement/models.py:188 advertisement/models.py:253
 #: advertisement/templates/ad_purchase_order_detail.html:27
 #: advertisement/templates/ad_purchase_order_list.html:52
 #: advertisement/templates/ad_purchase_order_list.html:98
@@ -36,9 +36,9 @@ msgstr "Anuncio"
 msgid "Advertiser"
 msgstr "Anunciante"
 
-#: advertisement/filters.py:28 advertisement/models.py:42
-#: advertisement/models.py:113 advertisement/models.py:203
-#: advertisement/models.py:259
+#: advertisement/filters.py:28 advertisement/models.py:43
+#: advertisement/models.py:114 advertisement/models.py:204
+#: advertisement/models.py:260
 #: advertisement/templates/ad_purchase_order_create_update.html:45
 #: advertisement/templates/ad_purchase_order_detail.html:41
 #: advertisement/templates/ad_purchase_order_list.html:64
@@ -47,21 +47,26 @@ msgstr "Anunciante"
 #: advertisement/templates/advertiser_detail.html:57
 #: advertisement/templates/advertiser_list.html:84
 #: advertisement/templates/agency_detail.html:58
-#: advertisement/templates/agency_list.html:84 core/models.py:1334
-#: core/models.py:2516 support/models.py:372
+#: advertisement/templates/agency_list.html:84 core/models.py:1533
+#: core/models.py:2776 support/models.py:441 support/models.py:716
+#: support/templates/activities/activity_detail.html:59
 #: support/templates/assign_sellers.html:38
-#: support/templates/contact_detail/tabs/_campaigns.html:23
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:35
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:51
+#: support/templates/contact_detail/edit_campaign_status.html:26
+#: support/templates/contact_detail/tabs/_activities.html:23
+#: support/templates/contact_detail/tabs/_campaigns.html:41
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:85
 #: support/templates/release_seller_contacts.html:18
 #: support/templates/release_seller_contacts_by_campaign.html:18
 #: support/templates/sales_record_create.html:220
-#: support/templates/sales_record_filter.html:62
-#: support/templates/sales_record_filter.html:99
-#: support/templates/seller_console.html:236
-#: support/templates/validate_subscription_sales_record.html:215
-#: support/templates/validate_subscription_sales_record.html:249
-#: support/views/all_views.py:1991
+#: support/templates/sales_record_filter.html:104
+#: support/templates/sales_record_filter.html:141
+#: support/templates/seller_console.html:270
+#: support/templates/support/seller_attendance.html:49
+#: support/templates/support/seller_attendance_filter.html:118
+#: support/templates/validate_subscription_sales_record.html:334
+#: support/templates/validate_subscription_sales_record.html:380
+#: support/views/all_views.py:2292 support/views/all_views.py:2899
+#: support/views/all_views.py:3421
 msgid "Seller"
 msgstr "Vendedor"
 
@@ -70,31 +75,34 @@ msgstr "Vendedor"
 msgid "Bill to"
 msgstr "Facturar a"
 
-#: advertisement/filters.py:30 advertisement/models.py:251
+#: advertisement/filters.py:30 advertisement/models.py:252
 #: advertisement/templates/advertisement_activity_create_update.html:44
 #: advertisement/templates/advertiser_detail.html:103
 #: advertisement/templates/agency_detail.html:104
 #: advertisement/templates/my_advertisers.html:123
-#: advertisement/templates/my_advertisers.html:152 core/models.py:2521
-#: core/models.py:3140 core/models.py:3164
-#: invoicing/templates/invoice_filter.html:124 invoicing/views.py:284
-#: logistics/models.py:241 logistics/models.py:280
+#: advertisement/templates/my_advertisers.html:152 core/models.py:2781
+#: core/models.py:3422 core/models.py:3446
+#: invoicing/templates/invoice_filter.html:238 invoicing/views.py:305
+#: logistics/models.py:241 logistics/models.py:284
 #: logistics/templates/issues_per_route.html:58
 #: logistics/templates/print_labels_for_product_date.html:26
-#: logistics/templates/route_details.html:16
-#: logistics/templates/route_details.html:131 support/models.py:120
+#: logistics/templates/route_details.html:17
+#: logistics/templates/route_details.html:23
+#: logistics/templates/route_details.html:138 support/forms.py:412
+#: support/models.py:142 support/models.py:703
 #: support/templates/contact_detail/tabs/_activities.html:13
 #: support/templates/contact_detail/tabs/_issues.html:13
-#: support/templates/contact_detail/tabs/_overview.html:241
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:16
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:26
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:125
 #: support/templates/history_extended.html:30
 #: support/templates/history_extended.html:87
 #: support/templates/history_extended.html:148
 #: support/templates/invoicing_issues.html:57
-#: support/templates/list_issues.html:149
-#: support/templates/seller_console.html:353
+#: support/templates/seller_console.html:391
+#: support/templates/support/seller_attendance.html:19
+#: support/templates/support/seller_attendance_filter.html:117
 #: support/templates/unsubscription_statistics.html:47
-#: support/templates/view_issue.html:217 support/views/all_views.py:1990
+#: support/views/all_views.py:2898 support/views/all_views.py:3420
 msgid "Date"
 msgstr "Fecha"
 
@@ -104,28 +112,28 @@ msgstr "Fecha"
 msgid "Billed"
 msgstr "Facturado"
 
-#: advertisement/models.py:13
+#: advertisement/models.py:14
 msgid "Public"
 msgstr "Publico"
 
-#: advertisement/models.py:14
+#: advertisement/models.py:15
 msgid "Private"
 msgstr "Privado"
 
-#: advertisement/models.py:17 advertisement/models.py:84 core/choices.py:76
+#: advertisement/models.py:18 advertisement/models.py:85 core/choices.py:67
 msgid "High"
 msgstr "Alto"
 
-#: advertisement/models.py:18 advertisement/models.py:85
+#: advertisement/models.py:19 advertisement/models.py:86
 msgid "Mid"
 msgstr "Medio"
 
-#: advertisement/models.py:19 advertisement/models.py:86 core/choices.py:78
+#: advertisement/models.py:20 advertisement/models.py:87 core/choices.py:69
 msgid "Low"
 msgstr "Bajo"
 
-#: advertisement/models.py:21 advertisement/models.py:88
-#: advertisement/models.py:130 advertisement/models.py:146
+#: advertisement/models.py:22 advertisement/models.py:89
+#: advertisement/models.py:131 advertisement/models.py:147
 #: advertisement/templates/advertiser_create_update.html:43
 #: advertisement/templates/advertiser_detail.html:45
 #: advertisement/templates/advertiser_list.html:54
@@ -137,41 +145,44 @@ msgstr "Bajo"
 #: advertisement/templates/my_advertisers.html:26
 #: advertisement/templates/my_advertisers.html:59
 #: advertisement/templates/my_advertisers.html:88 community/models.py:22
-#: core/models.py:97 core/models.py:115 core/models.py:210 core/models.py:377
-#: core/models.py:419 core/models.py:1249 core/models.py:2476
-#: core/models.py:2493 core/models.py:3175 core/models.py:3187
-#: core/models.py:3211 core/models.py:3235 invoicing/models.py:448
+#: core/models.py:96 core/models.py:114 core/models.py:217 core/models.py:405
+#: core/models.py:447 core/models.py:1337 core/models.py:2736
+#: core/models.py:2753 core/models.py:3457 core/models.py:3469
+#: core/models.py:3493 core/models.py:3517 invoicing/models.py:449
 #: logistics/models.py:23 logistics/models.py:143 logistics/models.py:164
 #: logistics/models.py:204 logistics/templates/assign_routes.html:56
 #: logistics/templates/change_route.html:61
 #: logistics/templates/issues_per_route.html:111
 #: logistics/templates/list_routes.html:36
 #: logistics/templates/list_routes_detailed.html:45
+#: logistics/templates/merge_compare_addresses.html:113
 #: logistics/templates/order_route.html:99
 #: logistics/templates/order_route_print.html:17
 #: logistics/templates/order_routes_list.html:36
 #: logistics/templates/print_routes_simple.html:65
 #: logistics/templates/print_unordered_subscriptions_list.html:19
-#: logistics/templates/route_details.html:42
-#: logistics/templates/route_details.html:168 support/forms.py:245
-#: support/models.py:32 support/templates/campaign_statistics_detail.html:30
+#: logistics/templates/route_details.html:49
+#: logistics/templates/route_details.html:175 support/forms.py:152
+#: support/forms.py:284 support/forms.py:988 support/models.py:26
+#: support/models.py:45 support/models.py:411 support/models.py:679
+#: support/templates/campaign_statistics_detail.html:34
 #: support/templates/campaign_statistics_list.html:43
 #: support/templates/campaign_statistics_list.html:59
 #: support/templates/campaign_statistics_per_seller.html:42
 #: support/templates/campaign_statistics_per_seller.html:61
-#: support/templates/contact_detail/tabs/_information.html:10
-#: support/templates/contact_detail/tabs/_information.html:105
+#: support/templates/contact_detail/tabs/_information.html:11
+#: support/templates/contact_detail/tabs/_information.html:140
 #: support/templates/contact_detail/tabs/_overview.html:10
 #: support/templates/create_contact/tabs/_data.html:15
 #: support/templates/debtor_contacts.html:89
-#: support/templates/seller_console_list_campaigns.html:22
+#: support/templates/seller_console_list_campaigns.html:24
 #: support/templates/seller_console_special_routes.html:22
 #: support/templates/seller_performance_by_time.html:74
-#: support/views/all_views.py:1185
+#: support/views/all_views.py:1864
 msgid "Name"
 msgstr "Nombre"
 
-#: advertisement/models.py:23 advertisement/models.py:91
+#: advertisement/models.py:24 advertisement/models.py:92
 #: advertisement/templates/advertiser_detail.html:48
 #: advertisement/templates/advertiser_list.html:83
 #: advertisement/templates/agency_detail.html:49
@@ -179,31 +190,31 @@ msgstr "Nombre"
 msgid "Main contact"
 msgstr "Contacto principal"
 
-#: advertisement/models.py:25
+#: advertisement/models.py:26
 #: advertisement/templates/advertisement_activity_create_update.html:36
 #: advertisement/templates/advertiser_create_update.html:47
 #: advertisement/templates/advertiser_detail.html:101
 #: advertisement/templates/agency_detail.html:102
 #: advertisement/templates/my_advertisers.html:122
-#: advertisement/templates/my_advertisers.html:151 core/models.py:217
-#: core/models.py:1392 core/models.py:2527 invoicing/models.py:296
-#: invoicing/templates/print.html:48 support/models.py:230
-#: support/templates/contact_detail/tabs/_information.html:17
-#: support/templates/contact_detail/tabs/_overview.html:18
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:20
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:30
+#: advertisement/templates/my_advertisers.html:151 core/models.py:224
+#: core/models.py:1622 core/models.py:2787 invoicing/models.py:299
+#: invoicing/templates/print.html:48 support/models.py:279
+#: support/templates/activities/activity_detail.html:40
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:32
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:89
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:128
 #: support/templates/sales_record_create.html:100
-#: support/templates/sales_record_filter.html:106
-#: support/templates/validate_subscription_sales_record.html:99
+#: support/templates/sales_record_filter.html:148
+#: support/templates/validate_subscription_sales_record.html:218
 msgid "Type"
 msgstr "Tipo"
 
-#: advertisement/models.py:27 advertisement/models.py:98
+#: advertisement/models.py:28 advertisement/models.py:99
 msgid "Other contacts"
 msgstr "Otros contactos"
 
-#: advertisement/models.py:29 advertisement/models.py:101
-#: advertisement/models.py:242 advertisement/models.py:291
+#: advertisement/models.py:30 advertisement/models.py:102
+#: advertisement/models.py:243 advertisement/models.py:292
 #: advertisement/templates/advertiser_create_update.html:78
 #: advertisement/templates/advertiser_detail.html:53
 #: advertisement/templates/advertiser_list.html:81
@@ -211,46 +222,58 @@ msgstr "Otros contactos"
 #: advertisement/templates/agency_detail.html:54
 #: advertisement/templates/agency_detail.html:139
 #: advertisement/templates/agency_list.html:81
-#: advertisement/templates/agent_create_update.html:38 core/models.py:449
-#: core/models.py:1185 logistics/models.py:30 support/forms.py:250
-#: support/templates/check_for_existing_contacts.html:80
-#: support/templates/check_for_existing_contacts.html:137
-#: support/templates/contact_detail/tabs/_information.html:23
-#: support/templates/contact_detail/tabs/_overview.html:25
-#: support/templates/contact_list.html:82
-#: support/templates/create_contact/tabs/_data.html:23
-#: support/templates/seller_console.html:203
+#: advertisement/templates/agent_create_update.html:38 core/models.py:477
+#: core/models.py:1273 invoicing/filters.py:45
+#: invoicing/templates/invoice_filter.html:84 invoicing/views.py:298
+#: logistics/models.py:30 logistics/templates/merge_compare_addresses.html:202
+#: support/forms.py:175 support/forms.py:289 support/forms.py:1011
+#: support/templates/check_for_existing_contacts.html:181
+#: support/templates/check_for_existing_contacts.html:262
+#: support/templates/contact_detail/tabs/_information.html:20
+#: support/templates/contact_detail/tabs/_overview.html:19
+#: support/templates/contact_list.html:173
+#: support/templates/create_contact/tabs/_data.html:28
+#: support/templates/create_contact/tabs/_data.html:31
+#: support/templates/create_contact/tabs/_data.html:35
+#: support/templates/seller_console.html:233
+#: support/templates/seller_console_never_paid_issues.html:29
 #: support/templates/seller_console_special_routes.html:25
 #: support/templates/subscriptions/subscription_end_date_list.html:88
-#: support/views/all_views.py:1186 support/views/all_views.py:1865
-#: support/views/contacts.py:85
+#: support/views/all_views.py:1865 support/views/all_views.py:2286
+#: support/views/all_views.py:2749 support/views/contacts.py:153
 msgid "Email"
 msgstr "Correo electrónico"
 
-#: advertisement/models.py:30 advertisement/models.py:102
+#: advertisement/models.py:31 advertisement/models.py:103
 #: advertisement/templates/advertiser_create_update.html:73
 #: advertisement/templates/advertiser_detail.html:51
 #: advertisement/templates/advertiser_list.html:82
 #: advertisement/templates/agency_create_update.html:60
 #: advertisement/templates/agency_detail.html:52
-#: advertisement/templates/agency_list.html:82 core/models.py:439
+#: advertisement/templates/agency_list.html:82 core/models.py:467
+#: invoicing/templates/invoice_filter.html:92 invoicing/views.py:299
 #: logistics/models.py:27 logistics/templates/issues_per_route.html:60
-#: logistics/templates/route_details.html:43
-#: logistics/templates/route_details.html:133
-#: logistics/templates/route_details.html:170 support/forms.py:247
-#: support/templates/contact_detail/tabs/_information.html:29
-#: support/templates/contact_detail/tabs/_overview.html:29
-#: support/templates/contact_list.html:83
-#: support/templates/create_contact/tabs/_data.html:29
-#: support/templates/seller_console.html:145
-#: support/templates/seller_console.html:189
+#: logistics/templates/route_details.html:50
+#: logistics/templates/route_details.html:140
+#: logistics/templates/route_details.html:177 support/forms.py:157
+#: support/forms.py:286 support/forms.py:993
+#: support/templates/check_for_existing_contacts.html:204
+#: support/templates/contact_detail/tabs/_information.html:40
+#: support/templates/contact_detail/tabs/_overview.html:37
+#: support/templates/contact_list.html:174
+#: support/templates/create_contact/tabs/_data.html:46
+#: support/templates/create_contact/tabs/_data.html:49
+#: support/templates/seller_console.html:172
+#: support/templates/seller_console.html:218
+#: support/templates/seller_console_never_paid_issues.html:30
 #: support/templates/subscriptions/subscription_end_date_list.html:89
-#: support/views/all_views.py:1188 support/views/all_views.py:1866
-#: support/views/contacts.py:86
+#: support/templates/view_issue.html:341 support/views/all_views.py:1867
+#: support/views/all_views.py:2287 support/views/all_views.py:2750
+#: support/views/contacts.py:154
 msgid "Phone"
 msgstr "Teléfono"
 
-#: advertisement/models.py:31 advertisement/models.py:100
+#: advertisement/models.py:32 advertisement/models.py:101
 #: advertisement/templates/advertiser_create_update.html:51
 #: advertisement/templates/advertiser_list.html:85
 #: advertisement/templates/agency_create_update.html:38
@@ -258,51 +281,51 @@ msgstr "Teléfono"
 msgid "Importance"
 msgstr "Importancia"
 
-#: advertisement/models.py:34 advertisement/models.py:105
+#: advertisement/models.py:35 advertisement/models.py:106
 #: advertisement/templates/advertiser_create_update.html:90
 #: advertisement/templates/advertiser_detail.html:64
 #: advertisement/templates/agency_create_update.html:77
-#: advertisement/templates/agency_detail.html:65 core/models.py:1398
-#: support/forms.py:257 support/templates/sales_record_create.html:164
-#: support/templates/validate_subscription_sales_record.html:163
+#: advertisement/templates/agency_detail.html:65 core/models.py:1628
+#: support/forms.py:296 support/templates/sales_record_create.html:164
+#: support/templates/validate_subscription_sales_record.html:282
 msgid "Billing name"
 msgstr "Nombre de facturación"
 
-#: advertisement/models.py:35 advertisement/models.py:106
+#: advertisement/models.py:36 advertisement/models.py:107
 msgid "Billing ID document"
 msgstr "Documento de identificación de facturación"
 
-#: advertisement/models.py:36 advertisement/models.py:107
+#: advertisement/models.py:37 advertisement/models.py:108
 #: advertisement/templates/advertiser_create_update.html:100
 #: advertisement/templates/agency_create_update.html:87
 msgid "Unique taxpayer reference"
 msgstr "NIT"
 
-#: advertisement/models.py:37 advertisement/models.py:108
+#: advertisement/models.py:38 advertisement/models.py:109
 #: advertisement/templates/advertiser_create_update.html:112
 #: advertisement/templates/advertiser_detail.html:70
 #: advertisement/templates/agency_create_update.html:99
-#: advertisement/templates/agency_detail.html:71 core/models.py:1403
-#: support/forms.py:260 support/templates/sales_record_create.html:184
-#: support/templates/validate_subscription_sales_record.html:183
+#: advertisement/templates/agency_detail.html:71 core/models.py:1633
+#: support/forms.py:299 support/templates/sales_record_create.html:184
+#: support/templates/validate_subscription_sales_record.html:302
 msgid "Billing phone"
 msgstr "Teléfono de facturación"
 
-#: advertisement/models.py:38 advertisement/models.py:109
+#: advertisement/models.py:39 advertisement/models.py:110
 #: advertisement/templates/advertiser_create_update.html:107
 #: advertisement/templates/advertiser_detail.html:72
 #: advertisement/templates/agency_create_update.html:94
-#: advertisement/templates/agency_detail.html:73 core/models.py:1420
-#: support/forms.py:256 support/templates/sales_record_create.html:156
-#: support/templates/validate_subscription_sales_record.html:155
+#: advertisement/templates/agency_detail.html:73 core/models.py:1650
+#: support/forms.py:295 support/templates/sales_record_create.html:156
+#: support/templates/validate_subscription_sales_record.html:274
 msgid "Billing address"
 msgstr "Dirección de facturación"
 
-#: advertisement/models.py:39 advertisement/models.py:110
+#: advertisement/models.py:40 advertisement/models.py:111
 msgid "Billing email field"
 msgstr "Correo electrónico de facturación"
 
-#: advertisement/models.py:51
+#: advertisement/models.py:52
 #: advertisement/templates/ad_purchase_order_list.html:25
 #: advertisement/templates/advertiser_list.html:24
 #: advertisement/templates/my_advertisers.html:4
@@ -310,197 +333,201 @@ msgstr "Correo electrónico de facturación"
 msgid "Advertisers"
 msgstr "Anunciantes"
 
-#: advertisement/models.py:121 advertisement/models.py:210
-#: advertisement/models.py:254
+#: advertisement/models.py:122 advertisement/models.py:211
+#: advertisement/models.py:255
 msgid "Agency"
 msgstr "Agencia"
 
-#: advertisement/models.py:122 advertisement/templates/agency_list.html:24
+#: advertisement/models.py:123 advertisement/templates/agency_list.html:24
 #: templates/components/sidebar_items/_advertisement.html:33
 msgid "Agencies"
 msgstr "Agencias"
 
-#: advertisement/models.py:134
+#: advertisement/models.py:135
 msgid "Advertisement seller"
 msgstr "Vendedor de anuncios"
 
-#: advertisement/models.py:135
+#: advertisement/models.py:136
 msgid "Advertisement sellers"
 msgstr "Vendedores de anuncios"
 
-#: advertisement/models.py:147 advertisement/models.py:166
+#: advertisement/models.py:148 advertisement/models.py:167
 #: advertisement/templates/ad_purchase_order_create_update.html:70
 #: advertisement/templates/ad_purchase_order_detail.html:88
-#: community/models.py:23 core/models.py:132 core/models.py:2354
-#: core/models.py:2477 core/models.py:2494 core/models.py:3176
-#: core/models.py:3188 core/models.py:3212 core/models.py:3236
-#: invoicing/models.py:281 invoicing/models.py:450
-#: invoicing/templates/invoice/invoice_detail.html:220
-#: invoicing/templates/invoice/invoice_detail.html:247 logistics/models.py:25
+#: community/models.py:23 core/models.py:131 core/models.py:2640
+#: core/models.py:2737 core/models.py:2754 core/models.py:3458
+#: core/models.py:3470 core/models.py:3494 core/models.py:3518
+#: invoicing/models.py:284 invoicing/models.py:451
+#: invoicing/templates/invoice/invoice_detail.html:251
+#: invoicing/templates/invoice/invoice_detail.html:278 logistics/models.py:25
 #: logistics/models.py:187 logistics/templates/list_routes_detailed.html:46
-#: support/templates/campaign_statistics_detail.html:36
+#: support/models.py:413 support/models.py:680
+#: support/templates/campaign_statistics_detail.html:51
 #: support/templates/campaign_statistics_per_seller.html:47
 #: support/templates/dynamic_contact_filter_list.html:39
+#: support/templates/import_contacts.html:135
+#: support/templates/seller_console_list_campaigns.html:57
 msgid "Description"
 msgstr "Descripción"
 
-#: advertisement/models.py:148
+#: advertisement/models.py:149
 msgid "Reference price"
 msgstr "Precio de referencia"
 
-#: advertisement/models.py:149
+#: advertisement/models.py:150
 msgid "Advertise in these products"
 msgstr "Anunciar en estos productos"
 
-#: advertisement/models.py:152
+#: advertisement/models.py:153
 msgid "Ad type"
 msgstr "Tipo de anuncio"
 
-#: advertisement/models.py:153
+#: advertisement/models.py:154
 msgid "Ad types"
 msgstr "Tipos de anuncios"
 
-#: advertisement/models.py:165
+#: advertisement/models.py:166
 msgid "Advertisement type"
 msgstr "Tipo de anuncio"
 
-#: advertisement/models.py:167
+#: advertisement/models.py:168
 #: advertisement/templates/ad_purchase_order_create_update.html:75
-#: advertisement/templates/ad_purchase_order_detail.html:90 core/models.py:215
+#: advertisement/templates/ad_purchase_order_detail.html:90 core/models.py:222
 #: invoicing/templates/bill_subscriptions_for_one_contact.html:67
-#: invoicing/templates/invoice/invoice_detail.html:222 invoicing/views.py:220
-#: support/models.py:378
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:37
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:29
+#: invoicing/templates/invoice/invoice_detail.html:253 invoicing/views.py:221
+#: support/models.py:447
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:59
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:66
 #: support/templates/sales_record_create.html:80
-#: support/templates/validate_subscription_sales_record.html:79
-#: support/templates/validate_subscription_sales_record.html:227
+#: support/templates/validate_subscription_sales_record.html:198
+#: support/templates/validate_subscription_sales_record.html:346
 msgid "Price"
 msgstr "Precio"
 
-#: advertisement/models.py:168 core/models.py:1427 support/forms.py:254
-#: support/templates/campaign_statistics_detail.html:39
+#: advertisement/models.py:169 core/models.py:1657 support/forms.py:178
+#: support/forms.py:293 support/forms.py:1014
+#: support/templates/campaign_statistics_detail.html:57
 #: support/templates/campaign_statistics_per_seller.html:50
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:79
 #: support/templates/invoicing_issues.html:103
-#: support/templates/list_issues.html:191
 #: support/templates/sales_record_create.html:118
-#: support/templates/sales_record_filter.html:102
+#: support/templates/sales_record_filter.html:144
 #: support/templates/subscriptions/corporate_subscription.html:45
-#: support/templates/validate_subscription_sales_record.html:117
-#: support/templates/view_issue.html:48 support/views/all_views.py:624
-#: support/views/all_views.py:707 support/views/all_views.py:1341
+#: support/templates/validate_subscription_sales_record.html:236
+#: support/views/all_views.py:2020
 msgid "Start date"
 msgstr "Fecha de inicio"
 
-#: advertisement/models.py:169 core/models.py:1428
-#: logistics/templates/route_details.html:173 support/forms.py:255
-#: support/templates/campaign_statistics_detail.html:41
+#: advertisement/models.py:170 core/models.py:1658
+#: logistics/templates/route_details.html:180 support/forms.py:182
+#: support/forms.py:294 support/forms.py:1018 support/models.py:176
+#: support/templates/activities/activity_detail.html:101
+#: support/templates/campaign_statistics_detail.html:61
 #: support/templates/campaign_statistics_list.html:60
 #: support/templates/campaign_statistics_per_seller.html:51
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:83
 #: support/templates/sales_record_create.html:123
 #: support/templates/subscriptions/corporate_subscription.html:49
-#: support/templates/validate_subscription_sales_record.html:122
+#: support/templates/validate_subscription_sales_record.html:241
 msgid "End date"
 msgstr "Fecha de fin"
 
-#: advertisement/models.py:172 advertisement/models.py:173
+#: advertisement/models.py:173 advertisement/models.py:174
 msgid "Ad"
 msgstr "Anuncio"
 
-#: advertisement/models.py:184
+#: advertisement/models.py:185 support/views/all_views.py:2295
 msgid "Date created"
 msgstr "Fecha de creación"
 
-#: advertisement/models.py:185
+#: advertisement/models.py:186
 msgid "Date billed"
 msgstr "Fecha de facturación"
 
-#: advertisement/models.py:186
+#: advertisement/models.py:187
 msgid "billed"
 msgstr "facturado"
 
-#: advertisement/models.py:188
+#: advertisement/models.py:189
 #: advertisement/templates/ad_purchase_order_create_update.html:41
 #: advertisement/templates/ad_purchase_order_detail.html:110
 msgid "Taxes"
 msgstr "Impuestos"
 
-#: advertisement/models.py:189
+#: advertisement/models.py:190
 #: advertisement/templates/ad_purchase_order_create_update.html:37
 #: advertisement/templates/ad_purchase_order_detail.html:110
 msgid "Total price"
 msgstr "Precio total"
 
-#: advertisement/models.py:190 advertisement/models.py:292
+#: advertisement/models.py:191 advertisement/models.py:293
 #: advertisement/templates/ad_purchase_order_create_update.html:55
 #: advertisement/templates/ad_purchase_order_detail.html:39
 #: advertisement/templates/advertisement_activity_create_update.html:60
 #: advertisement/templates/agency_detail.html:140
-#: advertisement/templates/agent_create_update.html:60 core/models.py:466
-#: core/models.py:1187 core/models.py:2523 invoicing/models.py:291
-#: logistics/models.py:36 logistics/models.py:167
-#: logistics/templates/issues_per_route.html:63
-#: logistics/templates/route_details.html:137 support/forms.py:249
-#: support/templates/contact_detail/tabs/_information.html:173
-#: support/templates/contact_detail/tabs/_overview.html:130
-#: support/templates/contact_detail/tabs/_overview.html:203
-#: support/templates/contact_detail/tabs/_overview.html:246
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:29
-#: support/templates/create_contact/tabs/_data.html:84
-#: support/templates/view_issue.html:72 support/templates/view_issue.html:222
+#: advertisement/templates/agent_create_update.html:60 core/models.py:494
+#: core/models.py:1275 core/models.py:2783 invoicing/models.py:294
+#: invoicing/templates/invoice/invoice_detail.html:196 logistics/models.py:36
+#: logistics/models.py:167 logistics/templates/issues_per_route.html:63
+#: logistics/templates/merge_compare_addresses.html:325
+#: logistics/templates/route_details.html:144 support/forms.py:169
+#: support/forms.py:288 support/forms.py:484 support/forms.py:1005
+#: support/models.py:150 support/templates/activities/activity_detail.html:84
+#: support/templates/contact_detail/tabs/_information.html:164
+#: support/templates/contact_detail/tabs/_information.html:212
+#: support/templates/contact_detail/tabs/_overview.html:177
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:64
+#: support/templates/create_contact/tabs/_data.html:122
+#: support/templates/new_issue.html:395 support/templates/view_issue.html:395
 msgid "Notes"
 msgstr "Notas"
 
-#: advertisement/models.py:195
+#: advertisement/models.py:196
 msgid "Bill to agency"
 msgstr "Facturar a agencia"
 
-#: advertisement/models.py:216
+#: advertisement/models.py:217
 msgid "Ad purchase order"
 msgstr "Orden de compra de anuncio"
 
-#: advertisement/models.py:217
+#: advertisement/models.py:218
 msgid "Ad purchase orders"
 msgstr "Ordenes de compra de anuncios"
 
-#: advertisement/models.py:223
+#: advertisement/models.py:224
 #, python-format
 msgid "Order created at %(d)s for %(a)s"
 msgstr "Orden creada el %(d)s para %(a)s"
 
-#: advertisement/models.py:237 core/choices.py:106
+#: advertisement/models.py:238 core/choices.py:97 core/models.py:794
 msgid "In"
 msgstr "Entrada"
 
-#: advertisement/models.py:238 core/choices.py:107
+#: advertisement/models.py:239 core/choices.py:98 core/models.py:800
 msgid "Out"
 msgstr "Salida"
 
-#: advertisement/models.py:241
+#: advertisement/models.py:242
 msgid "Visit"
 msgstr "Visita"
 
-#: advertisement/models.py:243
+#: advertisement/models.py:244
 msgid "Phone call"
 msgstr "Llamada telefónica"
 
-#: advertisement/models.py:244
+#: advertisement/models.py:245
 msgid "Instant messaging"
 msgstr "Mensajería instantánea"
 
-#: advertisement/models.py:247 core/choices.py:91 core/choices.py:99
-#: invoicing/choices.py:17 invoicing/filters.py:30 invoicing/models.py:163
-#: invoicing/templates/invoice/invoice_detail.html:120
-#: invoicing/templates/invoice/invoice_detail.html:152
-#: invoicing/templates/invoice_filter.html:108 support/models.py:577
-#: support/templates/seller_console_list_campaigns.html:122
+#: advertisement/models.py:248 core/choices.py:82 core/choices.py:90
+#: invoicing/choices.py:17 invoicing/filters.py:30 invoicing/models.py:166
+#: invoicing/templates/invoice/invoice_detail.html:121
+#: invoicing/templates/invoice/invoice_detail.html:153
+#: invoicing/templates/invoice_filter.html:193 support/models.py:644
+#: support/templates/seller_console_list_campaigns.html:126
 msgid "Pending"
 msgstr "Pendiente"
 
-#: advertisement/models.py:248 core/choices.py:92 core/choices.py:100
-#: invoicing/choices.py:21 support/models.py:234
+#: advertisement/models.py:249 core/choices.py:83 core/choices.py:91
+#: invoicing/choices.py:21 support/models.py:283
 #: support/templates/contact_detail/tabs/_tasks.html:15
 #: support/templates/scheduled_task_filter.html:49
 #: support/templates/scheduled_task_filter.html:89
@@ -508,37 +535,39 @@ msgstr "Pendiente"
 msgid "Completed"
 msgstr "Completado"
 
-#: advertisement/models.py:250 core/models.py:1571
-#: invoicing/templates/invoice_filter.html:44 support/models.py:240
+#: advertisement/models.py:251 core/models.py:1814
+#: invoicing/templates/invoice_filter.html:99 support/models.py:289
 #: support/templates/contact_detail/tabs/_tasks.html:13
+#: support/templates/list_issues.html:253
 #: support/templates/scheduled_task_filter.html:87
+#: support/templates/view_issue.html:325 support/views/all_views.py:686
 #: support/views/scheduled_tasks.py:235
 msgid "Creation date"
 msgstr "Fecha de creación"
 
-#: advertisement/models.py:263
+#: advertisement/models.py:264
 #: advertisement/templates/ad_purchase_order_detail.html:11
 msgid "Purchase order"
 msgstr "Orden de compra"
 
-#: advertisement/models.py:270
+#: advertisement/models.py:271
 msgid "Advertisement activity"
 msgstr "Actividad de anuncio"
 
-#: advertisement/models.py:271
+#: advertisement/models.py:272
 msgid "Advertisement activities"
 msgstr "Actividades de anuncio"
 
-#: advertisement/models.py:275
+#: advertisement/models.py:276
 #, python-format
 msgid "Activity of type %(t)s for %(a)s at %(d)s"
 msgstr "Actividad de tipo %(t)s para %(a)s el %(d)s"
 
-#: advertisement/models.py:295 advertisement/templates/agency_detail.html:131
+#: advertisement/models.py:296 advertisement/templates/agency_detail.html:131
 msgid "Agent"
 msgstr "Agente"
 
-#: advertisement/models.py:296
+#: advertisement/models.py:297
 msgid "Agents"
 msgstr "Agentes"
 
@@ -580,13 +609,15 @@ msgstr "Enviar"
 #: advertisement/templates/my_advertisers.html:38
 #: advertisement/templates/my_advertisers.html:69
 #: advertisement/templates/my_advertisers.html:98
-#: invoicing/templates/invoice/invoice_detail.html:14
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:106
+#: invoicing/templates/invoice/invoice_detail.html:15
+#: support/templates/contact_detail/tabs/_information.html:177
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:165
 #: support/templates/contact_detail/tabs/includes/_subscription_actions.html:9
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:183
 #: support/templates/dynamic_contact_filter_list.html:44
 #: support/templates/sales_record_create.html:245
-#: support/templates/validate_subscription_sales_record.html:262
-#: support/views/contacts.py:321
+#: support/templates/validate_subscription_sales_record.html:406
+#: support/views/contacts.py:478
 msgid "Edit"
 msgstr "Editar"
 
@@ -613,18 +644,18 @@ msgstr "Comisión de vendedor"
 
 #: advertisement/templates/ad_purchase_order_detail.html:56
 #: advertisement/templates/advertiser_detail.html:61
-#: advertisement/templates/agency_detail.html:62 core/admin.py:238
+#: advertisement/templates/agency_detail.html:62 core/admin.py:239
 #: invoicing/admin.py:54
 msgid "Billing data"
 msgstr "Datos de facturación"
 
 #: advertisement/templates/ad_purchase_order_detail.html:61
-#: invoicing/models.py:90 invoicing/templates/invoice/invoice_detail.html:181
+#: invoicing/models.py:90 invoicing/templates/invoice/invoice_detail.html:212
 msgid "Billing Name"
 msgstr "Nombre de facturación"
 
 #: advertisement/templates/ad_purchase_order_detail.html:63
-#: support/forms.py:259
+#: support/forms.py:298
 msgid "Billing ID Document"
 msgstr "Documento de identificación de facturación"
 
@@ -637,7 +668,7 @@ msgid "Billing Phone"
 msgstr "Teléfono de facturación"
 
 #: advertisement/templates/ad_purchase_order_detail.html:69
-#: invoicing/models.py:80 invoicing/templates/invoice/invoice_detail.html:185
+#: invoicing/models.py:80 invoicing/templates/invoice/invoice_detail.html:216
 msgid "Billing Address"
 msgstr "Dirección de facturación"
 
@@ -650,14 +681,10 @@ msgid "Ads Purchased"
 msgstr "Anuncios adquiridos"
 
 #: advertisement/templates/ad_purchase_order_detail.html:93
-#: support/templates/subscriptions/affiliate_subscriptions.html:21
-#: support/templates/subscriptions/affiliate_subscriptions.html:70
 msgid "Start Date"
 msgstr "Fecha de inicio"
 
 #: advertisement/templates/ad_purchase_order_detail.html:97
-#: support/templates/subscriptions/affiliate_subscriptions.html:22
-#: support/templates/subscriptions/affiliate_subscriptions.html:71
 msgid "End Date"
 msgstr "Fecha de fin"
 
@@ -675,14 +702,14 @@ msgstr "Ver todas las órdenes de compra de anuncios."
 #: advertisement/templates/advertiser_list.html:66
 #: advertisement/templates/agency_list.html:44
 #: advertisement/templates/agency_list.html:66
-#: invoicing/templates/invoice_filter.html:98
+#: invoicing/templates/invoice_filter.html:149
 #: logistics/templates/order_route.html:85
-#: support/templates/contact_list.html:22
-#: support/templates/contact_list.html:57
+#: support/templates/contact_list.html:94
+#: support/templates/contact_list.html:142
 #: support/templates/debtor_contacts.html:78
 #: support/templates/invoicing_issues.html:92
-#: support/templates/list_issues.html:175
-#: support/templates/scheduled_activities.html:78
+#: support/templates/list_issues.html:235
+#: support/templates/scheduled_activities.html:139
 #: support/templates/scheduled_task_filter.html:74
 #: support/templates/subscriptions/subscription_end_date_list.html:33
 #: support/templates/subscriptions/subscription_end_date_list.html:68
@@ -690,12 +717,10 @@ msgid "Search"
 msgstr "Buscar"
 
 #: advertisement/templates/ad_purchase_order_list.html:72
-#: support/templates/sales_record_filter.html:43
 msgid "Min. Date"
 msgstr "Fecha mínima"
 
 #: advertisement/templates/ad_purchase_order_list.html:78
-#: support/templates/sales_record_filter.html:49
 msgid "Max. Date"
 msgstr "Fecha máxima"
 
@@ -714,17 +739,16 @@ msgstr "Precio total"
 #: advertisement/templates/ad_purchase_order_list.html:117
 #: logistics/templates/issues_route_list.html:50
 #: support/templates/campaign_statistics_list.html:66
-#: support/templates/contact_detail/tabs/_activities.html:38
-#: support/templates/contact_detail/tabs/_activities.html:51
-#: support/templates/contact_detail/tabs/_issues.html:31
+#: support/templates/contact_detail/tabs/_activities.html:40
+#: support/templates/contact_detail/tabs/_activities.html:55
+#: support/templates/contact_detail/tabs/_issues.html:33
 #: support/templates/contact_detail/tabs/_tasks.html:30
 #: support/templates/contact_detail/tabs/_tasks.html:37
-#: support/templates/seller_console_list_campaigns.html:36
-#: support/templates/seller_console_list_campaigns.html:64
-#: support/templates/seller_console_list_campaigns.html:99
-#: support/templates/seller_console_list_campaigns.html:147
+#: support/templates/seller_console_list_campaigns.html:38
+#: support/templates/seller_console_list_campaigns.html:68
+#: support/templates/seller_console_list_campaigns.html:103
+#: support/templates/seller_console_list_campaigns.html:151
 #: support/templates/subscriptions/subscription_end_date_list.html:106
-#: support/templates/view_issue.html:114
 msgid "View"
 msgstr "Ver"
 
@@ -744,46 +768,48 @@ msgid "Add activity"
 msgstr "Agregar actividad"
 
 #: advertisement/templates/advertisement_activity_create_update.html:40
-#: core/models.py:2533
+#: core/models.py:2793 support/templates/activities/activity_detail.html:48
 #: support/templates/contact_detail/tabs/_activities.html:15
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:24
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:38
 msgid "Direction"
 msgstr "Dirección"
 
 #: advertisement/templates/advertisement_activity_create_update.html:54
 #: advertisement/templates/advertiser_detail.html:102
-#: advertisement/templates/agency_detail.html:103 core/models.py:1394
-#: core/models.py:2530 invoicing/templates/contact_invoices.html:63
+#: advertisement/templates/agency_detail.html:103 core/models.py:1624
+#: core/models.py:2790 invoicing/templates/contact_invoices.html:63
 #: invoicing/templates/contact_invoices.html:104
-#: invoicing/templates/invoice/invoice_detail.html:105
-#: invoicing/templates/invoice_filter.html:60
-#: invoicing/templates/invoice_filter.html:127 invoicing/views.py:288
-#: logistics/models.py:165
+#: invoicing/templates/invoice/invoice_detail.html:106
+#: invoicing/templates/invoice_filter.html:111
+#: invoicing/templates/invoice_filter.html:241 invoicing/views.py:309
+#: logistics/models.py:165 support/forms.py:448 support/models.py:171
+#: support/models.py:717 support/templates/activities/activity_detail.html:44
 #: support/templates/contact_detail/htmx/_invoices_htmx.html:13
 #: support/templates/contact_detail/tabs/_activities.html:19
-#: support/templates/contact_detail/tabs/_campaigns.html:35
-#: support/templates/contact_detail/tabs/_issues.html:16
-#: support/templates/contact_detail/tabs/_overview.html:197
-#: support/templates/contact_detail/tabs/_overview.html:237
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:46
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:53
+#: support/templates/contact_detail/tabs/_campaigns.html:69
+#: support/templates/contact_detail/tabs/_issues.html:17
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:44
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:93
 #: support/templates/invoicing_issues.html:45
 #: support/templates/invoicing_issues.html:105
-#: support/templates/list_issues.html:133
-#: support/templates/list_issues.html:195
+#: support/templates/list_issues.html:151
+#: support/templates/list_issues.html:265
 #: support/templates/sales_record_create.html:107
-#: support/templates/scheduled_activities.html:41
-#: support/templates/scheduled_activities.html:98
-#: support/templates/subscriptions/affiliate_subscriptions.html:72
-#: support/templates/validate_subscription_sales_record.html:106
-#: support/templates/view_issue.html:213 support/templates/view_issue.html:282
-#: support/views/all_views.py:630 support/views/all_views.py:713
-#: support/views/all_views.py:1345
+#: support/templates/scheduled_activities.html:59
+#: support/templates/scheduled_activities.html:166
+#: support/templates/seller_console_never_paid_issues.html:32
+#: support/templates/support/seller_attendance.html:50
+#: support/templates/support/seller_attendance_filter.html:119
+#: support/templates/validate_subscription_sales_record.html:225
+#: support/templates/view_issue.html:189 support/views/all_views.py:694
+#: support/views/all_views.py:2024 support/views/all_views.py:2289
+#: support/views/all_views.py:3422
 msgid "Status"
 msgstr "Estado"
 
 #: advertisement/templates/advertisement_activity_create_update.html:65
 #: support/templates/activities/create_activity.html:57
+#: support/templates/contact_detail/edit_campaign_status.html:83
 #: support/templates/create_contact/create_contact.html:102
 #: support/templates/edit_address_complementary_information.html:41
 #: support/templates/edit_envelopes.html:56
@@ -793,8 +819,8 @@ msgid "Save"
 msgstr "Guardar"
 
 #: advertisement/templates/advertiser_create_update.html:25
-#: advertisement/templates/agency_create_update.html:19 core/choices.py:39
-#: logistics/templates/route_details.html:41
+#: advertisement/templates/agency_create_update.html:19 core/choices.py:30
+#: logistics/templates/route_details.html:48
 msgid "New"
 msgstr "Nuevo"
 
@@ -823,9 +849,9 @@ msgid "Billing id document"
 msgstr "Documento de identificación de facturación"
 
 #: advertisement/templates/advertiser_create_update.html:117
-#: advertisement/templates/agency_create_update.html:104 core/models.py:1424
-#: support/forms.py:261 support/templates/sales_record_create.html:190
-#: support/templates/validate_subscription_sales_record.html:189
+#: advertisement/templates/agency_create_update.html:104 core/models.py:1654
+#: support/forms.py:300 support/templates/sales_record_create.html:190
+#: support/templates/validate_subscription_sales_record.html:308
 msgid "Billing email"
 msgstr "Correo electrónico de facturación"
 
@@ -835,6 +861,7 @@ msgstr "Agregar Pedido de Compra"
 
 #: advertisement/templates/advertiser_detail.html:14
 #: advertisement/templates/agency_detail.html:15
+#: support/templates/contact_detail/tabs/_overview.html:131
 msgid "Edit info"
 msgstr "Editar información"
 
@@ -857,8 +884,8 @@ msgstr "Información general"
 #: advertisement/templates/advertiser_detail.html:55
 #: advertisement/templates/advertiser_list.html:60
 #: advertisement/templates/agency_detail.html:56
-#: advertisement/templates/agency_list.html:60 core/models.py:2359
-#: core/models.py:2525
+#: advertisement/templates/agency_list.html:60 core/models.py:2645
+#: core/models.py:2785 support/templates/activities/activity_detail.html:194
 msgid "Priority"
 msgstr "Prioridad"
 
@@ -903,8 +930,9 @@ msgstr "Agregar anunciano"
 #: advertisement/templates/my_advertisers.html:162
 #: logistics/templates/mass_georef_address_filter.html:56
 #: logistics/templates/print_unordered_subscriptions_form.html:45
-#: support/templates/seller_console_list_campaigns.html:24
-#: support/templates/seller_console_list_campaigns.html:56
+#: logistics/templates/route_details.html:19
+#: support/templates/seller_console_list_campaigns.html:26
+#: support/templates/seller_console_list_campaigns.html:59
 msgid "Go"
 msgstr "Ir"
 
@@ -1072,8 +1100,8 @@ msgstr "Esta suscripción no debe ser facturada todavía."
 msgid " {} months"
 msgstr " {} meses"
 
-#: archive/tests/old_bill_subscription.py:238 core/models.py:1337
-#: core/models.py:1425 invoicing/utils.py:403 support/models.py:155
+#: archive/tests/old_bill_subscription.py:238 core/models.py:1536
+#: core/models.py:1655 invoicing/utils.py:403 support/models.py:197
 msgid "Envelope"
 msgstr "Sobre"
 
@@ -1082,12 +1110,13 @@ msgstr "Sobre"
 msgid "{} months discount ({} discount)"
 msgstr "{} meses de descuento ({})"
 
-#: archive/tests/old_bill_subscription.py:273 core/models.py:1412
+#: archive/tests/old_bill_subscription.py:273 core/models.py:1642
 #: invoicing/models.py:24 invoicing/utils.py:413
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:77
 #: support/templates/sales_record_create.html:135
 #: support/templates/sales_record_create.html:196
-#: support/templates/validate_subscription_sales_record.html:134
-#: support/templates/validate_subscription_sales_record.html:195
+#: support/templates/validate_subscription_sales_record.html:253
+#: support/templates/validate_subscription_sales_record.html:314
 msgid "Balance"
 msgstr "Saldo"
 
@@ -1095,8 +1124,8 @@ msgstr "Saldo"
 msgid "Balance owed"
 msgstr "Saldo adeudado"
 
-#: archive/tests/old_bill_subscription.py:301 core/utils.py:406
-#: invoicing/templates/invoice/invoice_detail.html:278
+#: archive/tests/old_bill_subscription.py:301 core/utils.py:412
+#: invoicing/templates/invoice/invoice_detail.html:309
 msgid "Rounding"
 msgstr "Redondeo"
 
@@ -1104,8 +1133,8 @@ msgstr "Redondeo"
 msgid "This subscription wasn't billed since amount is 0"
 msgstr "Esta suscripción no fue facturada ya que el monto es 0"
 
-#: community/apps.py:7 support/choices.py:20
-#: support/templates/new_issue.html:96
+#: community/apps.py:7 support/choices.py:20 support/choices.py:39
+#: support/templates/new_issue.html:237
 msgid "Community"
 msgstr "Comunidad"
 
@@ -1122,7 +1151,7 @@ msgstr "Participaciones en productos o eventos"
 msgid "Supports"
 msgstr "Apoyos"
 
-#: community/models.py:42 core/admin.py:324
+#: community/models.py:42 core/admin.py:325
 msgid "Supporters"
 msgstr "Personas que apoyaron"
 
@@ -1130,35 +1159,35 @@ msgstr "Personas que apoyaron"
 msgid "tags"
 msgstr "etiquetas"
 
-#: core/admin.py:213 support/templates/create_contact/create_contact.html:40
+#: core/admin.py:214 support/templates/create_contact/create_contact.html:40
 #: support/templates/create_contact/create_contact.html:63
 #: support/templates/create_contact/tabs/_data.html:10
 msgid "Contact data"
 msgstr "Datos del contacto"
 
-#: core/admin.py:215
+#: core/admin.py:216
 msgid "Subscription data"
 msgstr "Datos de suscripción"
 
-#: core/admin.py:232
+#: core/admin.py:233
 msgid "Corporate subscription data"
 msgstr "Datos de suscripción corporativa"
 
-#: core/admin.py:250
+#: core/admin.py:251
 msgid "Inactivity"
 msgstr "Inactividad"
 
-#: core/admin.py:317 support/choices.py:73
-#: support/templates/contact_detail/tabs/_overview.html:274
+#: core/admin.py:318 support/choices.py:98
+#: support/templates/contact_detail/tabs/_overview.html:316
 #: support/templates/create_contact/tabs/_newsletters.html:9
 msgid "Newsletters"
 msgstr "Newsletters"
 
-#: core/admin.py:333
+#: core/admin.py:334
 msgid "Contact details"
 msgstr "Datos de contacto"
 
-#: core/admin.py:427
+#: core/admin.py:428
 msgid ""
 "Settings variables MERCADOPAGO_PLAN_BACK_URL and "
 "MERCADOPAGO_PLAN_DEFAULT_CURRENCY must be set"
@@ -1166,39 +1195,40 @@ msgstr ""
 "Las variables MERCADOPAGO_PLAN_BACK_URL y MERCADOPAGO_PLAN_DEFAULT_CURRENCY "
 "deben ser configuradas en settings"
 
-#: core/admin.py:471
+#: core/admin.py:475
 msgid "Failed to disable product in MercadoPago"
 msgstr "Error al desactivar producto en MercadoPago"
 
-#: core/admin.py:489
+#: core/admin.py:521
 msgid "Failed to sync product in MercadoPago"
 msgstr "Error al sincronizar producto en MercadoPago"
 
-#: core/admin.py:515 support/templates/contact_detail/detail.html:102
+#: core/admin.py:551 support/templates/contact_detail/detail.html:126
+#: support/templates/reactivate_subscription.html:21
 msgid "Information"
 msgstr "Información"
 
-#: core/admin.py:517
+#: core/admin.py:553
 msgid "Pricing & Discounts"
 msgstr "Precios y descuentos"
 
-#: core/admin.py:529
+#: core/admin.py:566
 msgid "Scheduling & Frequency"
 msgstr "Programación y frecuencia"
 
-#: core/admin.py:530
+#: core/admin.py:567
 msgid "Billing & Priority"
 msgstr "Facturación y prioridad"
 
-#: core/admin.py:531
+#: core/admin.py:569
 msgid "MercadoPago and others"
 msgstr "MercadoPago y otros"
 
-#: core/admin.py:536
+#: core/admin.py:576
 msgid "The product could not be updated in MercadoPago"
 msgstr "El producto no pudo ser actualizado en MercadoPago"
 
-#: core/admin.py:682
+#: core/admin.py:728
 msgid "Bounce action log details"
 msgstr "Registro de acción de rebote"
 
@@ -1206,11 +1236,11 @@ msgstr "Registro de acción de rebote"
 msgid "Core"
 msgstr "Aplicación principal"
 
-#: core/choices.py:7 core/models.py:230 logistics/models.py:284
+#: core/choices.py:7 core/models.py:237 logistics/models.py:288
 msgid "Digital"
 msgstr "Digital"
 
-#: core/choices.py:7 tests/test_contact.py:172
+#: core/choices.py:7 tests/test_contact.py:177
 msgid "Physical"
 msgstr "Físico"
 
@@ -1242,215 +1272,198 @@ msgstr "Posgrado"
 msgid "Doesn't want to inform"
 msgstr "No desea informar"
 
-#: core/choices.py:20 core/choices.py:59
-msgid "Normal end"
-msgstr "Final normal"
-
-#: core/choices.py:21 core/choices.py:57 core/choices.py:85
-#: support/templates/contact_detail/tabs/includes/_subscription_icons.html:23
-#: support/templates/sales_record_create.html:58
-#: support/templates/validate_subscription_sales_record.html:57
-msgid "Paused"
-msgstr "En pausa"
-
-#: core/choices.py:22
-msgid "Upgraded"
-msgstr "Actualizado"
-
-#: core/choices.py:23
-msgid "Debtor"
-msgstr "Deudor"
-
-#: core/choices.py:24
-msgid "Debtor, automatic unsubscription"
-msgstr "Deudor, desuscripción automática"
-
-#: core/choices.py:25 support/models.py:527
-msgid "N/A"
-msgstr "N/A"
-
-#: core/choices.py:28 core/choices.py:31 core/choices.py:172
+#: core/choices.py:19 core/choices.py:22 core/choices.py:192
 #: logistics/templates/issues_statistics.html:77
 msgid "Monthly"
 msgstr "Mensual"
 
-#: core/choices.py:28 core/choices.py:32
+#: core/choices.py:19 core/choices.py:23
 msgid "Quarterly"
 msgstr "Trimestral"
 
-#: core/choices.py:28 core/choices.py:34
+#: core/choices.py:19 core/choices.py:25
 msgid "Biannual"
 msgstr "Semestral"
 
-#: core/choices.py:28 core/choices.py:33
+#: core/choices.py:19 core/choices.py:24
 msgid "Annual"
 msgstr "Anual"
 
-#: core/choices.py:35 core/choices.py:173
+#: core/choices.py:26 core/choices.py:193
 msgid "One-shot"
 msgstr "Una sola vez"
 
-#: core/choices.py:40 core/models.py:191
+#: core/choices.py:31 core/models.py:190
 msgid "Automatic"
 msgstr "Automatico"
 
-#: core/choices.py:41 core/choices.py:109
+#: core/choices.py:32 core/choices.py:100
 msgid "Renewal"
 msgstr "Renovación"
 
-#: core/choices.py:45 core/choices.py:240
+#: core/choices.py:36 core/choices.py:253 core/models.py:213
 msgid "Promotion"
 msgstr "Promoción"
 
-#: core/choices.py:46 core/choices.py:56 core/choices.py:77
+#: core/choices.py:37 core/choices.py:47 core/choices.py:68
 msgid "Normal"
 msgstr "Normal"
 
-#: core/choices.py:47
+#: core/choices.py:38
 msgid "Gift"
 msgstr "Cortesía"
 
-#: core/choices.py:48
+#: core/choices.py:39 core/models.py:214
 msgid "Staff"
 msgstr "Equipo"
 
-#: core/choices.py:49
+#: core/choices.py:40
 msgid "Corporate"
 msgstr "Corporativo"
 
-#: core/choices.py:50
+#: core/choices.py:41
 msgid "Affiliate"
 msgstr "Afiliado"
 
-#: core/choices.py:54
+#: core/choices.py:45
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:40
 msgid "Awaiting payment"
 msgstr "Esperando pago"
 
-#: core/choices.py:55
+#: core/choices.py:46
 msgid "Not consolidated"
 msgstr "No consolidado"
 
-#: core/choices.py:58
+#: core/choices.py:48 core/choices.py:76 core/models.py:1597
+#: support/templates/contact_detail/tabs/includes/_subscription_icons.html:23
+#: support/templates/sales_record_create.html:58
+#: support/templates/validate_subscription_sales_record.html:176
+msgid "Paused"
+msgstr "En pausa"
+
+#: core/choices.py:49
 msgid "End because of debt"
 msgstr "Final por deuda"
 
-#: core/choices.py:60
+#: core/choices.py:50 core/models.py:1596
+msgid "Normal end"
+msgstr "Final normal"
+
+#: core/choices.py:51
 #: invoicing/templates/bill_subscriptions_for_one_contact.html:53
-#: support/templates/check_for_existing_contacts.html:30
-#: support/templates/import_contacts.html:22
+#: support/templates/check_for_existing_contacts.html:33
 msgid "Error"
 msgstr "Error"
 
-#: core/choices.py:64
+#: core/choices.py:55
 msgid "Male"
 msgstr "Masculino"
 
-#: core/choices.py:65
+#: core/choices.py:56
 msgid "Female"
 msgstr "Femenino"
 
-#: core/choices.py:66 core/models.py:203
+#: core/choices.py:57 core/models.py:202 core/models.py:215
 msgid "Other"
 msgstr "Otro"
 
-#: core/choices.py:70
+#: core/choices.py:61
 msgid "Impression"
 msgstr "Impresión"
 
-#: core/choices.py:71
+#: core/choices.py:62
 msgid "Imperssion Weekend"
 msgstr "Impresión fin de semana"
 
-#: core/choices.py:75
+#: core/choices.py:66
 msgid "Highest"
 msgstr "El más alto"
 
-#: core/choices.py:79
+#: core/choices.py:70
 msgid "Lowest"
 msgstr "El más bajo"
 
-#: core/choices.py:83 core/models.py:213 core/models.py:1388
-#: core/models.py:1578 core/models.py:2925 core/models.py:3213
-#: core/models.py:3237 invoicing/templates/invoice/invoice_detail.html:156
+#: core/choices.py:74 core/models.py:220 core/models.py:1618
+#: core/models.py:1821 core/models.py:3200 core/models.py:3495
+#: core/models.py:3519 invoicing/templates/invoice/invoice_detail.html:157
 #: logistics/filters.py:22 logistics/filters.py:28 logistics/models.py:38
-#: logistics/templates/order_routes_list.html:37
+#: logistics/templates/order_routes_list.html:37 support/models.py:682
 #: support/templates/campaign_statistics_list.html:39
 #: support/templates/debtor_contacts.html:90
-#: support/templates/seller_console.html:444
+#: support/templates/seller_console.html:482
 msgid "Active"
 msgstr "Activo"
 
-#: core/choices.py:84 core/models.py:1578 core/models.py:2925
-#: logistics/filters.py:31 support/templates/view_issue.html:44
+#: core/choices.py:75 core/models.py:1821 core/models.py:3200
+#: logistics/filters.py:31 support/templates/view_issue.html:320
 msgid "Inactive"
 msgstr "Inactivo"
 
-#: core/choices.py:86
+#: core/choices.py:77
 msgid "Resumed"
 msgstr "Reanudado"
 
-#: core/choices.py:93 core/choices.py:101
-#: support/templates/seller_console_list_campaigns.html:123
+#: core/choices.py:84 core/choices.py:92
+#: support/templates/seller_console_list_campaigns.html:127
 msgid "Delayed"
 msgstr "Retrasado"
 
-#: core/choices.py:94 core/choices.py:102 core/templatetags/core_tags.py:122
+#: core/choices.py:85 core/choices.py:93 core/templatetags/core_tags.py:127
 msgid "Expired"
 msgstr "Expirado"
 
-#: core/choices.py:108 core/choices.py:148
+#: core/choices.py:99 core/choices.py:165
 msgid "Internal"
 msgstr "Interno"
 
-#: core/choices.py:114
+#: core/choices.py:105
 msgid "Not yet contacted"
 msgstr "No contactado"
 
-#: core/choices.py:115 support/templates/campaign_statistics_detail.html:87
+#: core/choices.py:106 support/templates/campaign_statistics_detail.html:145
 #: support/templates/campaign_statistics_list.html:63
 msgid "Contacted"
 msgstr "Contactado"
 
-#: core/choices.py:116
+#: core/choices.py:107
 msgid "Called, could not contact"
 msgstr "Llamado, no contactado"
 
-#: core/choices.py:117
+#: core/choices.py:108
 msgid "Ended with contact"
 msgstr "Finalizado con contacto"
 
-#: core/choices.py:118 support/templates/campaign_statistics_detail.html:92
+#: core/choices.py:109 support/templates/campaign_statistics_detail.html:150
 msgid "Ended without contact"
 msgstr "Finalizado sin contacto"
 
-#: core/choices.py:119
+#: core/choices.py:110
 msgid "Switch to morning"
 msgstr "Cambio a la mañana"
 
-#: core/choices.py:120
+#: core/choices.py:111
 msgid "Switch to afternoon/evening"
 msgstr "Cambio a la tarde/noche"
 
-#: core/choices.py:124
+#: core/choices.py:129
 msgid "Started promotion"
 msgstr "Promoción iniciada"
 
-#: core/choices.py:125
+#: core/choices.py:130
 msgid "Already a subscriber"
 msgstr "Ya es suscriptor"
 
-#: core/choices.py:126
+#: core/choices.py:131
 msgid "Do not call anymore"
 msgstr "No llamar más"
 
-#: core/choices.py:127
+#: core/choices.py:132
 msgid "Error in promotion"
 msgstr "Error en promoción"
 
-#: core/choices.py:128 logistics/apps.py:7
+#: core/choices.py:133 logistics/apps.py:7
 #: logistics/templates/addresses_with_complementary_information.html:6
 #: logistics/templates/assign_routes.html:17
-#: logistics/templates/change_route.html:17
 #: logistics/templates/edition_time.html:9
 #: logistics/templates/list_routes.html:18
 #: logistics/templates/list_routes_detailed.html:17
@@ -1461,284 +1474,306 @@ msgstr "Error en promoción"
 #: logistics/templates/print_labels_from_csv.html:5
 #: logistics/templates/print_routes_simple.html:24
 #: logistics/templates/print_unordered_subscriptions_form.html:5
-#: support/choices.py:14 support/forms.py:536
-#: support/templates/new_issue.html:78
+#: support/choices.py:14 support/choices.py:33 support/forms.py:667
+#: support/templates/new_issue.html:195
 #: templates/components/sidebar_items/_logistics.html:21
 msgid "Logistics"
 msgstr "Logística"
 
-#: core/choices.py:129
+#: core/choices.py:134
 msgid "Not interested"
 msgstr "No interesado"
 
-#: core/choices.py:130
+#: core/choices.py:135
 msgid "Success with promotion"
 msgstr "Promoción exitosa"
 
-#: core/choices.py:131
+#: core/choices.py:136
 msgid "Success with direct sale"
 msgstr "Venta directa exitosa"
 
-#: core/choices.py:132 support/models.py:579
+#: core/choices.py:137 support/models.py:646
 msgid "Scheduled"
 msgstr "Agendado"
 
-#: core/choices.py:133 support/models.py:580
+#: core/choices.py:138 support/models.py:647
 msgid "Call later"
 msgstr "Llamar más tarde"
 
-#: core/choices.py:134
+#: core/choices.py:139 support/models.py:648
+#, fuzzy
+#| msgid "No Matches Found"
+msgid "Not found"
+msgstr "No se encontraron coincidencias"
+
+#: core/choices.py:140
 msgid "Cannot find contact"
 msgstr "No se puede encontrar el contacto"
 
-#: core/choices.py:135
+#: core/choices.py:141
 msgid "Close without contact"
 msgstr "Cerrar sin contacto"
 
-#: core/choices.py:141
+#: core/choices.py:147
 msgid "Campaign start"
 msgstr "Inicio de campaña"
 
-#: core/choices.py:142
+#: core/choices.py:148
 msgid "Call"
 msgstr "Llamar"
 
-#: core/choices.py:143
+#: core/choices.py:149
 msgid "E-mail"
 msgstr "Correo electrónico"
 
-#: core/choices.py:144
+#: core/choices.py:150
 msgid "Link hit"
 msgstr "Enlace abierto"
 
-#: core/choices.py:145
+#: core/choices.py:151
 msgid "WhatsApp message or other apps"
 msgstr "WhatsApp mensaje o otros apps"
 
-#: core/choices.py:146
+#: core/choices.py:152
 msgid "Event participation"
 msgstr "Participación en evento"
 
-#: core/choices.py:147
+#: core/choices.py:153
 msgid "In-place visit"
 msgstr "Visita en lugar"
 
-#: core/choices.py:157 logistics/templates/print_labels_for_day.html:25
+#: core/choices.py:177 logistics/templates/print_labels_for_day.html:25
 msgid "Monday"
 msgstr "Lunes"
 
-#: core/choices.py:158 logistics/templates/print_labels_for_day.html:26
+#: core/choices.py:178 logistics/templates/print_labels_for_day.html:26
 msgid "Tuesday"
 msgstr "Martes"
 
-#: core/choices.py:159 logistics/templates/print_labels_for_day.html:27
+#: core/choices.py:179 logistics/templates/print_labels_for_day.html:27
 msgid "Wednesday"
 msgstr "Miércoles"
 
-#: core/choices.py:160 logistics/templates/print_labels_for_day.html:28
+#: core/choices.py:180 logistics/templates/print_labels_for_day.html:28
 msgid "Thursday"
 msgstr "Jueves"
 
-#: core/choices.py:161 logistics/templates/print_labels_for_day.html:29
+#: core/choices.py:181 logistics/templates/print_labels_for_day.html:29
 msgid "Friday"
 msgstr "Viernes"
 
-#: core/choices.py:162 logistics/templates/print_labels_for_day.html:30
+#: core/choices.py:182 logistics/templates/print_labels_for_day.html:30
 msgid "Saturday"
 msgstr "Sábado"
 
-#: core/choices.py:163 logistics/templates/print_labels_for_day.html:31
+#: core/choices.py:183 logistics/templates/print_labels_for_day.html:31
 msgid "Sunday"
 msgstr "Domingo"
 
-#: core/choices.py:164
+#: core/choices.py:184
 msgid "All week"
 msgstr "Todos los días"
 
-#: core/choices.py:165 logistics/filters.py:16
+#: core/choices.py:185 logistics/filters.py:16
 msgid "Weekdays"
 msgstr "Días hábiles"
 
-#: core/choices.py:166
+#: core/choices.py:186
 msgid "Weekends"
 msgstr "Días de fin de semana"
 
-#: core/choices.py:170 logistics/templates/issues_statistics.html:17
+#: core/choices.py:190 logistics/templates/issues_statistics.html:17
 msgid "Daily"
 msgstr "Diario"
 
-#: core/choices.py:171 logistics/templates/issues_statistics.html:48
+#: core/choices.py:191 logistics/templates/issues_statistics.html:48
 msgid "Weekly"
 msgstr "Semanal"
 
-#: core/choices.py:174
+#: core/choices.py:194
 msgid "Others"
 msgstr "Otros"
 
-#: core/choices.py:178
+#: core/choices.py:198
 msgid "Replace all"
 msgstr "Reemplazar todo"
 
-#: core/choices.py:179
+#: core/choices.py:199
 msgid "Replace one"
 msgstr "Reemplazar uno"
 
-#: core/choices.py:180
+#: core/choices.py:200
 msgid "Add new"
 msgstr "Agregar nuevo"
 
-#: core/choices.py:183
+#: core/choices.py:203
 msgid "Pool AND Any"
 msgstr "Pool AND Any"
 
-#: core/choices.py:183
+#: core/choices.py:203
 msgid "Pool OR Any"
 msgstr "Pool OR Any"
 
-#: core/choices.py:185
+#: core/choices.py:205
 msgid "Equal than"
 msgstr "Igual que"
 
-#: core/choices.py:185
+#: core/choices.py:205
 msgid "Greater than"
 msgstr "Mayor que"
 
-#: core/choices.py:188
+#: core/choices.py:208
 msgid "At least one of the products"
 msgstr "Al menos un producto"
 
-#: core/choices.py:189
+#: core/choices.py:209
 msgid "All products"
 msgstr "Todos los productos"
 
-#: core/choices.py:194
+#: core/choices.py:214
 #: support/templates/contact_detail/tabs/includes/_subscription_icons.html:14
-#: support/templates/contact_list.html:123
+#: support/templates/contact_list.html:215
 #: support/templates/edit_envelopes.html:46
 #: support/templates/sales_record_create.html:49
-#: support/templates/validate_subscription_sales_record.html:48
+#: support/templates/validate_subscription_sales_record.html:167
 msgid "Paid envelope"
 msgstr "Sobre pago"
 
-#: core/choices.py:195 core/models.py:1426
+#: core/choices.py:215 core/models.py:1656
 #: support/templates/contact_detail/tabs/includes/_subscription_icons.html:18
-#: support/templates/contact_list.html:127
+#: support/templates/contact_list.html:219
 #: support/templates/edit_envelopes.html:47
 #: support/templates/sales_record_create.html:53
-#: support/templates/validate_subscription_sales_record.html:52
+#: support/templates/validate_subscription_sales_record.html:171
 msgid "Free envelope"
 msgstr "Sobre gratuito"
 
-#: core/choices.py:199
-msgid "Complete unsubscription"
-msgstr "Desuscripción completa"
-
-#: core/choices.py:200 support/templates/book_additional_product.html:61
-#: support/templates/book_partial_unsubscription.html:34
-#: support/templates/book_product_change.html:44
-#: support/templates/book_unsubscription.html:19
-#: support/views/subscriptions.py:608
-msgid "Partial unsubscription"
-msgstr "Desuscripción parcial"
-
-#: core/choices.py:201 support/templates/book_additional_product.html:64
-#: support/templates/book_partial_unsubscription.html:35
-#: support/templates/book_product_change.html:45
-#: support/templates/book_unsubscription.html:20
-msgid "Product change"
-msgstr "Cambio de producto"
-
-#: core/choices.py:202
-msgid "Upgrade"
-msgstr "Actualización"
-
-#: core/choices.py:206
+#: core/choices.py:219
 msgid "Exclude debtors"
 msgstr "Excluir deudores"
 
-#: core/choices.py:207
+#: core/choices.py:220
 msgid "Only debtors"
 msgstr "Solo deudores"
 
-#: core/choices.py:211
+#: core/choices.py:224
 msgid "Integer"
 msgstr "Entero"
 
-#: core/choices.py:212 invoicing/choices.py:13
+#: core/choices.py:225 invoicing/choices.py:13
 msgid "Percentage"
 msgstr "Porcentaje"
 
-#: core/choices.py:216
+#: core/choices.py:229
 msgid "Find at least one product"
 msgstr "Encontrar al menos un producto"
 
-#: core/choices.py:217
+#: core/choices.py:230
 msgid "Find all products"
 msgstr "Encontrar todos los productos"
 
-#: core/choices.py:221
+#: core/choices.py:234
 msgid "Suggested"
 msgstr "Sugerido"
 
-#: core/choices.py:222
+#: core/choices.py:235
 msgid "Requested"
 msgstr "Solicitado"
 
-#: core/choices.py:223
+#: core/choices.py:236
 msgid "Approved"
 msgstr "Aprobado"
 
-#: core/choices.py:224
+#: core/choices.py:237
 msgid "Rejected"
 msgstr "Rechazado"
 
-#: core/choices.py:230
+#: core/choices.py:243
 msgid "invalid email"
 msgstr "correo electrónico inválido"
 
-#: core/choices.py:231
+#: core/choices.py:244
 msgid "max bounce reached"
 msgstr "límite de rebotes alcanzado"
 
-#: core/choices.py:236
+#: core/choices.py:249
 msgid "Human resources"
 msgstr "Recursos humanos"
 
-#: core/choices.py:238
+#: core/choices.py:251
 msgid "Management"
 msgstr "Gestión"
 
-#: core/choices.py:239
-msgid "Journalism direction"
-msgstr "Dirección de periodismo"
+#: core/choices.py:252
+msgid "Newsroom"
+msgstr ""
 
-#: core/decorators.py:11 core/templates/main_menu.html:5 invoicing/views.py:93
-#: invoicing/views.py:457 support/location.py:190
-#: support/views/activities.py:27 support/views/all_views.py:151
-#: support/views/all_views.py:265 support/views/all_views.py:572
-#: support/views/all_views.py:678 support/views/all_views.py:751
-#: support/views/all_views.py:865 templates/admin/change_form.html:27
-#: templates/admin/change_list.html:38 templates/admin/index.html:68
-#: templates/admin/object_history.html:17 templates/components/_header.html:12
-#: templates/components/_sidebar.html:41
+#: core/decorators.py:11 core/templates/main_menu.html:5 invoicing/views.py:94
+#: invoicing/views.py:265 invoicing/views.py:500 invoicing/views.py:528
+#: logistics/views.py:367 logistics/views.py:1583 support/location.py:190
+#: support/templates/campaign_management_menu.html:93
+#: support/templates/tag_contacts.html:12 support/views/activities.py:27
+#: support/views/all_views.py:167 support/views/all_views.py:253
+#: support/views/all_views.py:289 support/views/all_views.py:539
+#: support/views/all_views.py:611 support/views/all_views.py:750
+#: support/views/all_views.py:856 support/views/all_views.py:958
+#: support/views/all_views.py:1174 support/views/all_views.py:1308
+#: support/views/all_views.py:1488 support/views/all_views.py:2188
+#: support/views/all_views.py:2211 support/views/all_views.py:2566
+#: support/views/all_views.py:2691 support/views/all_views.py:2731
+#: support/views/all_views.py:2778 support/views/all_views.py:2871
+#: support/views/all_views.py:3077 support/views/all_views.py:3252
+#: support/views/all_views.py:3396 support/views/campaign_management.py:51
+#: support/views/contacts.py:57 support/views/contacts.py:245
+#: support/views/contacts.py:475 support/views/contacts.py:543
+#: support/views/contacts.py:560 support/views/contacts.py:893
+#: support/views/contacts.py:1139 support/views/contacts.py:1237
+#: support/views/seller_console.py:60 support/views/seller_console.py:132
+#: support/views/subscriptions.py:1429 support/views/subscriptions.py:1616
+#: support/views/subscriptions.py:2016 support/views/subscriptions.py:2106
+#: templates/admin/change_form.html:27 templates/admin/change_list.html:38
+#: templates/admin/index.html:68 templates/admin/object_history.html:17
+#: templates/components/_header.html:12 templates/components/_sidebar.html:41
 msgid "Home"
 msgstr "Inicio"
 
 #: core/filters.py:10 invoicing/filters.py:11
-#: logistics/templates/route_details.html:69
-#: support/templates/check_for_existing_contacts.html:96
-#: support/templates/check_for_existing_contacts.html:103
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:66
+#: logistics/templates/merge_compare_addresses.html:241
+#: logistics/templates/merge_compare_addresses.html:242
+#: logistics/templates/merge_compare_addresses.html:245
+#: logistics/templates/merge_compare_addresses.html:246
+#: logistics/templates/route_details.html:76
+#: support/templates/activities/activity_detail.html:200
+#: support/templates/check_for_existing_contacts.html:213
+#: support/templates/check_for_existing_contacts.html:220
 #: support/templates/debtor_contacts.html:105
+#: support/templates/import_contacts.html:143
 msgid "Yes"
 msgstr "Sí"
 
 #: core/filters.py:11 invoicing/filters.py:12
-#: logistics/templates/route_details.html:71
-#: support/templates/check_for_existing_contacts.html:98
-#: support/templates/check_for_existing_contacts.html:105
+#: logistics/templates/merge_compare_addresses.html:241
+#: logistics/templates/merge_compare_addresses.html:242
+#: logistics/templates/merge_compare_addresses.html:245
+#: logistics/templates/merge_compare_addresses.html:246
+#: logistics/templates/route_details.html:78
+#: support/templates/activities/activity_detail.html:202
+#: support/templates/check_for_existing_contacts.html:215
+#: support/templates/check_for_existing_contacts.html:222
 #: support/templates/debtor_contacts.html:107
-#: support/templates/sales_record_filter.html:137
+#: support/templates/import_contacts.html:148
+#: support/templates/import_contacts.html:153
+#: support/templates/import_contacts.html:158
+#: support/templates/import_contacts.html:163
+#: support/templates/import_contacts.html:168
+#: support/templates/import_contacts.html:173
+#: support/templates/import_contacts.html:178
+#: support/templates/import_contacts.html:183
+#: support/templates/import_contacts.html:188
+#: support/templates/import_contacts.html:193
+#: support/templates/import_contacts.html:198
+#: support/templates/import_contacts.html:203
+#: support/templates/sales_record_filter.html:192
 msgid "No"
 msgstr "No"
 
@@ -1765,38 +1800,50 @@ msgstr "Correo electrónico inválido: %(email)s"
 msgid "This field must be provided if the contact is protected"
 msgstr "Este campo debe ser proporcionado si el contacto está protegido"
 
-#: core/forms.py:166 core/forms.py:185
+#: core/forms.py:166 core/forms.py:226 core/forms.py:245
 msgid "Open in a new tab"
 msgstr "Abrir en una nueva pestaña"
 
-#: core/forms.py:169
+#: core/forms.py:169 core/forms.py:229
 #, python-format
 msgid "Contact %(contact_id)s already has this document. %(url_str)s"
 msgstr "El contacto %(contact_id)s ya tiene este documento. %(url_str)s"
 
-#: core/forms.py:188
+#: core/forms.py:248
 #, python-format
 msgid "Contact %(contact_id)s already has this email. %(url_str)s"
 msgstr ""
 "El contacto %(contact_id)s ya tiene este correo electrónico. %(url_str)s"
 
-#: core/forms.py:198 core/models.py:1470
+#: core/forms.py:258 core/models.py:1713
 msgid "Frequency of billing in months"
 msgstr "Frecuencia de facturación en meses"
 
-#: core/forms.py:213
+#: core/forms.py:273
 msgid "You don't have permission to set this subscription as free"
 msgstr "No tienes permiso para marcar esta suscripción como gratuita"
 
-#: core/forms.py:216
+#: core/forms.py:276
 msgid "You need to select who requested the subscription if it's free"
 msgstr "Se requiere seleccionar quién solicitó la suscripción si es gratuita"
 
-#: core/forms.py:219
+#: core/forms.py:279
 msgid "Free subscriptions must have an end date"
 msgstr "Las suscripciones gratuitas deben tener una fecha final"
 
-#: core/models.py:79
+#: core/forms.py:282
+#, fuzzy
+#| msgid "Free subscriptions must have an end date"
+msgid "Promotion subscriptions must not have a payment type"
+msgstr "Las suscripciones gratuitas deben tener una fecha final"
+
+#: core/forms.py:284
+#, fuzzy
+#| msgid "Free subscriptions must have an end date"
+msgid "Promotion subscriptions must have an end date"
+msgstr "Las suscripciones gratuitas deben tener una fecha final"
+
+#: core/models.py:78
 msgid ""
 "This field only supports alphanumeric characters, at, apostrophes, spaces, "
 "hyphens, underscores, and periods."
@@ -1804,176 +1851,194 @@ msgstr ""
 "Este campo solo admite caracteres alfanuméricos, arroba, comillas, espacios, "
 "guiones, subrayados y puntos."
 
-#: core/models.py:84
+#: core/models.py:83
 msgid "Month can't be less than 1"
 msgstr "El mes no puede ser menor a 1"
 
-#: core/models.py:85
+#: core/models.py:84
 msgid "Month can't be more than 12"
 msgstr "El mes no puede ser mayor a 12"
 
-#: core/models.py:88
+#: core/models.py:87
 #, python-format
 msgid "Year is not valid, minimum value is %s"
 msgstr "El año no es válido, el valor mínimo es %s"
 
-#: core/models.py:104
+#: core/models.py:103
 msgid "institution"
 msgstr "institución"
 
-#: core/models.py:105
+#: core/models.py:104
 msgid "institutions"
 msgstr "instituciones"
 
-#: core/models.py:114 invoicing/models.py:449
+#: core/models.py:113 invoicing/models.py:450
 msgid "Code"
 msgstr "Código"
 
-#: core/models.py:122
+#: core/models.py:121
 msgid "ocupation"
 msgstr "ocupación"
 
-#: core/models.py:123
+#: core/models.py:122
 msgid "ocupations"
 msgstr "ocupaciones"
 
-#: core/models.py:131 core/models.py:152 core/models.py:2352
+#: core/models.py:130 core/models.py:151 core/models.py:2638
 #: logistics/templates/print_labels_from_csv.html:21
 msgid "name"
 msgstr "nombre"
 
-#: core/models.py:142
+#: core/models.py:141
 msgid "subtype"
 msgstr "subtipo"
 
-#: core/models.py:143
+#: core/models.py:142
 msgid "subtypes"
 msgstr "subtipos"
 
-#: core/models.py:153
+#: core/models.py:152
 msgid "value"
 msgstr "valor"
 
-#: core/models.py:154
+#: core/models.py:153
 msgid "type"
 msgstr "tipo"
 
-#: core/models.py:160
+#: core/models.py:159
 msgid "variable"
 msgstr "variable"
 
-#: core/models.py:161
+#: core/models.py:160
 msgid "variables"
 msgstr "variables"
 
-#: core/models.py:171
+#: core/models.py:170
 msgid "Number of months this period represents."
 msgstr "Número de meses que representa este periodo."
 
-#: core/models.py:172
+#: core/models.py:171
 msgid "Optional description for this period, if needed."
 msgstr "Descripción opcional para este periodo, si es necesario."
 
-#: core/models.py:175
+#: core/models.py:174
 msgid "Product Subscription Period"
 msgstr "Periodo de suscripción al producto"
 
-#: core/models.py:176
+#: core/models.py:175
 msgid "Product Subscription Periods"
 msgstr "Periodos de suscripción al producto"
 
-#: core/models.py:192
+#: core/models.py:191
 msgid "Manual"
 msgstr "Manual"
 
-#: core/models.py:193 logistics/filters.py:24
+#: core/models.py:192 logistics/filters.py:24
 msgid "Both"
 msgstr "Ambos"
 
-#: core/models.py:198 core/models.py:1315 invoicing/models.py:44
-#: invoicing/models.py:278
+#: core/models.py:197 core/models.py:1514 invoicing/models.py:44
+#: invoicing/models.py:281
 #: invoicing/templates/bill_subscriptions_for_one_contact.html:65
 #: invoicing/templates/contact_invoices.html:56
-#: invoicing/templates/invoice/invoice_detail.html:52 support/models.py:374
+#: invoicing/templates/invoice/invoice_detail.html:53
+#: logistics/templates/change_subscription_routes.html:49
+#: logistics/templates/change_subscription_routes.html:55 support/forms.py:431
+#: support/models.py:189 support/models.py:443
 #: support/templates/contact_detail/htmx/_invoices_htmx.html:6
-#: support/templates/contact_list.html:84
-#: support/templates/new_scheduled_task_address_change.html:197
-#: support/templates/new_scheduled_task_partial_pause.html:123
+#: support/templates/contact_list.html:175
+#: support/templates/new_scheduled_task_address_change.html:228
+#: support/templates/new_scheduled_task_partial_pause.html:165
 #: support/templates/sales_record_create.html:24
-#: support/templates/validate_subscription_sales_record.html:23
-#: support/templates/view_issue.html:101 tests/test_contact.py:135
+#: support/templates/validate_subscription_sales_record.html:142
+#: support/templates/view_issue.html:385 tests/test_contact.py:135
 msgid "Subscription"
 msgstr "Suscripción"
 
-#: core/models.py:199 tests/test_contact.py:137
+#: core/models.py:198 tests/test_contact.py:137
 msgid "Newsletter"
 msgstr "Boletín informativo"
 
-#: core/models.py:200 invoicing/choices.py:7 invoicing/models.py:290
-#: invoicing/templates/invoice/invoice_detail.html:246
+#: core/models.py:199 invoicing/choices.py:7 invoicing/models.py:293
+#: invoicing/templates/invoice/invoice_detail.html:277
 #: support/templates/sales_record_create.html:40
-#: support/templates/validate_subscription_sales_record.html:39
+#: support/templates/validate_subscription_sales_record.html:158
 msgid "Discount"
 msgstr "Descuento"
 
-#: core/models.py:201
+#: core/models.py:200
 msgid "Percentage discount"
 msgstr "Descuento porcentaje"
 
-#: core/models.py:202
+#: core/models.py:201
 msgid "Advanced discount"
 msgstr "Descuento avanzado"
 
-#: core/models.py:206
+#: core/models.py:205
 msgid "Per Frequency"
 msgstr "Por frecuencia"
 
-#: core/models.py:207
+#: core/models.py:206
 msgid "Fixed Price"
 msgstr "Precio fijo"
 
-#: core/models.py:208 invoicing/filters.py:22 support/filters.py:21
+#: core/models.py:207 invoicing/filters.py:22 support/filters.py:33
+#: support/filters.py:177 support/templates/scheduled_activities.html:98
 msgid "Custom"
 msgstr "Personalizado"
 
-#: core/models.py:220 logistics/templates/list_routes_detailed.html:33
+#: core/models.py:212 core/models.py:1602 core/models.py:1612
+#: support/models.py:438
+#: support/templates/validate_subscription_sales_record.html:61
+#, fuzzy
+#| msgid "Recent actions"
+msgid "Retention"
+msgstr "Acciones recientes"
+
+#: core/models.py:227 logistics/templates/list_routes_detailed.html:33
 msgid "Weekday"
 msgstr "Día de la semana"
 
-#: core/models.py:224
+#: core/models.py:231
 msgid "Allow offer"
 msgstr "Permitir oferta"
 
-#: core/models.py:225
+#: core/models.py:232
 msgid "Allow product to be shown in the new subscription forms"
 msgstr ""
 "Permitir que el producto se muestre en los nuevos formularios de suscripción"
 
-#: core/models.py:227
+#: core/models.py:234
 msgid "Has implicit discount"
 msgstr "Tiene descuento implícito"
 
-#: core/models.py:228
+#: core/models.py:235
 msgid "Billing priority"
 msgstr "Prioridad de facturación"
 
-#: core/models.py:233
+#: core/models.py:240
 msgid "Edition frequency"
 msgstr "Frecuencia de la edición"
 
-#: core/models.py:236
+#: core/models.py:243
 msgid "Temporary discount months"
 msgstr "Meses de descuento temporales"
 
-#: core/models.py:244
+#: core/models.py:251
 msgid "Target product"
 msgstr "Producto objetivo"
 
-#: core/models.py:247
+#: core/models.py:252
+msgid ""
+"The subscription product this discount applies to. Only active subscription "
+"products are shown."
+msgstr ""
+
+#: core/models.py:259
 msgid "CMS subscription type"
 msgstr "Identificador"
 
-#: core/models.py:249
+#: core/models.py:261
 msgid ""
 "The subscription type of the SubscriptionPrice object in utopia-cms, used "
 "for synchronization with this Product. Also used by the CMS front-end to "
@@ -1984,43 +2049,60 @@ msgstr ""
 "CMS para construir la URL de la página de suscripción relacionada y en "
 "herramientas de tracking."
 
-#: core/models.py:254
+#: core/models.py:266
 msgid "Internal code"
 msgstr "Código interno"
 
-#: core/models.py:257
+#: core/models.py:269
 msgid "Billing frequency"
 msgstr "Frecuencia de facturación"
 
-#: core/models.py:266 core/models.py:1509
+#: core/models.py:278 core/models.py:1752
 msgid "Renewal type"
 msgstr "Tipo de renovación"
 
-#: core/models.py:272
+#: core/models.py:284
 msgid "Duration in months"
 msgstr "Duración en meses"
 
-#: core/models.py:281
+#: core/models.py:293
 msgid "Subscription Period"
 msgstr "Período de suscripción"
 
-#: core/models.py:291
+#: core/models.py:301
+#, fuzzy
+#| msgid "Failed to sync product in MercadoPago"
+msgid "Do not sync this product with a MercadoPago plan"
+msgstr "Error al sincronizar producto en MercadoPago"
+
+#: core/models.py:303
+msgid ""
+"If checked, this product will not be synchronized with a MercadoPago plan "
+"until this field is unchecked and the object is saved. This means that the "
+"field is disabled if the product has a MercadoPago ID set."
+msgstr ""
+
+#: core/models.py:311
 msgid "MercadoPago ID"
 msgstr "ID de MercadoPago"
 
-#: core/models.py:292
+#: core/models.py:312
+#, fuzzy
+#| msgid ""
+#| "If MercadoPago product sync is enabled, this field is auto-filled when "
+#| "this product is created."
 msgid ""
 "If MercadoPago product sync is enabled, this field is auto-filled when this "
-"product is created."
+"product is saved."
 msgstr ""
 "Si la sincronización con MercadoPago está activada, este campo se rellenará "
 "automáticamente cuando este producto sea creado."
 
-#: core/models.py:298
+#: core/models.py:318
 msgid "Billing mode"
 msgstr "Modo de facturación"
 
-#: core/models.py:300
+#: core/models.py:320
 msgid ""
 "How the product is billed. Fixed uses the price set in the product, per "
 "frequency uses the price calculated from the products in the subscription "
@@ -2030,281 +2112,306 @@ msgstr ""
 "por frecuencia usa el precio calculado de los productos en la suscripción "
 "con la frecuencia establecida en el producto."
 
-#: core/models.py:345
+#: core/models.py:327
+#, fuzzy
+#| msgid "Issue Subcategory"
+msgid "Discount category"
+msgstr "Subcategoría de incidencia"
+
+#: core/models.py:330
+msgid "Category of the discount. Mandatory if the product type is discount."
+msgstr ""
+
+#: core/models.py:373
 msgid "product"
 msgstr "producto"
 
-#: core/models.py:346 core/models.py:1583
-#: logistics/templates/order_route.html:86
+#: core/models.py:374 core/models.py:1826 invoicing/views.py:543
+#: logistics/templates/order_route.html:86 support/models.py:606
 msgid "products"
 msgstr "productos"
 
-#: core/models.py:371
+#: core/models.py:399
 msgid "Email Bounce Action Log"
 msgstr "Registro de acción de rebote"
 
-#: core/models.py:372
+#: core/models.py:400
 msgid "Email Bounce Action Logs"
 msgstr "Registros de acción de rebote"
 
-#: core/models.py:383
+#: core/models.py:411
 msgid "ID Document Type"
 msgstr "Tipo de documento de identidad"
 
-#: core/models.py:384
+#: core/models.py:412
 msgid "ID Document Types"
 msgstr "Tipos de documentos de identidad"
 
-#: core/models.py:393
+#: core/models.py:421
 msgid "Person"
 msgstr "Persona"
 
-#: core/models.py:394
+#: core/models.py:422
 msgid "Company"
 msgstr "Empresa"
 
-#: core/models.py:400
+#: core/models.py:428
 msgid "Subtype"
 msgstr "Subtipo"
 
-#: core/models.py:408
+#: core/models.py:436
 msgid "Referrer"
 msgstr "Referente"
 
-#: core/models.py:415
+#: core/models.py:443
 msgid "Institution"
 msgstr "Institución"
 
-#: core/models.py:421 support/forms.py:246
-#: support/templates/create_contact/tabs/_data.html:19
+#: core/models.py:449 support/forms.py:154 support/forms.py:285
+#: support/forms.py:990 support/templates/create_contact/tabs/_data.html:19
+#: support/templates/import_contacts.html:147
 msgid "Last name"
 msgstr "Apellido"
 
-#: core/models.py:427
+#: core/models.py:455
 msgid "Contact type"
 msgstr "Tipo de contacto"
 
-#: core/models.py:431
+#: core/models.py:459
 msgid "Identifcation Document"
 msgstr "Documento de identificación"
 
-#: core/models.py:436
+#: core/models.py:464
 msgid "Document type"
 msgstr "Tipo de documento"
 
-#: core/models.py:440 logistics/models.py:28
+#: core/models.py:468 logistics/models.py:28
 msgid "Phone extension"
 msgstr "Extensión de teléfono"
 
-#: core/models.py:441 logistics/models.py:29
-#: logistics/templates/route_details.html:44 support/forms.py:248
-#: support/templates/contact_detail/tabs/_information.html:34
-#: support/templates/contact_detail/tabs/_overview.html:34
-#: support/templates/create_contact/tabs/_data.html:36
-#: support/templates/seller_console.html:167
-#: support/templates/seller_console.html:192
+#: core/models.py:469 invoicing/views.py:300 logistics/models.py:29
+#: logistics/templates/route_details.html:51 support/forms.py:163
+#: support/forms.py:287 support/forms.py:999
+#: support/templates/check_for_existing_contacts.html:207
+#: support/templates/contact_detail/tabs/_information.html:57
+#: support/templates/contact_detail/tabs/_overview.html:54
+#: support/templates/create_contact/tabs/_data.html:61
+#: support/templates/create_contact/tabs/_data.html:64
+#: support/templates/seller_console.html:194
+#: support/templates/seller_console.html:221
+#: support/templates/seller_console_never_paid_issues.html:31
 #: support/templates/seller_console_special_routes.html:27
-#: support/views/all_views.py:1189 support/views/all_views.py:1867
-#: support/views/contacts.py:87
+#: support/views/all_views.py:1868 support/views/all_views.py:2288
+#: support/views/all_views.py:2751 support/views/contacts.py:155
 msgid "Mobile"
 msgstr "Celular"
 
-#: core/models.py:442
+#: core/models.py:470
 msgid "Work phone"
 msgstr "Teléfono de trabajo"
 
-#: core/models.py:447
+#: core/models.py:475
 msgid "Work phone extension"
 msgstr "Extensión de teléfono de trabajo"
 
-#: core/models.py:450
+#: core/models.py:478
 msgid "No email"
 msgstr "No tiene email"
 
-#: core/models.py:451 support/templates/create_contact/tabs/_data.html:66
+#: core/models.py:479 support/templates/create_contact/tabs/_data.html:104
 msgid "Gender"
 msgstr "Género"
 
-#: core/models.py:456
+#: core/models.py:484
 msgid "Ocupation"
 msgstr "Ocupación"
 
-#: core/models.py:460 support/templates/create_contact/tabs/_data.html:70
+#: core/models.py:488 support/templates/create_contact/tabs/_data.html:108
 msgid "Education"
 msgstr "Educación"
 
-#: core/models.py:462 support/templates/create_contact/tabs/_data.html:60
+#: core/models.py:490 support/templates/create_contact/tabs/_data.html:98
 msgid "Birthdate"
 msgstr "Fecha de nacimiento"
 
-#: core/models.py:463
+#: core/models.py:491
 msgid "Private birthdate"
 msgstr "Fecha de nacimiento privada"
 
-#: core/models.py:464
+#: core/models.py:492
 msgid "Protected"
 msgstr "Protegido"
 
-#: core/models.py:465
+#: core/models.py:493
 msgid "Protection reason"
 msgstr "Razón de protección"
 
-#: core/models.py:468
+#: core/models.py:496
 msgid "Allows polls"
 msgstr "Permite encuestas"
 
-#: core/models.py:469
+#: core/models.py:497
 msgid "Allows promotions"
 msgstr "Permite promociones"
 
-#: core/models.py:470
+#: core/models.py:498
 msgid "CMS join date"
 msgstr "Fecha de registro en el CMS"
 
-#: core/models.py:471
+#: core/models.py:499
 msgid "Ranking"
 msgstr "Ranking"
 
-#: core/models.py:473
+#: core/models.py:501
 msgid "Person type"
 msgstr "Tipo de persona"
 
-#: core/models.py:479
+#: core/models.py:507
 msgid "Business entity type"
 msgstr "Tipo de entidad de negocio"
 
-#: core/models.py:630
-#, python-format
-msgid "Contact %(name)s (ID: %(id)s) added to campaign %(campaign)s"
-msgstr "Contacto %(name)s (ID: %(id)s) agregado a la campaña %(campaign)s"
+#: core/models.py:658 tests/test_contact.py:109
+#, python-brace-format
+msgid "Contact {name} (ID: {id}) added to campaign {campaign}"
+msgstr "Contacto {name} (ID: {id}) agregado a la campaña {campaign}"
 
-#: core/models.py:637
+#: core/models.py:665
 #, python-format
 msgid "Contact %(name)s (ID: %(id)s) is already in campaign %(campaign)s"
 msgstr "Contacto %(name)s (ID: %(id)s) ya está en la campaña %(campaign)s"
 
-#: core/models.py:788
+#: core/models.py:846
 msgid "Invalid product id"
 msgstr "ID de producto inválido"
 
-#: core/models.py:1075 support/templates/contact_list.html:81
-#: support/views/contacts.py:84
+#: core/models.py:1142 support/templates/contact_list.html:172
+#: support/views/contacts.py:152
 msgid "Full name"
 msgstr "Nombre completo"
 
-#: core/models.py:1082
+#: core/models.py:1149
 msgid "Full ID document"
 msgstr "Documento de identificación completo"
 
-#: core/models.py:1112
+#: core/models.py:1200
 msgid "contact"
 msgstr "contacto"
 
-#: core/models.py:1113 support/templates/campaign_statistics_detail.html:54
-#: support/templates/contact_list.html:64
+#: core/models.py:1201 support/templates/campaign_statistics_detail.html:102
+#: support/templates/contact_list.html:149
 #: support/templates/debtor_contacts.html:71
 msgid "contacts"
 msgstr "contactos"
 
-#: core/models.py:1126
+#: core/models.py:1214
 msgid "country"
 msgstr "pais"
 
-#: core/models.py:1127
+#: core/models.py:1215
 msgid "countries"
 msgstr "países"
 
-#: core/models.py:1141
+#: core/models.py:1229
 msgid "state"
 msgstr "departamento"
 
-#: core/models.py:1142
+#: core/models.py:1230
 msgid "states"
 msgstr "departamentos"
 
-#: core/models.py:1157 logistics/models.py:213
+#: core/models.py:1245 logistics/models.py:213
 msgid "city"
 msgstr "ciudad"
 
-#: core/models.py:1158 logistics/models.py:214
+#: core/models.py:1246 logistics/models.py:214
 msgid "cities"
 msgstr "ciudades"
 
-#: core/models.py:1173 core/models.py:1390 core/models.py:2512
-#: invoicing/templates/invoice/invoice_detail.html:45
-#: invoicing/templates/invoice_filter.html:120 logistics/models.py:256
+#: core/models.py:1261 core/models.py:1620 core/models.py:2772
+#: invoicing/templates/invoice/invoice_detail.html:46
+#: invoicing/templates/invoice_filter.html:234 logistics/models.py:256
 #: logistics/templates/addresses_with_complementary_information.html:21
 #: logistics/templates/issues_per_route.html:59
 #: logistics/templates/mass_georef_address_filter.html:70
-#: logistics/templates/route_details.html:132 support/models.py:119
-#: support/models.py:229 support/models.py:418
-#: support/templates/check_for_existing_contacts.html:79
+#: logistics/templates/merge_compare_addresses.html:45
+#: logistics/templates/merge_compare_addresses.html:419
+#: logistics/templates/route_details.html:139 support/forms.py:407
+#: support/models.py:141 support/models.py:278 support/models.py:487
+#: support/templates/activities/activity_detail.html:27
+#: support/templates/check_for_existing_contacts.html:179
+#: support/templates/contact_detail/edit_campaign_status.html:22
 #: support/templates/invoicing_issues.html:104
-#: support/templates/list_issues.html:192
-#: support/templates/sales_record_filter.html:97
-#: support/templates/scheduled_activities.html:134
+#: support/templates/list_issues.html:261
+#: support/templates/reactivate_subscription.html:34
+#: support/templates/sales_record_filter.html:139
+#: support/templates/scheduled_activities.html:201
 #: support/templates/scheduled_task_filter.html:37
 #: support/templates/scheduled_task_filter.html:85
-#: support/templates/seller_console_list_campaigns.html:55
-#: support/templates/subscriptions/affiliate_subscriptions.html:20
-#: support/templates/subscriptions/affiliate_subscriptions.html:69
-#: support/templates/view_issue.html:40
+#: support/templates/seller_console_never_paid_issues.html:25
+#: support/templates/view_issue.html:317
 msgid "Contact"
 msgstr "Contacto"
 
-#: core/models.py:1176
-#: support/templates/contact_detail/tabs/_information.html:93
+#: core/models.py:1264 logistics/templates/merge_compare_addresses.html:75
+#: support/templates/contact_detail/tabs/_information.html:131
 msgid "Address 1"
 msgstr "Dirección línea 1"
 
-#: core/models.py:1177 logistics/templates/issues_per_route.html:113
-#: support/templates/contact_detail/tabs/_information.html:99
+#: core/models.py:1265 logistics/templates/issues_per_route.html:113
+#: logistics/templates/merge_compare_addresses.html:94 support/forms.py:472
+#: support/templates/contact_detail/tabs/_information.html:135
 msgid "Address 2"
 msgstr "Dirección línea 2"
 
-#: core/models.py:1183 core/models.py:1242 logistics/models.py:205
+#: core/models.py:1271 core/models.py:1330 logistics/models.py:205
 #: logistics/templates/assign_routes.html:60
-#: logistics/templates/route_details.html:46
-#: logistics/templates/route_details.html:171
-#: support/templates/contact_detail/tabs/_information.html:112
-#: support/views/contacts.py:94
+#: logistics/templates/merge_compare_addresses.html:132
+#: logistics/templates/merge_compare_addresses.html:151
+#: logistics/templates/route_details.html:53
+#: logistics/templates/route_details.html:178 support/forms.py:475
+#: support/templates/contact_detail/tabs/_information.html:146
+#: support/templates/import_contacts.html:182 support/views/contacts.py:164
 msgid "City"
 msgstr "Ciudad"
 
-#: core/models.py:1186
+#: core/models.py:1274 logistics/templates/merge_compare_addresses.html:221
+#: support/forms.py:682
 msgid "Address type"
 msgstr "Tipo de dirección"
 
-#: core/models.py:1188
-#: support/templates/contact_detail/tabs/_information.html:80
+#: core/models.py:1276 logistics/templates/merge_compare_addresses.html:238
+#: support/templates/contact_detail/tabs/_information.html:116
 msgid "Default"
 msgstr "Principal"
 
-#: core/models.py:1192
+#: core/models.py:1280
 msgid "Do not show in picture/google maps list"
 msgstr "No mostrar en la lista de fotos/google maps"
 
-#: core/models.py:1205
+#: core/models.py:1293
 msgid "Country (old)"
 msgstr "País (antiguo)"
 
-#: core/models.py:1211
+#: core/models.py:1299
 msgid "State (old)"
 msgstr "Estado (antiguo)"
 
-#: core/models.py:1226
-#: support/templates/contact_detail/tabs/_information.html:122
+#: core/models.py:1314 logistics/templates/merge_compare_addresses.html:185
+#: logistics/templates/merge_compare_addresses.html:186
+#: support/templates/contact_detail/tabs/_information.html:156
+#: support/templates/import_contacts.html:192
 msgid "Country"
 msgstr "País"
 
-#: core/models.py:1234 logistics/models.py:24 logistics/models.py:161
-#: logistics/templates/route_details.html:172
-#: support/templates/contact_detail/tabs/_information.html:117
-#: support/templates/contact_list.html:37 support/views/contacts.py:93
+#: core/models.py:1322 logistics/models.py:24 logistics/models.py:161
+#: logistics/templates/merge_compare_addresses.html:168
+#: logistics/templates/route_details.html:179 support/forms.py:478
+#: support/templates/contact_detail/tabs/_information.html:151
+#: support/templates/contact_list.html:118 support/views/contacts.py:163
 msgid "State"
 msgstr "Departamento"
 
-#: core/models.py:1250
+#: core/models.py:1338
 msgid ""
 "Name of the address. It can be a reference to the address or the name of the "
 "person"
@@ -2312,22 +2419,29 @@ msgstr ""
 "Nombre de la dirección, puede ser una referencia a la dirección o al nombre "
 "de la persona"
 
-#: core/models.py:1303
+#: core/models.py:1499
 msgid "address"
 msgstr "dirección"
 
-#: core/models.py:1304 logistics/templates/mass_georef_address_filter.html:31
+#: core/models.py:1500 logistics/templates/mass_georef_address_filter.html:31
 msgid "addresses"
 msgstr "direcciones"
 
-#: core/models.py:1314 core/models.py:2514 core/models.py:3160
-#: invoicing/models.py:275 invoicing/templates/invoice/invoice_detail.html:219
+#: core/models.py:1502
+#, fuzzy
+#| msgid "Change address"
+msgid "Can merge addresses"
+msgstr "Cambiar dirección"
+
+#: core/models.py:1513 core/models.py:2774 core/models.py:3442
+#: invoicing/models.py:278 invoicing/templates/invoice/invoice_detail.html:250
 #: invoicing/templates/invoice_non_subscription_form.html:36
-#: logistics/models.py:258 logistics/models.py:276 logistics/models.py:323
+#: logistics/models.py:258 logistics/models.py:280 logistics/models.py:327
 #: logistics/templates/assign_routes.html:27
 #: logistics/templates/assign_routes.html:57
 #: logistics/templates/change_route.html:31
 #: logistics/templates/change_route.html:63
+#: logistics/templates/change_subscription_routes.html:96
 #: logistics/templates/issues_per_route.html:62
 #: logistics/templates/list_routes_detailed.html:33
 #: logistics/templates/order_route.html:47
@@ -2339,11 +2453,11 @@ msgstr "direcciones"
 #: logistics/templates/print_routes_simple.html:67
 #: logistics/templates/print_unordered_subscriptions_list.html:14
 #: logistics/templates/print_unordered_subscriptions_list.html:21
-#: logistics/templates/route_details.html:18
-#: logistics/templates/route_details.html:136
+#: logistics/templates/route_details.html:25
+#: logistics/templates/route_details.html:143 support/forms.py:419
+#: support/models.py:192 support/templates/activities/activity_detail.html:216
 #: support/templates/contact_detail/tabs/_activities.html:17
 #: support/templates/seller_console_special_routes.html:24
-#: support/templates/subscriptions/affiliate_subscriptions.html:23
 #: support/templates/subscriptions/corporate_subscription.html:35
 #: support/templates/subscriptions/subscription_end_date_list.html:90
 #: support/templates/unsubscription_statistics.html:88
@@ -2352,273 +2466,359 @@ msgstr "direcciones"
 #: support/templates/unsubscription_statistics.html:175
 #: support/templates/unsubscription_statistics.html:213
 #: support/templates/unsubscription_statistics.html:238
-#: support/templates/view_issue.html:89
+#: support/templates/view_issue.html:359 support/templates/view_issue.html:362
 msgid "Product"
 msgstr "Producto"
 
-#: core/models.py:1316 invoicing/models.py:280
-#: invoicing/templates/invoice/invoice_detail.html:223 logistics/models.py:243
-#: logistics/templates/route_details.html:27
-#: support/templates/new_subscription.html:301
-#: support/templates/seller_console_start_promo.html:167
-#: support/templates/subscriptions/affiliate_subscriptions.html:24
+#: core/models.py:1515 invoicing/models.py:283
+#: invoicing/templates/invoice/invoice_detail.html:254 logistics/models.py:243
+#: logistics/templates/route_details.html:34 support/models.py:179
+#: support/templates/free_subscription_form.html:210
+#: support/templates/free_subscription_form.html:213
+#: support/templates/free_subscription_form.html:257
+#: support/templates/free_subscription_form.html:260
+#: support/templates/free_subscription_form.html:303
+#: support/templates/free_subscription_form.html:306
+#: support/templates/new_subscription.html:356
+#: support/templates/seller_console_start_promo.html:203
+#: support/templates/seller_console_start_promo.html:206
 msgid "Copies"
 msgstr "Copias"
 
-#: core/models.py:1318 logistics/models.py:144
+#: core/models.py:1517 logistics/models.py:144
 #: logistics/templates/addresses_with_complementary_information.html:20
 #: logistics/templates/assign_routes.html:58
 #: logistics/templates/change_route.html:65
+#: logistics/templates/change_subscription_routes.html:97
 #: logistics/templates/issues_per_route.html:61
 #: logistics/templates/issues_per_route.html:112
 #: logistics/templates/mass_georef_address_filter.html:69
+#: logistics/templates/merge_compare_addresses.html:38
+#: logistics/templates/merge_compare_addresses.html:39
+#: logistics/templates/merge_compare_addresses.html:245
+#: logistics/templates/merge_compare_addresses.html:246
+#: logistics/templates/merge_compare_addresses.html:316
+#: logistics/templates/merge_compare_addresses.html:317
 #: logistics/templates/order_route.html:103
 #: logistics/templates/order_route_print.html:21
 #: logistics/templates/print_routes_simple.html:69
 #: logistics/templates/print_unordered_subscriptions_list.html:23
-#: logistics/templates/route_details.html:134
-#: logistics/templates/route_details.html:169 support/models.py:232
-#: support/templates/contact_list.html:51
+#: logistics/templates/route_details.html:141
+#: logistics/templates/route_details.html:176 support/forms.py:460
+#: support/forms.py:469 support/models.py:195 support/models.py:281
+#: support/templates/contact_list.html:126
+#: support/templates/free_subscription_form.html:200
+#: support/templates/free_subscription_form.html:247
+#: support/templates/free_subscription_form.html:293
+#: support/templates/new_subscription.html:344
 #: support/templates/scheduled_task_filter.html:41
-#: support/templates/view_issue.html:95 support/views/contacts.py:92
+#: support/templates/seller_console_start_promo.html:192
+#: support/templates/view_issue.html:371 support/templates/view_issue.html:379
+#: support/views/contacts.py:162
 msgid "Address"
 msgstr "Dirección"
 
-#: core/models.py:1324 invoicing/models.py:93 logistics/models.py:57
-#: logistics/models.py:169 logistics/models.py:242 logistics/models.py:314
-#: logistics/models.py:324 logistics/templates/assign_routes.html:64
-#: logistics/templates/change_route.html:69
+#: core/models.py:1523 invoicing/models.py:93 logistics/models.py:57
+#: logistics/models.py:169 logistics/models.py:242 logistics/models.py:318
+#: logistics/models.py:328 logistics/templates/assign_routes.html:64
+#: logistics/templates/change_route.html:70
+#: logistics/templates/change_subscription_routes.html:128
 #: logistics/templates/issues_per_route.html:56
 #: logistics/templates/issues_per_route.html:110
 #: logistics/templates/mass_georef_address_filter.html:42
 #: logistics/templates/mass_georef_address_filter.html:71
 #: logistics/templates/print_routes_simple.html:60
-#: logistics/templates/route_details.html:23
-#: support/templates/seller_console_list_campaigns.html:21
+#: logistics/templates/route_details.html:30
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:52
+#: support/templates/seller_console_list_campaigns.html:23
 msgid "Route"
 msgstr "Ruta"
 
-#: core/models.py:1327 invoicing/models.py:94 logistics/models.py:170
+#: core/models.py:1526 invoicing/models.py:94 logistics/models.py:170
 #: logistics/templates/list_routes.html:56
 #: logistics/templates/list_routes_detailed.html:60
 #: logistics/templates/order_route.html:107
 #: logistics/templates/order_route_print.html:25
 #: logistics/templates/print_routes_simple.html:73
 #: logistics/templates/print_unordered_subscriptions_list.html:27
-#: logistics/templates/route_details.html:47
+#: logistics/templates/route_details.html:54
 #: support/templates/debtor_contacts.html:62
 #: support/templates/invoicing_issues.html:70
 msgid "Order"
 msgstr "Orden"
 
-#: core/models.py:1328
+#: core/models.py:1527
 msgid "Label message"
 msgstr "Mensaje de etiqueta"
 
-#: core/models.py:1329
+#: core/models.py:1528
 msgid "Special instructions"
 msgstr "Instrucciones especiales"
 
-#: core/models.py:1331
+#: core/models.py:1530
 msgid "Label contact"
 msgstr "Contacto de etiqueta"
 
-#: core/models.py:1355
+#: core/models.py:1542
+#, fuzzy
+#| msgid "Date and time"
+msgid "Original date and time"
+msgstr "Fecha y hora"
+
+#: core/models.py:1544
+msgid ""
+"Date and time when the subscription product was originally created, "
+"regardless of the subscription. This product might have been inherited from "
+"another subscription."
+msgstr ""
+
+#: core/models.py:1564 support/forms.py:425
 msgid "Subscription Product"
 msgstr "Producto de suscripción"
 
-#: core/models.py:1356
+#: core/models.py:1565
 msgid "Subscription Products"
 msgstr "Productos de suscripción"
 
-#: core/models.py:1382
+#: core/models.py:1591
 msgid "Auto-renewal subscription"
 msgstr "Suscripción recurrente"
 
-#: core/models.py:1383
+#: core/models.py:1592
 msgid "One-time subscription"
 msgstr "Suscripción corriente"
 
-#: core/models.py:1386 core/models.py:2513 support/models.py:380
+#: core/models.py:1598 core/models.py:1611
+#, fuzzy
+#| msgid "Added Products"
+msgid "Added products"
+msgstr "Productos agregados"
+
+#: core/models.py:1599 core/models.py:1610
+#, fuzzy
+#| msgid "Change product"
+msgid "Changed products"
+msgstr "Cambiar producto"
+
+#: core/models.py:1600
+msgid "Debtor"
+msgstr "Deudor"
+
+#: core/models.py:1601
+msgid "Debtor, automatic unsubscription"
+msgstr "Deudor, desuscripción automática"
+
+#: core/models.py:1603 core/models.py:1613
+#, fuzzy
+#| msgid "All products"
+msgid "All products removed"
+msgstr "Todos los productos"
+
+#: core/models.py:1604 support/models.py:596
+msgid "N/A"
+msgstr "N/A"
+
+#: core/models.py:1608
+msgid "Complete unsubscription"
+msgstr "Desuscripción completa"
+
+#: core/models.py:1609 support/templates/book_additional_product.html:61
+#: support/templates/book_partial_unsubscription.html:34
+#: support/templates/book_product_change.html:44
+#: support/templates/book_unsubscription.html:19
+#: support/views/subscriptions.py:884
+msgid "Partial unsubscription"
+msgstr "Desuscripción parcial"
+
+#: core/models.py:1616 core/models.py:2773 support/forms.py:1079
+#: support/models.py:449 support/templates/activities/activity_detail.html:65
 #: support/templates/contact_detail/tabs/_activities.html:16
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:41
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:66
+#: support/templates/contact_detail/tabs/_overview.html:284
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:101
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:87
 #: support/templates/distribute_campaigns.html:18
 #: support/templates/sales_record_create.html:91
-#: support/templates/sales_record_filter.html:105
-#: support/templates/scheduled_activities.html:47
-#: support/templates/scheduled_activities.html:97
-#: support/templates/seller_console.html:233
-#: support/templates/seller_console_list_campaigns.html:158
-#: support/templates/validate_subscription_sales_record.html:90
-#: support/views/all_views.py:1994
+#: support/templates/sales_record_filter.html:147
+#: support/templates/scheduled_activities.html:65
+#: support/templates/scheduled_activities.html:165
+#: support/templates/seller_console.html:267
+#: support/templates/seller_console_list_campaigns.html:162
+#: support/templates/validate_subscription_sales_record.html:209
+#: support/templates/validate_subscription_sales_record.html:384
+#: support/views/all_views.py:2902
 msgid "Campaign"
 msgstr "Campaña"
 
-#: core/models.py:1400
+#: core/models.py:1630
 msgid "Billing Identification Document"
 msgstr "Documento de identificación de facturación"
 
-#: core/models.py:1402
+#: core/models.py:1632
 msgid "UTR"
 msgstr "NIT"
 
-#: core/models.py:1405
+#: core/models.py:1635
 msgid "Billing phone extension"
 msgstr "Extensión de teléfono de facturación"
 
-#: core/models.py:1413
+#: core/models.py:1643
 msgid "Positive for discount, negative for surcharge"
 msgstr "Positivo para descuento, negativo para cargo adicional"
 
-#: core/models.py:1415 support/forms.py:263
+#: core/models.py:1645 support/forms.py:302
 msgid "Send bill copy by email"
 msgstr "Enviar copia de la factura por correo electrónico"
 
-#: core/models.py:1430 support/templates/sales_record_create.html:129
-#: support/templates/validate_subscription_sales_record.html:128
+#: core/models.py:1660 support/templates/reactivate_subscription.html:54
+#: support/templates/sales_record_create.html:129
+#: support/templates/validate_subscription_sales_record.html:247
 msgid "Next billing"
 msgstr "Próxima factura"
 
-#: core/models.py:1432
+#: core/models.py:1662
 msgid "Highlight in listing"
 msgstr "Destacar en la lista"
 
-#: core/models.py:1433
+#: core/models.py:1663
 msgid "Send pdf"
 msgstr "Enviar PDF"
 
-#: core/models.py:1435
+#: core/models.py:1668
 msgid "Inactivity reason"
 msgstr "Motivo de inactividad"
 
-#: core/models.py:1438
+#: core/models.py:1669
+#, fuzzy
+#| msgid "Has active subscriptions"
+msgid "Reason for the inactivity of the subscription"
+msgstr "Tiene suscripciones activas"
+
+#: core/models.py:1672
 msgid "Pickup point"
 msgstr "Punto de recogida"
 
-#: core/models.py:1442
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:101
+#: core/models.py:1676 support/templates/activities/activity_detail.html:105
+#: support/templates/reactivate_subscription.html:79
 msgid "Unsubscription date"
 msgstr "Fecha de desuscripción"
 
-#: core/models.py:1444
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:117
+#: core/models.py:1678
 msgid "Unsubscription manager"
 msgstr "Gestor de baja"
 
-#: core/models.py:1447
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:109
-#: support/templates/seller_console.html:480
+#: core/models.py:1684 support/templates/reactivate_subscription.html:69
+#: support/templates/seller_console.html:518
 msgid "Unsubscription reason"
 msgstr "Motivo de baja"
 
-#: core/models.py:1453
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:113
+#: core/models.py:1685
+msgid "Reason why the user finished definitively the subscription"
+msgstr ""
+
+#: core/models.py:1691
 msgid "Unsubscription channel"
 msgstr "Canal de baja"
 
-#: core/models.py:1459
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:105
+#: core/models.py:1697
 msgid "Unsubscription type"
 msgstr "Tipo de baja"
 
-#: core/models.py:1461
+#: core/models.py:1699
 msgid "Unsubscription addendum"
 msgstr "Adenda de baja"
 
-#: core/models.py:1468
+#: core/models.py:1711
 #: invoicing/templates/bill_subscriptions_for_one_contact.html:66
-#: support/models.py:376 support/models.py:409
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:6
+#: support/filters.py:379 support/filters.py:413 support/models.py:445
+#: support/models.py:478 support/templates/reactivate_subscription.html:42
 #: support/templates/sales_record_create.html:29
-#: support/templates/sales_record_filter.html:104
-#: support/templates/sales_record_filter.html:163
-#: support/templates/validate_subscription_sales_record.html:28
-#: support/views/all_views.py:1993
+#: support/templates/sales_record_filter.html:97
+#: support/templates/sales_record_filter.html:146
+#: support/templates/sales_record_filter.html:218
+#: support/templates/validate_subscription_sales_record.html:147
+#: support/views/all_views.py:2901
 msgid "Products"
 msgstr "Productos"
 
-#: core/models.py:1470
+#: core/models.py:1713
 #: invoicing/templates/bill_subscriptions_for_one_contact.html:68
-#: support/forms.py:252
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:34
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:25
+#: support/forms.py:291
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:56
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:63
 #: support/templates/sales_record_create.html:74
-#: support/templates/sales_record_filter.html:209
-#: support/templates/validate_subscription_sales_record.html:73
+#: support/templates/sales_record_filter.html:264
+#: support/templates/validate_subscription_sales_record.html:192
 msgid "Frequency"
 msgstr "Frecuencia"
 
-#: core/models.py:1478 core/models.py:1564 invoicing/models.py:27
-#: invoicing/models.py:69 invoicing/templates/invoice_filter.html:66
-#: invoicing/templates/invoice_filter.html:123 invoicing/views.py:283
-#: support/forms.py:253
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:71
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:39
-#: support/templates/sales_record_create.html:151
-#: support/templates/sales_record_filter.html:186
-#: support/templates/seller_console.html:476
-#: support/templates/validate_subscription_sales_record.html:150
+#: core/models.py:1721 core/models.py:1807 invoicing/models.py:27
+#: invoicing/models.py:69 invoicing/templates/invoice_filter.html:115
+#: invoicing/templates/invoice_filter.html:237 invoicing/views.py:304
+#: support/forms.py:292 support/templates/sales_record_create.html:151
+#: support/templates/sales_record_filter.html:241
+#: support/templates/seller_console.html:514
+#: support/templates/validate_subscription_sales_record.html:269
 msgid "Payment type"
 msgstr "Tipo de pago"
 
-#: core/models.py:1482
+#: core/models.py:1725
 msgid "Updated from"
 msgstr "Actualizado de"
 
-#: core/models.py:1485
+#: core/models.py:1728
 msgid "Payment certificate"
 msgstr "Certificado de Pago"
 
-#: core/models.py:1493
+#: core/models.py:1736 support/forms.py:1029
 msgid "Free subscription requested by"
 msgstr "Solicitud de suscripción gratuita por"
 
-#: core/models.py:1495 support/templates/sales_record_filter.html:68
-#: support/views/all_views.py:1997
+#: core/models.py:1738 support/templates/sales_record_filter.html:110
+#: support/views/all_views.py:2905
 msgid "Validated"
 msgstr "Validado"
 
-#: core/models.py:1500
+#: core/models.py:1743
 msgid "Validated by"
 msgstr "Validado por"
 
-#: core/models.py:1504
+#: core/models.py:1747
 msgid "Validated date"
 msgstr "Fecha de validación"
 
-#: core/models.py:1520
+#: core/models.py:1763
 msgid "Billing Contact"
 msgstr "Contacto de facturación"
 
-#: core/models.py:1527
+#: core/models.py:1770
 msgid "Terms and conditions"
 msgstr "Términos y condiciones"
 
-#: core/models.py:1532
+#: core/models.py:1775
 #: support/templates/subscriptions/corporate_subscription.html:39
 msgid "Number of subscriptions"
 msgstr "Número de suscripciones"
 
-#: core/models.py:1538
+#: core/models.py:1781
 msgid "Override price"
 msgstr "Reemplazar precio"
 
-#: core/models.py:1545
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:85
+#: core/models.py:1788
 msgid "Parent subscription"
 msgstr "Suscripción padre"
 
-#: core/models.py:1553 invoicing/models.py:58
+#: core/models.py:1796 invoicing/models.py:58
 #: invoicing/templates/contact_invoices.html:62
-#: invoicing/templates/contact_invoices.html:103 invoicing/views.py:240
+#: invoicing/templates/contact_invoices.html:103 invoicing/views.py:241
 #: support/templates/contact_detail/htmx/_invoices_htmx.html:12
+#: support/templates/contact_detail/tabs/_overview.html:164
+#: support/templates/reactivate_subscription.html:65
+#: support/templates/reactivate_subscription.html:124
 #: support/templates/subscriptions/corporate_subscription.html:55
-#: support/templates/view_issue.html:281
 msgid "Payment method"
 msgstr "Método de pago"
 
-#: core/models.py:1555 invoicing/models.py:60
+#: core/models.py:1798 invoicing/models.py:60
 msgid ""
 "Payment method used to pay for the subscription, for example: 'Cash', "
 "'Credit Card', 'Debit Card', 'Bank Transfer', etc."
@@ -2626,7 +2826,7 @@ msgstr ""
 "Método de pago utilizado para pagar la suscripción, por ejemplo: 'Efectivo', "
 "'Tarjeta de débito', 'Tarjeta de crédito', 'Transferencia bancaria', etc."
 
-#: core/models.py:1566 invoicing/models.py:71
+#: core/models.py:1809 invoicing/models.py:71
 msgid ""
 "Payment type used to pay for the subscription, for example: 'American "
 "Express', 'Visa', 'Mastercard', etc."
@@ -2634,130 +2834,157 @@ msgstr ""
 "Tipo de pago utilizado para pagar la suscripción, por ejemplo: 'American "
 "Express', 'Visa', 'Mastercard', etc."
 
-#: core/models.py:1570
+#: core/models.py:1813
 msgid "Purchase date"
 msgstr "Fecha de compra"
 
-#: core/models.py:1578 core/models.py:2332
+#: core/models.py:1821 core/models.py:2617
 msgid "subscription"
 msgstr "suscripción"
 
-#: core/models.py:1580
+#: core/models.py:1823
 msgid "for the contact"
 msgstr "para el contacto"
 
-#: core/models.py:1583
+#: core/models.py:1826
 msgid "with"
 msgstr "con"
 
-#: core/models.py:1874 core/models.py:1887
+#: core/models.py:1937
+#, fuzzy
+#| msgid "All products"
+msgid "All products were removed."
+msgstr "Todos los productos"
+
+#: core/models.py:2134 core/models.py:2147
 #, python-brace-format
 msgid "{} months"
 msgstr "{} meses"
 
-#: core/models.py:1978 core/models.py:1996
+#: core/models.py:2243 core/models.py:2261
 msgid "Subscription must be normal to use this method"
 msgstr "La suscripción debe ser normal para usar este método"
 
-#: core/models.py:2333
+#: core/models.py:2618
 msgid "subscriptions"
 msgstr "suscripciones"
 
-#: core/models.py:2335
+#: core/models.py:2620
 msgid "Can add free subscription"
 msgstr "Puede agregar una suscripción gratuita"
 
-#: core/models.py:2336
+#: core/models.py:2621
 msgid "Can add corporate subscription"
 msgstr "Puede agregar una suscripción corporativa"
 
-#: core/models.py:2346
+#: core/models.py:2622
+#, fuzzy
+#| msgid "Date of execution"
+msgid "Can offer retention"
+msgstr "Fecha de ejecución"
+
+#: core/models.py:2632
 msgid "1 - Highest"
 msgstr "1 - Mayor"
 
-#: core/models.py:2347
+#: core/models.py:2633
 msgid "2 - High"
 msgstr "2 - Alto"
 
-#: core/models.py:2348
+#: core/models.py:2634
 msgid "3 - Mid"
 msgstr "3 - Medio"
 
-#: core/models.py:2349
+#: core/models.py:2635
 msgid "4 - Low"
 msgstr "4 - Bajo"
 
-#: core/models.py:2350
+#: core/models.py:2636
 msgid "5 - Lowest"
 msgstr "5 - Menor"
 
-#: core/models.py:2462
+#: core/models.py:2722
 msgid "campaign"
 msgstr "campaña"
 
-#: core/models.py:2463
+#: core/models.py:2723
 msgid "campaigns"
 msgstr "campañas"
 
-#: core/models.py:2483
+#: core/models.py:2743
 msgid "activity topic"
 msgstr "tema de actividad"
 
-#: core/models.py:2484
+#: core/models.py:2744
 msgid "activity topics"
 msgstr "temas de actividad"
 
-#: core/models.py:2495 core/models.py:2538
+#: core/models.py:2755 core/models.py:2798
+#: support/templates/activities/activity_detail.html:71
 #: support/templates/contact_detail/tabs/_activities.html:20
-#: support/templates/contact_detail/tabs/_overview.html:251
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:63
+#: support/templates/contact_detail/tabs/_overview.html:297
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:122
 msgid "Topic"
 msgstr "Tema"
 
-#: core/models.py:2501
+#: core/models.py:2761
 msgid "activity response"
 msgstr "respuesta de actividad"
 
-#: core/models.py:2502
+#: core/models.py:2762
 msgid "activity responses"
 msgstr "respuestas de actividad"
 
-#: core/models.py:2519 invoicing/templates/contact_invoices.html:100
-#: support/models.py:159
+#: core/models.py:2779 invoicing/templates/contact_invoices.html:100
+#: support/models.py:204 support/templates/activities/activity_detail.html:210
 #: support/templates/contact_detail/tabs/_activities.html:18
-#: support/templates/view_issue.html:13 support/templates/view_issue.html:278
+#: support/templates/view_issue.html:85
 msgid "Issue"
 msgstr "Incidente"
 
-#: core/models.py:2522
+#: core/models.py:2782 support/templates/activities/activity_detail.html:197
 msgid "ASAP"
 msgstr "Urgente"
 
-#: core/models.py:2536
+#: core/models.py:2796 support/templates/activities/activity_detail.html:53
 #: support/templates/contact_detail/tabs/_activities.html:22
-#: support/templates/contact_detail/tabs/_overview.html:232
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:57
-#: support/templates/view_issue.html:67
+#: support/templates/contact_detail/tabs/_overview.html:299
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:93
+#: support/templates/view_issue.html:349
 msgid "Created by"
 msgstr "Creado por"
 
-#: core/models.py:2540
+#: core/models.py:2800 support/templates/activities/activity_detail.html:77
 #: support/templates/contact_detail/tabs/_activities.html:21
-#: support/templates/contact_detail/tabs/_overview.html:256
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:69
+#: support/templates/contact_detail/tabs/_overview.html:298
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:130
 msgid "Response"
 msgstr "Respuesta"
 
-#: core/models.py:2548
+#: core/models.py:2808
+#: support/templates/contact_detail/tabs/_activities.html:24
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:138
 msgid "Seller console action"
 msgstr "Acción de consola de ventas"
 
-#: core/models.py:2552
+#: core/models.py:2813 support/templates/activities/activity_detail.html:90
+#, fuzzy
+#| msgid "Contact data"
+msgid "Metadata"
+msgstr "Datos del contacto"
+
+#: core/models.py:2814
+msgid ""
+"Structured data for storing additional activity information (e.g., "
+"unsubscription data)"
+msgstr ""
+
+#: core/models.py:2818
 #, python-brace-format
 msgid "Activity {} for contact {}"
 msgstr "Actividad {} para el contacto {}"
 
-#: core/models.py:2586
+#: core/models.py:2861
 #, python-brace-format
 msgid ""
 "Success in sale after scheduling {}\n"
@@ -2766,31 +2993,31 @@ msgstr ""
 "Éxito en la venta después de programar {}\n"
 "{}"
 
-#: core/models.py:2611
+#: core/models.py:2886
 msgid "activity"
 msgstr "actividad"
 
-#: core/models.py:2612
+#: core/models.py:2887
 msgid "activities"
 msgstr "actividades"
 
-#: core/models.py:2644
+#: core/models.py:2919
 msgid "Contact Product History"
 msgstr "Historial de productos de contactos"
 
-#: core/models.py:2645
+#: core/models.py:2920
 msgid "Contact Product Histories"
 msgstr "Historiales de productos de contactos"
 
-#: core/models.py:2670
+#: core/models.py:2945
 msgid "Contact Campaign Status"
 msgstr "Estado de contacto en la campaña"
 
-#: core/models.py:2671
+#: core/models.py:2946
 msgid "Contact Campaign Statuses"
 msgstr "Estados de contacto en la campaña"
 
-#: core/models.py:2703
+#: core/models.py:2978
 #, python-brace-format
 msgid ""
 "Success in direct sale {}\n"
@@ -2799,134 +3026,134 @@ msgstr ""
 "Éxito en la venta directa {}\n"
 "{}"
 
-#: core/models.py:2803
+#: core/models.py:3078
 msgid "Price Rule"
 msgstr "Regla de precios"
 
-#: core/models.py:2804
+#: core/models.py:3079
 msgid "Price Rules"
 msgstr "Reglas de precios"
 
-#: core/models.py:2830
+#: core/models.py:3105
 msgid "Automatically sync with Mailtrain"
 msgstr "Sincronización automática con Mailtrain"
 
-#: core/models.py:2928
+#: core/models.py:3203
 msgid "Dynamic Contact Filter"
 msgstr "Filtro de contactos dinámicos"
 
-#: core/models.py:2929
+#: core/models.py:3204
 msgid "Dynamic Contact Filters"
 msgstr "Filtros de contactos dinámicos"
 
-#: core/models.py:2937
+#: core/models.py:3212
 msgid "Product Bundle"
 msgstr "Paquete de productos"
 
-#: core/models.py:2938
+#: core/models.py:3213
 msgid "Product Bundles"
 msgstr "Paquetes de productos"
 
-#: core/models.py:2967
+#: core/models.py:3242
 msgid "Advanced Discount"
 msgstr "Descuento avanzado"
 
-#: core/models.py:2968
+#: core/models.py:3243
 msgid "Advanced Discounts"
 msgstr "Descuentos avanzados"
 
-#: core/models.py:2989
+#: core/models.py:3264
 msgid "Do Not Call Number"
 msgstr "Número de no llamar"
 
-#: core/models.py:2990
+#: core/models.py:3265
 msgid "Do Not Call Numbers"
 msgstr "Números de no llamar"
 
-#: core/models.py:3011
+#: core/models.py:3286
 msgid "Email Replacement"
 msgstr "Reemplazo de correo electrónico"
 
-#: core/models.py:3012
+#: core/models.py:3287
 msgid "Email Replacements"
 msgstr "Reemplazos de correos electrónicos"
 
-#: core/models.py:3096 support/views/subscriptions.py:116
+#: core/models.py:3378 support/views/subscriptions.py:119
 msgid "CMS sync error"
 msgstr "Error de sincronización CMS"
 
-#: core/models.py:3134
+#: core/models.py:3416
 msgid "Mailtrain List"
 msgstr "Lista de Mailtrain"
 
-#: core/models.py:3135
+#: core/models.py:3417
 msgid "Mailtrain Lists"
 msgstr "Listas de Mailtrain"
 
-#: core/models.py:3139
+#: core/models.py:3421
 msgid "Version"
 msgstr "Versión"
 
-#: core/models.py:3143
+#: core/models.py:3425
 msgid "Description code"
 msgstr "Descripción interna"
 
-#: core/models.py:3146
+#: core/models.py:3428
 msgid "Description for internal use"
 msgstr ""
 "Esta descripción es para documentación interna de CRM, no es visible para el "
 "usuario final"
 
-#: core/models.py:3148
+#: core/models.py:3430
 msgid "PDF File"
 msgstr "Archivo PDF"
 
-#: core/models.py:3149 logistics/models.py:226
+#: core/models.py:3431 logistics/models.py:226
 msgid "Text"
 msgstr "Texto"
 
-#: core/models.py:3155 core/models.py:3156 core/models.py:3162
+#: core/models.py:3437 core/models.py:3438 core/models.py:3444
 msgid "Terms and Conditions"
 msgstr "Términos y condiciones"
 
-#: core/models.py:3170
+#: core/models.py:3452
 msgid "Terms and Conditions Product"
 msgstr "Términos y condiciones por producto"
 
-#: core/models.py:3171
+#: core/models.py:3453
 msgid "Terms and Conditions Products"
 msgstr "Términos y condiciones por producto"
 
-#: core/models.py:3182
+#: core/models.py:3464
 msgid "Business Entity Type"
 msgstr "Tipo de entidad de negocio"
 
-#: core/models.py:3183
+#: core/models.py:3465
 msgid "Business Entity Types"
 msgstr "Tipos de entidad de negocio"
 
-#: core/models.py:3194
+#: core/models.py:3476
 msgid "Person Type"
 msgstr "Tipo de persona"
 
-#: core/models.py:3195
+#: core/models.py:3477
 msgid "Person Types"
 msgstr "Tipos de persona"
 
-#: core/models.py:3216 support/templates/sales_record_filter.html:55
-#: support/templates/sales_record_filter.html:103
+#: core/models.py:3498 support/templates/sales_record_filter.html:91
+#: support/templates/sales_record_filter.html:145
 msgid "Payment Method"
 msgstr "Método de pago"
 
-#: core/models.py:3217
+#: core/models.py:3499
 msgid "Payment Methods"
 msgstr "Métodos de pago"
 
-#: core/models.py:3240 invoicing/templates/invoice/invoice_detail.html:72
+#: core/models.py:3522 invoicing/templates/invoice/invoice_detail.html:73
 msgid "Payment Type"
 msgstr "Tipo de pago"
 
-#: core/models.py:3241
+#: core/models.py:3523
 msgid "Payment Types"
 msgstr "Tipos de pago"
 
@@ -2940,22 +3167,23 @@ msgid "Hi %(first_name)s, choose your destination"
 msgstr "Hola %(first_name)s, elija dónde desea ir"
 
 #: core/templates/main_menu.html:22 support/templates/assign_sellers.html:39
-#: support/templates/campaign_statistics_detail.html:71
+#: support/templates/campaign_statistics_detail.html:129
 #: support/templates/campaign_statistics_list.html:61
-#: support/templates/contact_list.html:9 support/templates/contact_list.html:13
+#: support/templates/contact_list.html:54
+#: support/templates/contact_list.html:85
 #: support/templates/distribute_campaigns.html:19
 #: support/templates/edit_envelopes.html:18
 #: support/templates/sales_record_create.html:9
 #: support/templates/seller_console.html:94
-#: support/templates/seller_console_list_campaigns.html:23
+#: support/templates/seller_console_list_campaigns.html:25
 #: support/templates/subscriptions/subscription_end_date_list.html:10
 #: support/templates/upload_payment_certificate.html:9
-#: support/views/all_views.py:752 support/views/all_views.py:866
-#: support/views/all_views.py:2032 templates/components/_sidebar.html:48
+#: support/views/all_views.py:1309 support/views/all_views.py:1489
+#: support/views/all_views.py:2945 templates/components/_sidebar.html:48
 msgid "Contacts"
 msgstr "Contactos"
 
-#: core/templates/main_menu.html:25 support/templates/contact_list.html:14
+#: core/templates/main_menu.html:25 support/templates/contact_list.html:86
 msgid "Manage all contacts in the database."
 msgstr "Gestionar todos los contactos en la base de datos."
 
@@ -2963,39 +3191,67 @@ msgstr "Gestionar todos los contactos en la base de datos."
 msgid "Go to contacts"
 msgstr "Ir a contactos"
 
+#: core/templates/main_menu.html:36
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:7
+#: support/templates/campaign_management_menu.html:84
+#: support/templates/campaign_management_menu.html:88
+#: support/templates/campaign_management_menu.html:94
+#: support/templates/support/seller_attendance.html:7
+#: support/views/all_views.py:168 support/views/all_views.py:254
+#: support/views/all_views.py:290 support/views/all_views.py:540
+#: support/views/all_views.py:2189 support/views/all_views.py:2212
+#: support/views/all_views.py:2567 support/views/all_views.py:2692
+#: support/views/all_views.py:2732 support/views/all_views.py:2872
+#: support/views/all_views.py:3078 support/views/all_views.py:3253
+#: support/views/all_views.py:3397 support/views/campaign_management.py:52
+#: support/views/contacts.py:561 support/views/contacts.py:894
+#: templates/components/sidebar_items/_campaign_management.html:21
+msgid "Campaign Management"
+msgstr "Gestión de campañas"
+
+#: core/templates/main_menu.html:39
+msgid "Campaign tools, statistics and seller management."
+msgstr ""
+
+#: core/templates/main_menu.html:41
+#, fuzzy
+#| msgid "campaigns"
+msgid "Go to campaigns"
+msgstr "campañas"
+
 #: core/templates/partials/search_contacts_results.html:2
 msgid "Select contact"
 msgstr "Seleccionar contacto"
 
-#: core/templatetags/core_tags.py:97
+#: core/templatetags/core_tags.py:102
 msgid "Unbilled Ad Purchase Orders"
 msgstr "Pedidos de compra de anuncios sin facturar"
 
-#: core/templatetags/core_tags.py:128
+#: core/templatetags/core_tags.py:133
 #, python-brace-format
 msgid "{days} days remaining"
 msgstr "{days} días restantes"
 
-#: core/utils.py:178 core/utils.py:228
+#: core/utils.py:182 core/utils.py:232
 #, python-brace-format
 msgid " {frequency} months"
 msgstr " {frequency} meses"
 
-#: core/utils.py:361
+#: core/utils.py:365
 #, python-brace-format
 msgid "{frequency} months discount ({discount_pct}% discount)"
 msgstr "{frequency} meses de descuento ({discount_pct}% de descuento)"
 
-#: core/utils.py:438
+#: core/utils.py:444
 msgid "The subscription needs to be corporate to use this function"
 msgstr "La suscripción debe ser corporativa para utilizar esta función"
 
 #: invoicing/apps.py:7 invoicing/templates/print.html:22 support/choices.py:15
-#: support/templates/new_issue.html:81
+#: support/choices.py:34 support/templates/new_issue.html:202
 msgid "Invoicing"
 msgstr "Facturación"
 
-#: invoicing/choices.py:6 invoicing/views.py:220
+#: invoicing/choices.py:6 invoicing/views.py:221
 msgid "Item"
 msgstr "Ítem"
 
@@ -3004,6 +3260,7 @@ msgid "Surcharge"
 msgstr "Adicional"
 
 #: invoicing/choices.py:12
+#: support/templates/check_for_existing_contacts.html:266
 msgid "Value"
 msgstr "Valor"
 
@@ -3024,39 +3281,51 @@ msgid "Completed with errors"
 msgstr "Completado con errores"
 
 #: invoicing/filters.py:16 logistics/templates/list_routes.html:38
-#: support/filters.py:15 util/dates.py:82
+#: support/filters.py:25 support/filters.py:173
+#: support/templates/community_console.html:108
+#: support/templates/community_console.html:216
+#: support/templates/community_console.html:355
+#: support/templates/community_manager_assign.html:75
+#: support/templates/community_manager_assign.html:135
+#: support/templates/community_manager_dashboard.html:212
+#: support/templates/community_manager_dashboard.html:364
+#: support/templates/community_manager_overview.html:163
+#: support/templates/community_manager_overview.html:239
+#: support/templates/community_manager_overview.html:422
+#: support/templates/scheduled_activities.html:86
+#: support/templates/scheduled_activities.html:154 util/dates.py:82
 msgid "Today"
 msgstr "Hoy"
 
-#: invoicing/filters.py:17 support/filters.py:16 util/dates.py:84
+#: invoicing/filters.py:17 support/filters.py:26 util/dates.py:84
 msgid "Yesterday"
 msgstr "Ayer"
 
-#: invoicing/filters.py:18 support/filters.py:17
+#: invoicing/filters.py:18 support/filters.py:27
 msgid "Last 7 days"
 msgstr "Últimos 7 días"
 
-#: invoicing/filters.py:19 support/filters.py:18
+#: invoicing/filters.py:19 support/filters.py:29
 msgid "Last 30 days"
 msgstr "Últimos 30 días"
 
-#: invoicing/filters.py:20 support/filters.py:19
+#: invoicing/filters.py:20 support/filters.py:30
 msgid "This month"
 msgstr "Este mes"
 
-#: invoicing/filters.py:21 support/filters.py:20
+#: invoicing/filters.py:21 support/filters.py:31
 msgid "Last month"
 msgstr "Mes anterior"
 
-#: invoicing/filters.py:27 invoicing/models.py:34 invoicing/models.py:159
-#: invoicing/templates/invoice/invoice_detail.html:116
-#: invoicing/templates/invoice/invoice_detail.html:154
-#: invoicing/templates/invoice_filter.html:108
+#: invoicing/filters.py:27 invoicing/models.py:34 invoicing/models.py:162
+#: invoicing/templates/invoice/invoice_detail.html:117
+#: invoicing/templates/invoice/invoice_detail.html:155
+#: invoicing/templates/invoice_filter.html:186
 msgid "Paid"
 msgstr "Pagado"
 
 #: invoicing/filters.py:28 invoicing/models.py:33
-#: invoicing/templates/invoice/invoice_detail.html:118
+#: invoicing/templates/invoice/invoice_detail.html:119
 msgid "Debited"
 msgstr "Debitado"
 
@@ -3064,21 +3333,32 @@ msgstr "Debitado"
 msgid "Paid or debited"
 msgstr "Pagado o debitado"
 
-#: invoicing/filters.py:31 invoicing/models.py:40 invoicing/models.py:152
-#: invoicing/templates/invoice/invoice_detail.html:146
-#: invoicing/templates/invoice_filter.html:108
+#: invoicing/filters.py:31 invoicing/models.py:40 invoicing/models.py:155
+#: invoicing/templates/invoice/invoice_detail.html:147
+#: invoicing/templates/invoice_filter.html:207
 msgid "Canceled"
 msgstr "Anulado"
 
-#: invoicing/filters.py:32 invoicing/models.py:42 invoicing/models.py:154
-#: invoicing/templates/invoice/invoice_detail.html:148
-#: invoicing/templates/invoice_filter.html:108
+#: invoicing/filters.py:32 invoicing/models.py:42 invoicing/models.py:157
+#: invoicing/templates/invoice/invoice_detail.html:149
+#: invoicing/templates/invoice_filter.html:214
 msgid "Uncollectible"
 msgstr "Incobrable"
 
-#: invoicing/filters.py:33 invoicing/models.py:161
-#: invoicing/templates/invoice/invoice_detail.html:150
-#: invoicing/templates/invoice_filter.html:108
+#: invoicing/filters.py:33 invoicing/models.py:164
+#: invoicing/templates/invoice/invoice_detail.html:151
+#: invoicing/templates/invoice_filter.html:200
+#: support/templates/community_console.html:99
+#: support/templates/community_console.html:215
+#: support/templates/community_console.html:354
+#: support/templates/community_manager_assign.html:66
+#: support/templates/community_manager_assign.html:132
+#: support/templates/community_manager_dashboard.html:211
+#: support/templates/community_manager_dashboard.html:363
+#: support/templates/community_manager_overview.html:160
+#: support/templates/community_manager_overview.html:239
+#: support/templates/community_manager_overview.html:421
+#: support/templates/scheduled_activities.html:153
 msgid "Overdue"
 msgstr "Vencido"
 
@@ -3086,11 +3366,28 @@ msgstr "Vencido"
 msgid "Not paid"
 msgstr "No pagado"
 
-#: invoicing/models.py:20 invoicing/templates/invoice/invoice_detail.html:85
+#: invoicing/filters.py:41
+#, fuzzy
+#| msgid "Last name"
+msgid "Name or last name"
+msgstr "Apellido"
+
+#: invoicing/filters.py:49 invoicing/templates/invoice_filter.html:88
+#: invoicing/views.py:297 support/templates/contact_list.html:194
+msgid "ID document"
+msgstr "Documento de identificación"
+
+#: invoicing/filters.py:53
+#, fuzzy
+#| msgid "Phone number"
+msgid "Phone or mobile"
+msgstr "Número de teléfono"
+
+#: invoicing/models.py:20 invoicing/templates/invoice/invoice_detail.html:86
 msgid "Creation Date"
 msgstr "Fecha de creación"
 
-#: invoicing/models.py:21 invoicing/templates/invoice/invoice_detail.html:89
+#: invoicing/models.py:21 invoicing/templates/invoice/invoice_detail.html:90
 msgid "Expiration Date"
 msgstr "Fecha de vencimiento"
 
@@ -3102,23 +3399,22 @@ msgstr "Servicio desde"
 msgid "Service To"
 msgstr "Servicio hasta"
 
-#: invoicing/models.py:25 invoicing/models.py:402
+#: invoicing/models.py:25 invoicing/models.py:405
 #: invoicing/templates/contact_invoices.html:61
 #: invoicing/templates/contact_invoices.html:102
-#: invoicing/templates/invoice/invoice_detail.html:68
-#: invoicing/templates/invoice/invoice_detail.html:221
-#: invoicing/templates/invoice/invoice_detail.html:248
-#: invoicing/templates/invoice_filter.html:122 invoicing/views.py:282
+#: invoicing/templates/invoice/invoice_detail.html:69
+#: invoicing/templates/invoice/invoice_detail.html:252
+#: invoicing/templates/invoice/invoice_detail.html:279
+#: invoicing/templates/invoice_filter.html:236 invoicing/views.py:303
 #: support/templates/contact_detail/htmx/_invoices_htmx.html:11
-#: support/templates/view_issue.html:280
 msgid "Amount"
 msgstr "Monto"
 
-#: invoicing/models.py:35 invoicing/views.py:289
+#: invoicing/models.py:35 invoicing/views.py:310
 msgid "Payment date"
 msgstr "Fecha de pago"
 
-#: invoicing/models.py:37 invoicing/views.py:292
+#: invoicing/models.py:37 invoicing/views.py:313
 msgid "Payment reference"
 msgstr "Referencia de pago"
 
@@ -3134,12 +3430,12 @@ msgstr "Fecha de anulación"
 msgid "Print date"
 msgstr "Fecha de impresión"
 
-#: invoicing/models.py:48 invoicing/models.py:400 invoicing/views.py:290
+#: invoicing/models.py:48 invoicing/models.py:403 invoicing/views.py:311
 msgid "Serie"
 msgstr "Serie"
 
-#: invoicing/models.py:49 invoicing/models.py:401
-#: invoicing/templates/invoice_filter.html:82 invoicing/views.py:291
+#: invoicing/models.py:49 invoicing/models.py:404
+#: invoicing/templates/invoice_filter.html:133 invoicing/views.py:312
 #: logistics/models.py:22
 msgid "Number"
 msgstr "Número"
@@ -3152,11 +3448,11 @@ msgstr "PDF"
 msgid "Billing Country"
 msgstr "País de facturación"
 
-#: invoicing/models.py:82 invoicing/templates/invoice/invoice_detail.html:191
+#: invoicing/models.py:82 invoicing/templates/invoice/invoice_detail.html:222
 msgid "Billing State"
 msgstr "Estado de facturación"
 
-#: invoicing/models.py:83 invoicing/templates/invoice/invoice_detail.html:195
+#: invoicing/models.py:83 invoicing/templates/invoice/invoice_detail.html:226
 msgid "Billing City"
 msgstr "Ciudad de facturación"
 
@@ -3172,7 +3468,7 @@ msgstr "Número de factura (Siigo)"
 msgid "Internal Provider Text"
 msgstr "Texto de uso interno"
 
-#: invoicing/models.py:103 invoicing/models.py:456
+#: invoicing/models.py:103 invoicing/models.py:457
 msgid "Transaction Type"
 msgstr "Tipo de transacción"
 
@@ -3184,76 +3480,88 @@ msgstr "Número de transacción"
 msgid "Consecutive Payment"
 msgstr "Consecutivo"
 
-#: invoicing/models.py:124 invoicing/models.py:270 invoicing/models.py:398
+#: invoicing/models.py:112 invoicing/models.py:407
+#, fuzzy
+#| msgid "Created"
+msgid "Created at"
+msgstr "Creado"
+
+#: invoicing/models.py:113 invoicing/models.py:408
+#, fuzzy
+#| msgid "Update"
+msgid "Updated at"
+msgstr "Actualizar"
+
+#: invoicing/models.py:127 invoicing/models.py:273 invoicing/models.py:401
 #: invoicing/templates/contact_invoices.html:55
 #: invoicing/templates/contact_invoices.html:97
 #: support/templates/contact_detail/htmx/_invoices_htmx.html:5
-#: support/templates/view_issue.html:275
 msgid "Invoice"
 msgstr "Factura"
 
-#: invoicing/models.py:157
+#: invoicing/models.py:160
 #, python-brace-format
 msgid "Paid on {}"
 msgstr "Pagado el {}"
 
-#: invoicing/models.py:167
+#: invoicing/models.py:170
 msgid "Unspecified payment method"
 msgstr "Método de pago no especificado"
 
-#: invoicing/models.py:246
+#: invoicing/models.py:249
 msgid "invoice"
 msgstr "factura"
 
-#: invoicing/models.py:247 invoicing/templates/invoice_filter.html:91
+#: invoicing/models.py:250 invoicing/templates/invoice_filter.html:142
+#: support/templates/contact_detail/tabs/_overview.html:158
 msgid "invoices"
 msgstr "facturas"
 
-#: invoicing/models.py:272
+#: invoicing/models.py:275
 msgid "Total amount"
 msgstr "Monto total"
 
-#: invoicing/models.py:287 invoicing/models.py:288 logistics/models.py:41
+#: invoicing/models.py:290 invoicing/models.py:291 logistics/models.py:41
 msgid "Price per copy"
 msgstr "Precio por copia"
 
-#: invoicing/models.py:292 invoicing/templates/contact_invoices.html:57
-#: invoicing/templates/invoice_filter.html:125 invoicing/views.py:286
+#: invoicing/models.py:295 invoicing/templates/contact_invoices.html:57
+#: invoicing/templates/invoice_filter.html:239 invoicing/views.py:307
 #: support/templates/contact_detail/htmx/_invoices_htmx.html:7
 msgid "Service from"
 msgstr "Serivio desde"
 
-#: invoicing/models.py:293 invoicing/templates/contact_invoices.html:58
-#: invoicing/templates/invoice_filter.html:126 invoicing/views.py:287
+#: invoicing/models.py:296 invoicing/templates/contact_invoices.html:58
+#: invoicing/templates/invoice_filter.html:240 invoicing/views.py:308
 #: support/templates/contact_detail/htmx/_invoices_htmx.html:8
 msgid "Service to"
 msgstr "Serivio hasta"
 
-#: invoicing/models.py:303
+#: invoicing/models.py:306
 msgid "Type Discount/Surcharge"
 msgstr "Tipo descuento/recarga"
 
-#: invoicing/models.py:310
+#: invoicing/models.py:313
 msgid "Invoice item"
 msgstr "Item de factura"
 
-#: invoicing/models.py:311
+#: invoicing/models.py:314
 msgid "Invoice items"
 msgstr "Items de factura"
 
-#: invoicing/models.py:409
+#: invoicing/models.py:412
 msgid "credit notes"
 msgstr "notas de crédito"
 
-#: invoicing/models.py:410
+#: invoicing/models.py:413
 msgid "credit note"
 msgstr "nota de crédito"
 
-#: invoicing/models.py:443 invoicing/models.py:444
+#: invoicing/models.py:444 invoicing/models.py:445
 msgid "Mercado Pago Data"
 msgstr "Datos de MercadoPago"
 
-#: invoicing/models.py:457
+#: invoicing/models.py:458
 msgid "Transaction Types"
 msgstr "Tipos de transacción"
 
@@ -3272,14 +3580,22 @@ msgstr "Volver al contacto"
 #: invoicing/templates/admin/invoicing/invoice/change_form.html:12
 #: invoicing/templates/contact_invoices.html:73
 #: support/templates/contact_detail/htmx/_invoices_htmx.html:26
-#: support/templates/view_issue.html:291
 msgid "Download invoice"
 msgstr "Descargar factura"
 
 #: invoicing/templates/admin/invoicing/invoice/change_form.html:18
-#: support/templates/new_subscription.html:354
-#: support/templates/seller_console_start_promo.html:189
-#: support/views/subscriptions.py:898
+#: logistics/templates/change_subscription_routes.html:204
+#: logistics/templates/merge_compare_addresses.html:380
+#: logistics/templates/merge_compare_addresses.html:384
+#: logistics/templates/merge_compare_addresses.html:454
+#: logistics/templates/merge_compare_addresses.html:512
+#: support/templates/contact_detail/edit_campaign_status.html:80
+#: support/templates/free_subscription_form.html:328
+#: support/templates/new_issue.html:465
+#: support/templates/new_subscription.html:407
+#: support/templates/reactivate_subscription.html:138
+#: support/templates/seller_console_start_promo.html:227
+#: support/views/subscriptions.py:1502 support/views/subscriptions.py:1696
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -3310,6 +3626,7 @@ msgid "PROTECTED CLIENT"
 msgstr "CLIENTE PROTEGIDO"
 
 #: invoicing/templates/bill_subscriptions_for_one_contact.html:35
+#: support/filters.py:41
 msgid "Issue Date"
 msgstr "Fecha de emisión"
 
@@ -3334,14 +3651,62 @@ msgstr "No hay suscripciones activas por facturar"
 msgid "Billings"
 msgstr "Facturación"
 
+#: invoicing/templates/canceled_invoices_report.html:4
+#: invoicing/templates/canceled_invoices_report.html:7 invoicing/views.py:529
+#, fuzzy
+#| msgid "Cancel invoice"
+msgid "Canceled invoices report"
+msgstr "Anular factura"
+
+#: invoicing/templates/canceled_invoices_report.html:13
+#, fuzzy
+#| msgid "Download invoice"
+msgid "Download canceled invoices CSV"
+msgstr "Descargar factura"
+
+#: invoicing/templates/canceled_invoices_report.html:17
+msgid ""
+"Download a CSV report with all canceled invoices in the selected date range, "
+"including their credit notes."
+msgstr ""
+
+#: invoicing/templates/canceled_invoices_report.html:22
+#, fuzzy
+#| msgid "Cancelation date"
+msgid "Cancelation date range"
+msgstr "Fecha de anulación"
+
+#: invoicing/templates/canceled_invoices_report.html:25
+#: invoicing/templates/contact_invoices.html:98
+#: invoicing/templates/invoice_filter.html:103
+#: invoicing/templates/print.html:38 support/filters.py:48
+#: support/filters.py:66
+msgid "From"
+msgstr "Desde"
+
+#: invoicing/templates/canceled_invoices_report.html:34
+#: invoicing/templates/print.html:42
+msgid "Up to"
+msgstr "Hasta"
+
+#: invoicing/templates/canceled_invoices_report.html:34
+#: invoicing/templates/print.html:42
+msgid "(inclusively)"
+msgstr "(inclusive)"
+
+#: invoicing/templates/canceled_invoices_report.html:46
+#: logistics/templates/print_labels_for_product_date.html:39
+msgid "Download CSV"
+msgstr "Descargar CSV"
+
 #: invoicing/templates/contact_invoices.html:5
 msgid "Invoices for contact:"
 msgstr "Facturas para el contacto:"
 
 #: invoicing/templates/contact_invoices.html:18
 #: invoicing/templates/contact_invoices.html:44
-#: invoicing/templates/invoice_filter.html:106
-#: support/templates/contact_detail/detail.html:150
+#: invoicing/templates/invoice_filter.html:162
+#: support/templates/contact_detail/detail.html:172
 #: support/templates/debtor_contacts.html:120
 msgid "Invoices"
 msgstr "Facturas"
@@ -3352,8 +3717,8 @@ msgstr "ADVERTENCIA: Contacto protegido"
 
 #: invoicing/templates/contact_invoices.html:35
 #: support/templates/contact_detail/tabs/_invoices.html:8
-#: support/templates/contact_detail/tabs/_overview.html:113
-#: support/templates/view_issue.html:108
+#: support/templates/contact_detail/tabs/_overview.html:147
+#: support/templates/view_issue.html:201
 msgid "Debt"
 msgstr "Deuda"
 
@@ -3363,14 +3728,12 @@ msgstr "Facturar suscripciones del contacto"
 
 #: invoicing/templates/contact_invoices.html:59
 #: support/templates/contact_detail/htmx/_invoices_htmx.html:9
-#: support/templates/contact_detail/tabs/_overview.html:200
 msgid "Created"
 msgstr "Creado"
 
 #: invoicing/templates/contact_invoices.html:60
-#: invoicing/templates/contact_invoices.html:101 invoicing/views.py:285
+#: invoicing/templates/contact_invoices.html:101 invoicing/views.py:306
 #: support/templates/contact_detail/htmx/_invoices_htmx.html:10
-#: support/templates/view_issue.html:279
 msgid "Due"
 msgstr "Vencimiento"
 
@@ -3383,13 +3746,9 @@ msgstr "No hay PDF"
 msgid "Item invoices"
 msgstr "Ítems de factura"
 
-#: invoicing/templates/contact_invoices.html:98
-#: invoicing/templates/print.html:38 support/templates/view_issue.html:276
-msgid "From"
-msgstr "Desde"
-
 #: invoicing/templates/contact_invoices.html:99
-#: support/templates/view_issue.html:277
+#: invoicing/templates/invoice_filter.html:107 support/filters.py:54
+#: support/filters.py:72
 msgid "To"
 msgstr "Hasta"
 
@@ -3401,184 +3760,204 @@ msgstr "Pagado"
 msgid "Invoice Detail"
 msgstr "Detalle de la factura"
 
-#: invoicing/templates/invoice/invoice_detail.html:18
+#: invoicing/templates/invoice/invoice_detail.html:19
 msgid "Are you sure you want to cancel this invoice?"
 msgstr "¿Confirma la anulación de esta factura?"
 
-#: invoicing/templates/invoice/invoice_detail.html:18
+#: invoicing/templates/invoice/invoice_detail.html:19
 msgid "Cancel invoice"
 msgstr "Anular factura"
 
-#: invoicing/templates/invoice/invoice_detail.html:22
+#: invoicing/templates/invoice/invoice_detail.html:23
 msgid "Download PDF"
 msgstr "Descargar PDF"
 
-#: invoicing/templates/invoice/invoice_detail.html:24
+#: invoicing/templates/invoice/invoice_detail.html:25
 msgid "No PDF available"
 msgstr "No hay PDF disponible"
 
-#: invoicing/templates/invoice/invoice_detail.html:37
+#: invoicing/templates/invoice/invoice_detail.html:38
 msgid "Invoice Information"
 msgstr "Información de la factura"
 
-#: invoicing/templates/invoice/invoice_detail.html:48
+#: invoicing/templates/invoice/invoice_detail.html:49
 #: support/templates/debtor_contacts.html:117
 #: support/templates/history_extended.html:22
 msgid "Go to contact"
 msgstr "Ir al contacto"
 
-#: invoicing/templates/invoice/invoice_detail.html:57
+#: invoicing/templates/invoice/invoice_detail.html:58
 msgid "Go to subscriptions"
 msgstr "Ir a las suscripciones"
 
-#: invoicing/templates/invoice/invoice_detail.html:60
+#: invoicing/templates/invoice/invoice_detail.html:61
 msgid "Go to subscription in admin"
 msgstr "Ir a la suscripción en el admin"
 
-#: invoicing/templates/invoice/invoice_detail.html:64
+#: invoicing/templates/invoice/invoice_detail.html:65
 msgid "No subscription associated"
 msgstr "No hay suscripción asociada"
 
-#: invoicing/templates/invoice/invoice_detail.html:93
+#: invoicing/templates/invoice/invoice_detail.html:94
 msgid "Service Period"
 msgstr "Período de servicio"
 
-#: invoicing/templates/invoice/invoice_detail.html:113
+#: invoicing/templates/invoice/invoice_detail.html:114
 msgid "Payment Status"
 msgstr "Estado del pago"
 
-#: invoicing/templates/invoice/invoice_detail.html:126
+#: invoicing/templates/invoice/invoice_detail.html:127
 msgid "Payment Date"
 msgstr "Fecha del pago"
 
-#: invoicing/templates/invoice/invoice_detail.html:132
+#: invoicing/templates/invoice/invoice_detail.html:133
 msgid "Payment Reference"
 msgstr "Referencia del pago"
 
-#: invoicing/templates/invoice/invoice_detail.html:143
+#: invoicing/templates/invoice/invoice_detail.html:144
 msgid "Invoice Status"
 msgstr "Estado de la factura"
 
-#: invoicing/templates/invoice/invoice_detail.html:162
+#: invoicing/templates/invoice/invoice_detail.html:163
 msgid "Cancelation Date"
 msgstr "Fecha de anulación"
 
-#: invoicing/templates/invoice/invoice_detail.html:175
+#: invoicing/templates/invoice/invoice_detail.html:169
+#, fuzzy
+#| msgid "credit note"
+msgid "Credit Note"
+msgstr "nota de crédito"
+
+#: invoicing/templates/invoice/invoice_detail.html:178
+#, fuzzy
+#| msgid "Go to subscription in admin"
+msgid "Go to credit note in admin"
+msgstr "Ir a la suscripción en el admin"
+
+#: invoicing/templates/invoice/invoice_detail.html:206
 msgid "Billing Data"
 msgstr "Datos de facturación"
 
-#: invoicing/templates/invoice/invoice_detail.html:199
+#: invoicing/templates/invoice/invoice_detail.html:230
 msgid "Billing Document"
 msgstr "Documento de facturación"
 
-#: invoicing/templates/invoice/invoice_detail.html:210
+#: invoicing/templates/invoice/invoice_detail.html:241
 msgid "Invoice Items"
 msgstr "Items de la factura"
 
-#: invoicing/templates/invoice/invoice_detail.html:265
+#: invoicing/templates/invoice/invoice_detail.html:296
 msgid "Products Total"
 msgstr "Total de productos"
 
-#: invoicing/templates/invoice/invoice_detail.html:271
+#: invoicing/templates/invoice/invoice_detail.html:302
 msgid "Discounts Total"
 msgstr "Total de descuentos"
 
-#: invoicing/templates/invoice/invoice_detail.html:285 invoicing/views.py:220
-#: invoicing/views.py:234 logistics/models.py:287
+#: invoicing/templates/invoice/invoice_detail.html:316 invoicing/views.py:221
+#: invoicing/views.py:235 logistics/models.py:291
 #: logistics/templates/list_routes.html:37
 #: logistics/templates/list_routes_detailed.html:43
-#: logistics/templates/route_details.html:25
+#: logistics/templates/route_details.html:32
+#: support/templates/community_console.html:219
+#: support/templates/community_console.html:279
+#: support/templates/community_manager_dashboard.html:215
+#: support/templates/community_manager_dashboard.html:284
+#: support/templates/community_manager_overview.html:171
+#: support/templates/community_manager_overview.html:346
 msgid "Total"
 msgstr "Total"
 
 #: invoicing/templates/invoice_filter.html:4
-#: invoicing/templates/invoice_filter.html:28
+#: invoicing/templates/invoice_filter.html:58 invoicing/views.py:266
 #: templates/components/sidebar_items/_finances.html:32
 msgid "Invoice filter"
 msgstr "Filtro de facturas"
 
-#: invoicing/templates/invoice_filter.html:29
+#: invoicing/templates/invoice_filter.html:59
 msgid "Manage invoices."
 msgstr "Gestionar facturas."
 
-#: invoicing/templates/invoice_filter.html:40 invoicing/views.py:277
-#: support/templates/scheduled_activities.html:96
-#: support/views/all_views.py:626 support/views/all_views.py:709
-#: support/views/all_views.py:1343 support/views/all_views.py:1423
-#: support/views/all_views.py:1864 support/views/scheduled_tasks.py:233
+#: invoicing/templates/invoice_filter.html:68
+#, fuzzy
+#| msgid "Filter"
+msgid "Filters"
+msgstr "Filtro"
+
+#: invoicing/templates/invoice_filter.html:80 invoicing/views.py:294
+#: support/templates/scheduled_activities.html:164
+#: support/views/all_views.py:689 support/views/all_views.py:2022
+#: support/views/all_views.py:2118 support/views/all_views.py:2285
+#: support/views/all_views.py:2748 support/views/scheduled_tasks.py:233
 msgid "Contact name"
 msgstr "Nombre del contacto"
 
-#: invoicing/templates/invoice_filter.html:50
-#: support/templates/invoicing_issues.html:79
-#: support/templates/list_issues.html:155
-#: support/templates/unsubscription_statistics.html:53
-msgid "Creation date (from)"
-msgstr "Fecha de creación (desde)"
+#: invoicing/templates/invoice_filter.html:94
+msgid "Searches both phone and mobile"
+msgstr ""
 
-#: invoicing/templates/invoice_filter.html:54
-#: support/templates/invoicing_issues.html:83
-#: support/templates/list_issues.html:159
-#: support/templates/unsubscription_statistics.html:57
-msgid "Creation date (to)"
-msgstr "Fecha de creación (hasta)"
-
-#: invoicing/templates/invoice_filter.html:70
+#: invoicing/templates/invoice_filter.html:121
 msgid "Payment from"
 msgstr "Fecha de pago (desde)"
 
-#: invoicing/templates/invoice_filter.html:74
+#: invoicing/templates/invoice_filter.html:125
 msgid "Payment to"
 msgstr "Fecha de pago (hasta)"
 
-#: invoicing/templates/invoice_filter.html:78
+#: invoicing/templates/invoice_filter.html:129
 msgid "Series"
 msgstr "Serie"
 
-#: invoicing/templates/invoice_filter.html:86
+#: invoicing/templates/invoice_filter.html:137
 msgid "No serial"
 msgstr "Sin número de serie"
 
-#: invoicing/templates/invoice_filter.html:94
-#: support/templates/check_for_existing_contacts.html:68
-#: support/templates/check_for_existing_contacts.html:126
-#: support/templates/contact_list.html:62
+#: invoicing/templates/invoice_filter.html:145
+#: support/templates/check_for_existing_contacts.html:168
+#: support/templates/check_for_existing_contacts.html:250
+#: support/templates/contact_list.html:147
 #: support/templates/debtor_contacts.html:74
 #: support/templates/invoicing_issues.html:91
-#: support/templates/list_issues.html:178
+#: support/templates/list_issues.html:238
 #: support/templates/scheduled_task_filter.html:73
 #: support/templates/subscriptions/subscription_end_date_list.html:72
 msgid "Export to CSV"
 msgstr "Exportar a CSV"
 
-#: invoicing/templates/invoice_filter.html:110
-#: support/templates/scheduled_activities.html:75
+#: invoicing/templates/invoice_filter.html:174
+#: support/templates/scheduled_activities.html:136
 #: support/templates/subscriptions/subscription_end_date_list.html:70
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: invoicing/templates/invoice_filter.html:119 invoicing/views.py:276
+#: invoicing/templates/invoice_filter.html:227
+#: support/templates/contact_list.html:166
+msgid "Scroll horizontally to see all columns"
+msgstr ""
+
+#: invoicing/templates/invoice_filter.html:233 invoicing/views.py:293
 #: support/templates/invoicing_issues.html:102
-#: support/templates/list_issues.html:190 support/views/contacts.py:83
+#: support/templates/list_issues.html:250 support/views/contacts.py:151
 msgid "Id"
 msgstr "Id"
 
-#: invoicing/templates/invoice_filter.html:121 invoicing/views.py:278
+#: invoicing/templates/invoice_filter.html:235 invoicing/views.py:295
 msgid "Items"
 msgstr "Items"
 
-#: invoicing/templates/invoice_filter.html:128
+#: invoicing/templates/invoice_filter.html:242
 msgid "S/N"
 msgstr "S/N"
 
-#: invoicing/templates/invoice_filter.html:129
-#: invoicing/templates/invoice_filter.html:159
+#: invoicing/templates/invoice_filter.html:243
+#: invoicing/templates/invoice_filter.html:275
 #: logistics/templates/list_routes_detailed.html:59
 #: support/templates/campaign_statistics_list.html:82
+#: support/templates/contact_detail/tabs/_information.html:180
 msgid "Details"
 msgstr "Detalles"
 
-#: invoicing/templates/invoice_filter.html:140
+#: invoicing/templates/invoice_filter.html:256
 msgid "Invoice has no contact!"
 msgstr "Factura no tiene contacto!"
 
@@ -3608,14 +3987,6 @@ msgstr "Imprimir facturas"
 msgid "Emission"
 msgstr "Emisión"
 
-#: invoicing/templates/print.html:42
-msgid "Up to"
-msgstr "Hasta"
-
-#: invoicing/templates/print.html:42
-msgid "(inclusively)"
-msgstr "(inclusive)"
-
 #: invoicing/templates/print.html:50
 msgid "Print all invoices"
 msgstr "Imprimir todas las facturas"
@@ -3638,99 +4009,168 @@ msgstr "El cliente es deudor y no está autorizado para crear una suscripción."
 msgid "This subscription is not normal or corporate and should not be billed."
 msgstr "Esta suscripción no es normal o corporativa y no debe ser facturada."
 
-#: invoicing/utils.py:484
+#: invoicing/utils.py:489
 msgid "This subscription wasn't billed since amount is not greater than 0"
 msgstr "Esta suscripción no fue facturada ya que el monto no es mayor que 0"
 
-#: invoicing/views.py:90
+#: invoicing/views.py:91
 #, python-brace-format
 msgid "Invoice {} has been created successfully"
 msgstr "Factura {} ha sido creada exitosamente"
 
-#: invoicing/views.py:94 invoicing/views.py:458 support/location.py:93
-#: support/location.py:191 support/location.py:239
-#: support/views/activities.py:149 support/views/activities.py:200
-#: support/views/all_views.py:1787 support/views/contacts.py:134
-#: support/views/contacts.py:319 support/views/contacts.py:386
-#: support/views/contacts.py:734 support/views/scheduled_tasks.py:66
+#: invoicing/views.py:95 invoicing/views.py:501 logistics/views.py:1594
+#: logistics/views.py:1612 support/location.py:93 support/location.py:191
+#: support/location.py:239 support/views/activities.py:150
+#: support/views/activities.py:201 support/views/activities.py:226
+#: support/views/all_views.py:2650 support/views/contacts.py:58
+#: support/views/contacts.py:246 support/views/contacts.py:476
+#: support/views/contacts.py:544 support/views/contacts.py:1140
+#: support/views/contacts.py:1238 support/views/scheduled_tasks.py:66
 #: support/views/scheduled_tasks.py:137 support/views/scheduled_tasks.py:199
-#: support/views/subscriptions.py:63 support/views/subscriptions.py:514
-#: support/views/subscriptions.py:603 support/views/subscriptions.py:707
-#: support/views/subscriptions.py:831
+#: support/views/subscriptions.py:68 support/views/subscriptions.py:560
+#: support/views/subscriptions.py:772 support/views/subscriptions.py:879
+#: support/views/subscriptions.py:1000 support/views/subscriptions.py:1127
+#: support/views/subscriptions.py:1180 support/views/subscriptions.py:1430
+#: support/views/subscriptions.py:1617 support/views/subscriptions.py:2017
+#: support/views/subscriptions.py:2107
 msgid "Contact list"
 msgstr "Lista de contactos"
 
-#: invoicing/views.py:99 invoicing/views.py:463
+#: invoicing/views.py:100 invoicing/views.py:506
 msgid "Invoice detail"
 msgstr "Detalle de la factura"
 
-#: invoicing/views.py:156
+#: invoicing/views.py:157
 msgid "The invoice is already canceled"
 msgstr "La factura ya ha sido cancelada"
 
-#: invoicing/views.py:162
+#: invoicing/views.py:163
 msgid "This invoice already has credit notes."
 msgstr "Esta factura ya tiene notas de crédito."
 
-#: invoicing/views.py:167
+#: invoicing/views.py:168
 msgid "This invoice was successfully canceled"
 msgstr "Esta factura ha sido cancelada exitosamente"
 
-#: invoicing/views.py:169
+#: invoicing/views.py:170
 #, python-brace-format
 msgid "This invoice could not be canceled: {}"
 msgstr "Esta factura no pudo ser cancelada: {}"
 
-#: invoicing/views.py:212
+#: invoicing/views.py:213
 #, python-brace-format
 msgid "Issue date: {date}"
 msgstr "Fecha de emisión: {date}"
 
-#: invoicing/views.py:215
+#: invoicing/views.py:216
 #, python-brace-format
 msgid "Due date: {date}"
 msgstr "Fecha de vencimiento: {date}"
 
-#: invoicing/views.py:220
+#: invoicing/views.py:221
 msgid "Un."
 msgstr "Un."
 
-#: invoicing/views.py:222
+#: invoicing/views.py:223
 #, python-brace-format
 msgid "Subscription {id}"
 msgstr "Suscripción {id}"
 
-#: invoicing/views.py:244
+#: invoicing/views.py:245
 msgid "Original invoice"
 msgstr "Factura original"
 
-#: invoicing/views.py:248
+#: invoicing/views.py:249
 msgid "Customer invoice"
 msgstr "Factura al cliente"
 
-#: invoicing/views.py:279
+#: invoicing/views.py:296
 msgid "Contact id"
 msgstr "ID de contacto"
 
-#: invoicing/views.py:280
+#: invoicing/views.py:301
 msgid "Subscription id"
 msgstr "ID de suscripción"
 
-#: invoicing/views.py:281
+#: invoicing/views.py:302
 msgid "Subscription Payment Type"
 msgstr "Tipo de pago de la suscripción"
 
-#: invoicing/views.py:374
+#: invoicing/views.py:417
 msgid "Invoice is already canceled"
 msgstr "La factura ya ha sido cancelada"
 
-#: invoicing/views.py:379
+#: invoicing/views.py:422
 msgid "Invoice was canceled successfully"
 msgstr "La factura ha sido cancelada exitosamente"
 
-#: invoicing/views.py:381
+#: invoicing/views.py:424
 msgid "Invoice can't be canceled"
 msgstr "La factura no puede ser cancelada"
+
+#: invoicing/views.py:540
+#, fuzzy
+#| msgid "Mid"
+msgid "id"
+msgstr "Medio"
+
+#: invoicing/views.py:541
+#, fuzzy
+#| msgid "contact"
+msgid "contact_id"
+msgstr "contacto"
+
+#: invoicing/views.py:542
+#, fuzzy
+#| msgid "Cancelation date"
+msgid "cancelation_date"
+msgstr "Fecha de anulación"
+
+#: invoicing/views.py:544
+#, fuzzy
+#| msgid "Amount"
+msgid "amount"
+msgstr "Monto"
+
+#: invoicing/views.py:545
+#, fuzzy
+#| msgid "Uncollectible"
+msgid "uncollectible"
+msgstr "Incobrable"
+
+#: invoicing/views.py:546
+#, fuzzy
+#| msgid "Creation date"
+msgid "creation_date"
+msgstr "Fecha de creación"
+
+#: invoicing/views.py:547
+#, fuzzy
+#| msgid "Payment type"
+msgid "payment_type"
+msgstr "Tipo de pago"
+
+#: invoicing/views.py:548
+#, fuzzy
+#| msgid "Serie"
+msgid "serie"
+msgstr "Serie"
+
+#: invoicing/views.py:549
+msgid "numero"
+msgstr ""
+
+#: invoicing/views.py:550
+#, fuzzy
+#| msgid "credit notes"
+msgid "creditnote_serie"
+msgstr "notas de crédito"
+
+#: invoicing/views.py:551
+#, fuzzy
+#| msgid "credit note"
+msgid "creditnote_numero"
+msgstr "nota de crédito"
 
 #: logistics/choices.py:6
 msgid "To be confirmed"
@@ -3773,7 +4213,19 @@ msgid "No day"
 msgstr "Sin día"
 
 #: logistics/filters.py:23 logistics/filters.py:29
-#: logistics/templates/order_routes_list.html:38
+#: logistics/templates/order_routes_list.html:38 support/filters.py:174
+#: support/templates/community_console.html:117
+#: support/templates/community_console.html:217
+#: support/templates/community_console.html:356
+#: support/templates/community_manager_assign.html:84
+#: support/templates/community_manager_assign.html:138
+#: support/templates/community_manager_dashboard.html:213
+#: support/templates/community_manager_dashboard.html:365
+#: support/templates/community_manager_overview.html:166
+#: support/templates/community_manager_overview.html:239
+#: support/templates/community_manager_overview.html:423
+#: support/templates/scheduled_activities.html:89
+#: support/templates/scheduled_activities.html:155
 msgid "Future"
 msgstr "Futuro"
 
@@ -3793,7 +4245,7 @@ msgstr "Lugar de entrega"
 msgid "Arrival time"
 msgstr "Hora de llegada"
 
-#: logistics/models.py:33 logistics/models.py:325
+#: logistics/models.py:33 logistics/models.py:329
 msgid "Additional copies"
 msgstr "Copia adicional"
 
@@ -3897,56 +4349,56 @@ msgstr "Dirección antigua"
 msgid "Old city"
 msgstr "Ciudad antigua"
 
-#: logistics/models.py:265
+#: logistics/models.py:269
 msgid "route change"
 msgstr "cambio de ruta"
 
-#: logistics/models.py:266
+#: logistics/models.py:270
 msgid "route changes"
 msgstr "cambios de ruta"
 
-#: logistics/models.py:281
+#: logistics/models.py:285 support/models.py:27
 msgid "Start time"
 msgstr "Hora de inicio"
 
-#: logistics/models.py:282
+#: logistics/models.py:286
 msgid "End Time"
 msgstr "Hora de fin"
 
-#: logistics/models.py:283
+#: logistics/models.py:287
 msgid "Standard"
 msgstr "Estándar"
 
-#: logistics/models.py:285
+#: logistics/models.py:289
 msgid "Free"
 msgstr "Gratis"
 
-#: logistics/models.py:286 logistics/models.py:315
+#: logistics/models.py:290 logistics/models.py:319
 msgid "Promotions"
 msgstr "Promociones"
 
-#: logistics/models.py:300
+#: logistics/models.py:304
 msgid "edition"
 msgstr "edición"
 
-#: logistics/models.py:301
+#: logistics/models.py:305
 msgid "editions"
 msgstr "ediciones"
 
-#: logistics/models.py:305
+#: logistics/models.py:309
 #, python-brace-format
 msgid "Edition {product} {date}"
 msgstr "Edición {product} {date}"
 
-#: logistics/models.py:313
+#: logistics/models.py:317
 msgid "Edition"
 msgstr "Edición"
 
-#: logistics/models.py:318
+#: logistics/models.py:322
 msgid "edition route"
 msgstr "ruta de edición"
 
-#: logistics/models.py:319
+#: logistics/models.py:323
 msgid "edition routes"
 msgstr "rutas de edición"
 
@@ -3991,6 +4443,7 @@ msgstr "Filtrar por producto"
 #: logistics/templates/change_route.html:48
 #: logistics/templates/print_routes_simple.html:51
 #: logistics/templates/print_unordered_subscriptions_form.html:33
+#: support/filters.py:450 support/views/all_views.py:956
 msgid "All"
 msgstr "Todos"
 
@@ -4013,6 +4466,11 @@ msgstr "Departamento"
 #: logistics/templates/order_route_print.html:23
 #: logistics/templates/print_routes_simple.html:71
 #: logistics/templates/print_unordered_subscriptions_list.html:25
+#: support/templates/free_subscription_form.html:216
+#: support/templates/free_subscription_form.html:263
+#: support/templates/free_subscription_form.html:309
+#: support/templates/new_subscription.html:365
+#: support/templates/seller_console_start_promo.html:209
 msgid "Message"
 msgstr "Mensaje"
 
@@ -4023,41 +4481,34 @@ msgstr "Mensaje"
 #: logistics/templates/order_route_print.html:24
 #: logistics/templates/print_routes_simple.html:72
 #: logistics/templates/print_unordered_subscriptions_list.html:26
-#: support/templates/check_for_existing_contacts.html:41
+#: support/templates/add_retention_discount.html:72
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:37
+#: support/templates/free_subscription_form.html:222
+#: support/templates/free_subscription_form.html:269
+#: support/templates/free_subscription_form.html:315
+#: support/templates/import_contacts.html:30
+#: support/templates/new_subscription.html:375
+#: support/templates/seller_console_start_promo.html:215
 msgid "Instructions"
 msgstr "Instrucciones"
 
 #: logistics/templates/assign_routes.html:85
-#: logistics/templates/change_route.html:108
+#: logistics/templates/change_route.html:115
 #: logistics/templates/edition_time.html:25
 #: logistics/templates/order_route.html:151
+#: support/templates/add_retention_discount.html:223
 #: support/templates/book_additional_product.html:140
 #: support/templates/book_partial_unsubscription.html:98
 #: support/templates/book_product_change.html:123
 #: support/templates/book_unsubscription.html:72
-#: support/templates/new_issue.html:231
-#: support/templates/new_scheduled_task_address_change.html:235
-#: support/templates/new_scheduled_task_partial_pause.html:143
-#: support/templates/new_scheduled_task_total_pause.html:130
-#: support/templates/new_subscription.html:185
-#: support/templates/new_subscription.html:349
-#: support/templates/seller_console_start_promo.html:187
-#: support/templates/view_issue.html:252 support/views/subscriptions.py:903
+#: support/templates/new_scheduled_task_address_change.html:266
+#: support/templates/new_scheduled_task_partial_pause.html:185
+#: support/templates/new_scheduled_task_total_pause.html:161
+#: support/templates/new_subscription.html:236
+#: support/templates/new_subscription.html:402
+#: support/templates/seller_console_start_promo.html:228
 msgid "Send"
 msgstr "Enviar"
-
-#: logistics/templates/change_route.html:17
-#: logistics/templates/list_routes.html:18
-#: logistics/templates/list_routes.html:23
-#: logistics/templates/list_routes.html:29
-#: logistics/templates/list_routes_detailed.html:22
-#: logistics/templates/list_routes_detailed.html:28
-#: logistics/templates/order_route.html:33
-#: logistics/templates/order_routes_list.html:23
-#: logistics/templates/order_routes_list.html:29
-#: logistics/templates/print_routes_simple.html:24
-msgid "All routes"
-msgstr "Todas las rutas"
 
 #: logistics/templates/change_route.html:17
 #: logistics/templates/change_route.html:22
@@ -4067,6 +4518,179 @@ msgstr "Cambiar ruta"
 #: logistics/templates/change_route.html:29
 msgid "Change route to subscription products"
 msgstr "Cambiar ruta a productos de suscripción"
+
+#: logistics/templates/change_route.html:69
+#, fuzzy
+#| msgid "Issue Date"
+msgid "Issue notes"
+msgstr "Fecha de emisión"
+
+#: logistics/templates/change_route.html:69
+#, fuzzy
+#| msgid "Special route"
+msgid "for special routes"
+msgstr "Ruta especial"
+
+#: logistics/templates/change_route.html:99
+#, fuzzy
+#| msgid "Contacts in special routes"
+msgid "Custom notes for issue (only for special routes)"
+msgstr "Contactos en rutas especiales"
+
+#: logistics/templates/change_subscription_routes.html:50
+#: logistics/templates/change_subscription_routes.html:55
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:220
+#, fuzzy
+#| msgid "Change route"
+msgid "Change Routes"
+msgstr "Cambiar ruta"
+
+#: logistics/templates/change_subscription_routes.html:62
+#, fuzzy
+#| msgid "Change route to subscription products"
+msgid "Change Routes for Subscription Products"
+msgstr "Cambiar ruta a productos de suscripción"
+
+#: logistics/templates/change_subscription_routes.html:66
+#: support/templates/activities/activity_detail.html:176
+#, fuzzy
+#| msgid "Back to contact"
+msgid "Back to Contact"
+msgstr "Volver al contacto"
+
+#: logistics/templates/change_subscription_routes.html:73
+#: support/templates/add_retention_discount.html:91
+#: support/templates/import_contacts.html:210
+#, fuzzy
+#| msgid "Importance"
+msgid "Important:"
+msgstr "Importancia"
+
+#: logistics/templates/change_subscription_routes.html:74
+#, fuzzy
+#| msgid "This is not a special route."
+msgid "Changing a route to a special route"
+msgstr "Esta no es una ruta especial."
+
+#: logistics/templates/change_subscription_routes.html:74
+msgid ""
+"will automatically create a logistics issue with subcategory 'not-delivered'."
+msgstr ""
+
+#: logistics/templates/change_subscription_routes.html:79
+#, fuzzy
+#| msgid "Subscription Period"
+msgid "Subscription Information:"
+msgstr "Período de suscripción"
+
+#: logistics/templates/change_subscription_routes.html:80
+#: support/templates/seller_console.html:479
+msgid "Type:"
+msgstr "Tipo:"
+
+#: logistics/templates/change_subscription_routes.html:81
+#: support/templates/seller_console.html:446
+msgid "Status:"
+msgstr "Estado:"
+
+#: logistics/templates/change_subscription_routes.html:82
+#, fuzzy
+#| msgid "Start"
+msgid "Start:"
+msgstr "Inicio"
+
+#: logistics/templates/change_subscription_routes.html:84
+msgid "End:"
+msgstr ""
+
+#: logistics/templates/change_subscription_routes.html:98
+#, fuzzy
+#| msgid "Parent route"
+msgid "Current Route"
+msgstr "Ruta padre"
+
+#: logistics/templates/change_subscription_routes.html:99
+#, fuzzy
+#| msgid "Route"
+msgid "New Route"
+msgstr "Ruta"
+
+#: logistics/templates/change_subscription_routes.html:100
+#: logistics/templates/route_details.html:112
+#: logistics/templates/route_details.html:114
+msgid "Label Message"
+msgstr "Mensaje de etiqueta"
+
+#: logistics/templates/change_subscription_routes.html:131
+#, fuzzy
+#| msgid "route"
+msgid "No route"
+msgstr "ruta"
+
+#: logistics/templates/change_subscription_routes.html:138
+#: logistics/templates/change_subscription_routes.html:236
+#, fuzzy
+#| msgid "Select products"
+msgid "Select route"
+msgstr "Seleccionar productos"
+
+#: logistics/templates/change_subscription_routes.html:156
+#, fuzzy
+#| msgid "Label message"
+msgid "Optional message"
+msgstr "Mensaje de etiqueta"
+
+#: logistics/templates/change_subscription_routes.html:167
+#: logistics/templates/route_details.html:104
+#: logistics/templates/route_details.html:106
+msgid "Special Instructions"
+msgstr "Instrucciones especiales"
+
+#: logistics/templates/change_subscription_routes.html:168
+msgid "Add any special instructions for each product below:"
+msgstr ""
+
+#: logistics/templates/change_subscription_routes.html:185
+#, fuzzy
+#| msgid "Special instructions"
+msgid "Special instructions for delivery"
+msgstr "Instrucciones especiales"
+
+#: logistics/templates/change_subscription_routes.html:192
+#, fuzzy
+#| msgid "This is not a special route."
+msgid "Issue Notes for Special Routes"
+msgstr "Esta no es una ruta especial."
+
+#: logistics/templates/change_subscription_routes.html:193
+#, fuzzy
+#| msgid "This is not a special route."
+msgid "If changing to a special route"
+msgstr "Esta no es una ruta especial."
+
+#: logistics/templates/change_subscription_routes.html:193
+msgid "a single issue will be created. You can add custom notes below:"
+msgstr ""
+
+#: logistics/templates/change_subscription_routes.html:198
+msgid "Custom notes for the issue (only used when changing to special routes)"
+msgstr ""
+
+#: logistics/templates/change_subscription_routes.html:207
+#, fuzzy
+#| msgid "route changes"
+msgid "Save Route Changes"
+msgstr "cambios de ruta"
+
+#: logistics/templates/change_subscription_routes.html:214
+#, fuzzy
+#| msgid "This subscription has no sales record."
+msgid "This subscription has no products to update."
+msgstr "Esta suscripción no tiene un registro de venta."
+
+#: logistics/templates/change_subscription_routes.html:286
+msgid "Special route - Issue will be created"
+msgstr ""
 
 #: logistics/templates/edition_time.html:5
 #: logistics/templates/edition_time.html:9
@@ -4090,7 +4714,10 @@ msgstr "Incidentes por ruta"
 msgid "URL"
 msgstr "URL"
 
-#: logistics/templates/issues_per_route.html:64
+#: logistics/templates/issues_per_route.html:64 support/models.py:153
+#: support/templates/activities/activity_detail.html:109
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:139
+#: support/templates/reactivate_subscription.html:83
 msgid "Manager"
 msgstr "Gerente"
 
@@ -4120,8 +4747,8 @@ msgid "Route Number"
 msgstr "Número de ruta"
 
 #: logistics/templates/issues_route_list.html:37
-#: support/templates/contact_list.html:41
-#: support/templates/debtor_contacts.html:47 support/views/contacts.py:225
+#: support/templates/contact_list.html:122
+#: support/templates/debtor_contacts.html:47 support/views/contacts.py:381
 msgid "Active subscriptions"
 msgstr "Suscripciones activas"
 
@@ -4129,10 +4756,10 @@ msgstr "Suscripciones activas"
 #: logistics/templates/issues_statistics.html:31
 #: logistics/templates/issues_statistics.html:62
 #: logistics/templates/issues_statistics.html:91
-#: logistics/templates/route_details.html:128 support/models.py:160
-#: support/templates/contact_detail/detail.html:113
-#: support/templates/history_extended.html:129 support/views/all_views.py:573
-#: support/views/all_views.py:679
+#: logistics/templates/merge_compare_addresses.html:347
+#: logistics/templates/route_details.html:135 support/models.py:205
+#: support/templates/contact_detail/detail.html:137
+#: support/templates/history_extended.html:129 support/views/all_views.py:612
 #: templates/components/sidebar_items/_support.html:23
 msgid "Issues"
 msgstr "Incidencias"
@@ -4145,6 +4772,18 @@ msgstr "Proporción"
 #: logistics/templates/issues_statistics.html:9
 msgid "Issues statistics"
 msgstr "Estadísticas de incidencias"
+
+#: logistics/templates/list_routes.html:18
+#: logistics/templates/list_routes.html:23
+#: logistics/templates/list_routes.html:29
+#: logistics/templates/list_routes_detailed.html:22
+#: logistics/templates/list_routes_detailed.html:28
+#: logistics/templates/order_route.html:33
+#: logistics/templates/order_routes_list.html:23
+#: logistics/templates/order_routes_list.html:29
+#: logistics/templates/print_routes_simple.html:24
+msgid "All routes"
+msgstr "Todas las rutas"
 
 #: logistics/templates/list_routes.html:37
 #: logistics/templates/list_routes.html:48
@@ -4166,6 +4805,9 @@ msgstr "Mañana"
 #: logistics/templates/list_routes.html:40
 #: logistics/templates/list_routes_detailed.html:44
 #: logistics/templates/order_routes_list.html:39
+#: support/templates/community_manager_dashboard.html:216
+#: support/templates/contact_list.html:179
+#: support/templates/seller_console_never_paid_issues.html:33
 #: support/templates/subscriptions/subscription_end_date_list.html:92
 #: support/templates/tag_analysis.html:97
 msgid "Actions"
@@ -4195,16 +4837,16 @@ msgid "Re-route"
 msgstr "Re-ruteo"
 
 #: logistics/templates/mass_georef_address_filter.html:4
-#: support/templates/scheduled_activities.html:16
+#: support/templates/scheduled_activities.html:34
 msgid "Scheduled activities"
 msgstr "Actividades programadas"
 
 #: logistics/templates/mass_georef_address_filter.html:31
 #: logistics/templates/order_route.html:55
 #: support/templates/campaign_statistics_list.html:48
-#: support/templates/contact_list.html:33
-#: support/templates/sales_record_filter.html:84
-#: support/templates/scheduled_activities.html:29
+#: support/templates/sales_record_filter.html:126
+#: support/templates/scheduled_activities.html:47
+#: support/templates/support/seller_attendance_filter.html:99
 #: support/templates/tag_analysis.html:35
 #: support/templates/unsubscription_statistics.html:41
 #: support/templates/unsubscription_statistics.html:65
@@ -4219,6 +4861,318 @@ msgstr "Necesita georeferenciación"
 #: logistics/templates/mass_georef_address_filter.html:50
 msgid "Active sub."
 msgstr "Suscripción act."
+
+#: logistics/templates/merge_compare_addresses.html:5
+#: logistics/templates/merge_compare_addresses.html:412
+#: support/templates/contact_detail/tabs/_overview.html:85
+#, fuzzy
+#| msgid "Delete address"
+msgid "Merge duplicate addresses"
+msgstr "Eliminar dirección"
+
+#: logistics/templates/merge_compare_addresses.html:12
+#, fuzzy
+#| msgid "Select day and options"
+msgid "Select data and address to keep"
+msgstr "Seleccionar día y opciones"
+
+#: logistics/templates/merge_compare_addresses.html:17
+msgid "Warning: Addresses appear to be very different"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:19
+msgid ""
+"The street addresses you are merging appear to be significantly different"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:19
+msgid "similar"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:20
+msgid ""
+"Please verify you have selected the correct addresses before proceeding. "
+"Merging unrelated addresses cannot be undone."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:37
+#, fuzzy
+#| msgid "Distributor"
+msgid "Attribute"
+msgstr "Distribuidor"
+
+#: logistics/templates/merge_compare_addresses.html:40
+msgid "Keep this value"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:66
+#, fuzzy
+#| msgid "Label contact"
+msgid "Same contact"
+msgstr "Contacto de etiqueta"
+
+#: logistics/templates/merge_compare_addresses.html:68
+#, fuzzy
+#| msgid "Current contact"
+msgid "Different contacts"
+msgstr "Contacto actual"
+
+#: logistics/templates/merge_compare_addresses.html:76
+#, fuzzy
+#| msgid "Delete address"
+msgid "Street address"
+msgstr "Eliminar dirección"
+
+#: logistics/templates/merge_compare_addresses.html:95
+msgid "Apartment, suite, etc."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:114
+#, fuzzy
+#| msgid ""
+#| "Name of the address. It can be a reference to the address or the name of "
+#| "the person"
+msgid ""
+"Reference name for this address. It can reference the person or the address "
+"itself."
+msgstr ""
+"Nombre de la dirección, puede ser una referencia a la dirección o al nombre "
+"de la persona"
+
+#: logistics/templates/merge_compare_addresses.html:132
+msgid "text"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:133
+msgid "City name as text"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:152
+msgid "City from database"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:169
+msgid "State/Province/Department"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:203
+#, fuzzy
+#| msgid "Edit address"
+msgid "Email for this address"
+msgstr "Editar dirección"
+
+#: logistics/templates/merge_compare_addresses.html:222
+msgid "Physical/Postal/Billing"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:239
+#, fuzzy
+#| msgid "Invoices for contact:"
+msgid "Primary address for contact"
+msgstr "Facturas para el contacto:"
+
+#: logistics/templates/merge_compare_addresses.html:253
+msgid "Coordinates"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:254
+msgid "GPS coordinates (lat, long)"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:273
+msgid "Latitude"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:280
+msgid "Longitude"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:292
+#, fuzzy
+#| msgid "Google Maps Link"
+msgid "Google Maps URL"
+msgstr "Enlace de Google Maps"
+
+#: logistics/templates/merge_compare_addresses.html:293
+msgid "Link to location on map"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:298
+#: logistics/templates/merge_compare_addresses.html:307
+#, fuzzy
+#| msgid "View"
+msgid "View map"
+msgstr "Ver"
+
+#: logistics/templates/merge_compare_addresses.html:326
+#, fuzzy
+#| msgid "General information"
+msgid "Additional information"
+msgstr "Información general"
+
+#: logistics/templates/merge_compare_addresses.html:332
+#, fuzzy
+#| msgid "Generated automatically on {}\n"
+msgid "Merge notes automatically"
+msgstr "Generado automáticamente el {}\n"
+
+#: logistics/templates/merge_compare_addresses.html:333
+msgid "Only notes from address 1"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:334
+msgid "Only notes from address 2"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:340
+#: support/templates/edit_envelopes.html:36
+msgid "Subscription products"
+msgstr "Productos de suscripción"
+
+#: logistics/templates/merge_compare_addresses.html:354 support/models.py:371
+#: templates/components/sidebar_items/_support.html:50
+msgid "Scheduled tasks"
+msgstr "Tareas programadas"
+
+#: logistics/templates/merge_compare_addresses.html:367
+#, fuzzy
+#| msgid "Address type"
+msgid "Address to keep"
+msgstr "Tipo de dirección"
+
+#: logistics/templates/merge_compare_addresses.html:368
+msgid "the other will be permanently deleted"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:388
+#, fuzzy
+#| msgid "Executed"
+msgid "Execute merge"
+msgstr "Ejecutado"
+
+#: logistics/templates/merge_compare_addresses.html:395
+#, fuzzy
+#| msgid "Contact information"
+msgid "Important information"
+msgstr "Información del contacto"
+
+#: logistics/templates/merge_compare_addresses.html:397
+msgid ""
+"All related objects (subscription products, issues, and scheduled tasks) "
+"will be transferred to the selected address."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:398
+msgid ""
+"The address you don't select will be permanently deleted from the database."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:399
+msgid "Green rows indicate matching values between addresses."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:400
+msgid "Yellow rows indicate different values - select which one to keep."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:401
+msgid ""
+"For notes, you can choose to merge them automatically or keep only one set."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:402
+msgid ""
+"This action cannot be undone. Please review carefully before proceeding."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:425
+#, fuzzy
+#| msgid "Edit address"
+msgid "First address"
+msgstr "Editar dirección"
+
+#: logistics/templates/merge_compare_addresses.html:427
+#: logistics/templates/merge_compare_addresses.html:438
+#, fuzzy
+#| msgid "Delete address"
+msgid "Select an address..."
+msgstr "Eliminar dirección"
+
+#: logistics/templates/merge_compare_addresses.html:436
+#, fuzzy
+#| msgid "Save address"
+msgid "Second address"
+msgstr "Guardar dirección"
+
+#: logistics/templates/merge_compare_addresses.html:449
+msgid ""
+"You cannot select the same address twice. Please choose two different "
+"addresses."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:457
+#: logistics/templates/merge_compare_addresses.html:515
+#, fuzzy
+#| msgid "Change address"
+msgid "Compare addresses"
+msgstr "Cambiar dirección"
+
+#: logistics/templates/merge_compare_addresses.html:502
+#, fuzzy
+#| msgid "Address 1"
+msgid "Address 1 ID"
+msgstr "Dirección línea 1"
+
+#: logistics/templates/merge_compare_addresses.html:503
+#, fuzzy
+#| msgid "Edit address"
+msgid "Enter first address ID"
+msgstr "Editar dirección"
+
+#: logistics/templates/merge_compare_addresses.html:506
+#, fuzzy
+#| msgid "Address 2"
+msgid "Address 2 ID"
+msgstr "Dirección línea 2"
+
+#: logistics/templates/merge_compare_addresses.html:507
+#, fuzzy
+#| msgid "currently on address"
+msgid "Enter second address ID"
+msgstr "actualmente en dirección"
+
+#: logistics/templates/merge_compare_addresses.html:522
+msgid "How to use this tool"
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:525
+msgid "Select two different addresses from the dropdowns above."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:527
+msgid "Enter the IDs of two addresses you want to merge."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:529
+msgid ""
+"On the next screen, you'll see a side-by-side comparison of all address "
+"fields."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:530
+msgid ""
+"For each field, select which value you want to keep in the merged address."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:531
+msgid "Choose which address to keep (the other will be deleted)."
+msgstr ""
+
+#: logistics/templates/merge_compare_addresses.html:532
+msgid ""
+"All related objects will be automatically transferred to the address you "
+"keep."
+msgstr ""
 
 #: logistics/templates/order_route.html:17
 msgid "Accept"
@@ -4299,6 +5253,16 @@ msgstr "Seleccionar opciones"
 
 #: logistics/templates/print_labels.html:22
 #: logistics/templates/print_labels_for_day.html:40
+#: support/templates/free_subscription_form.html:219
+#: support/templates/free_subscription_form.html:225
+#: support/templates/free_subscription_form.html:266
+#: support/templates/free_subscription_form.html:272
+#: support/templates/free_subscription_form.html:312
+#: support/templates/free_subscription_form.html:318
+#: support/templates/new_subscription.html:372
+#: support/templates/new_subscription.html:381
+#: support/templates/seller_console_start_promo.html:212
+#: support/templates/seller_console_start_promo.html:218
 msgid "Optional"
 msgstr "Opcional"
 
@@ -4309,7 +5273,7 @@ msgstr ""
 
 #: logistics/templates/print_labels.html:26
 #: logistics/templates/print_labels_for_day.html:44
-#: logistics/templates/print_labels_from_csv.html:37
+#: logistics/templates/print_labels_from_csv.html:38
 msgid "Generate PDF with labels"
 msgstr "Generar PDF con etiquetas"
 
@@ -4327,17 +5291,13 @@ msgid "Select day"
 msgstr "Seleccionar día"
 
 #: logistics/templates/print_labels_for_day.html:36
-#: logistics/templates/print_labels_from_csv.html:30
+#: logistics/templates/print_labels_from_csv.html:31
 msgid "96x30 labels"
 msgstr "Etiquetas 96x30"
 
 #: logistics/templates/print_labels_for_day.html:40
 msgid "Upload CSV with contacts to exclude"
 msgstr "Cargar CSV con contactos para excluir"
-
-#: logistics/templates/print_labels_for_product_date.html:39
-msgid "Download CSV"
-msgstr "Descargar CSV"
 
 #: logistics/templates/print_labels_from_csv.html:9
 #: logistics/templates/print_labels_from_csv.html:15
@@ -4376,11 +5336,17 @@ msgstr "La línea de encabezado será ignorada."
 msgid "Only name and address are mandatory"
 msgstr "Solo el nombre y la dirección son obligatorios"
 
-#: logistics/templates/print_labels_from_csv.html:24
+#: logistics/templates/print_labels_from_csv.html:23
+#, fuzzy
+#| msgid "Download CSV Template"
+msgid "Download CSV template"
+msgstr "Descargar plantilla CSV"
+
+#: logistics/templates/print_labels_from_csv.html:25
 msgid "Upload CSV with data"
 msgstr "Subir CSV con datos"
 
-#: logistics/templates/print_labels_from_csv.html:33
+#: logistics/templates/print_labels_from_csv.html:34
 msgid "Use separators"
 msgstr "Usar separadores"
 
@@ -4410,97 +5376,168 @@ msgid "List of unordered products"
 msgstr "Lista de productos sin ordenar"
 
 #: logistics/templates/route_details.html:11
-msgid "Route details"
-msgstr "Detalles de la ruta"
+#, fuzzy
+#| msgid "List of issues"
+msgid "List of routes"
+msgstr "Lista de incidencias"
 
-#: logistics/templates/route_details.html:32
+#: logistics/templates/route_details.html:39
 msgid "Contacts in route"
 msgstr "Contactos en la ruta"
 
-#: logistics/templates/route_details.html:45
+#: logistics/templates/route_details.html:52
 msgid "Address/Instructions"
 msgstr "Dirección/Instrucciones"
 
-#: logistics/templates/route_details.html:97
-#: logistics/templates/route_details.html:99
-#: support/templates/new_subscription.html:322
-#: support/templates/seller_console_start_promo.html:177
-msgid "Special Instructions"
-msgstr "Instrucciones especiales"
-
-#: logistics/templates/route_details.html:105
-#: logistics/templates/route_details.html:107
-#: support/templates/new_subscription.html:311
-#: support/templates/seller_console_start_promo.html:172
-msgid "Label Message"
-msgstr "Mensaje de etiqueta"
-
-#: logistics/templates/route_details.html:117
+#: logistics/templates/route_details.html:124
 msgid "Changes in route"
 msgstr "Cambios en la ruta"
 
-#: logistics/templates/route_details.html:135
+#: logistics/templates/route_details.html:142
 msgid "Issue type"
 msgstr "Tipo de incidencia"
 
-#: logistics/templates/route_details.html:164
+#: logistics/templates/route_details.html:171
 msgid "Closing subscriptions"
 msgstr "Cierre de suscripciones"
 
-#: logistics/views.py:57 logistics/views.py:117 logistics/views.py:317
+#: logistics/utils.py:63
+#, python-brace-format
+msgid "Generated automatically for change of route to special route (route {})"
+msgstr ""
+
+#: logistics/utils.py:65
+#, fuzzy, python-brace-format
+#| msgid "Generated automatically on {today}\n"
+msgid "Generated automatically for change of routes to special routes ({})"
+msgstr "Generado automáticamente el {today}\n"
+
+#: logistics/views.py:63 logistics/views.py:123 logistics/views.py:334
 #, python-brace-format
 msgid "Contact {} - Product {}: Route {} does not exist"
 msgstr "Contacto {} - Producto {}: Ruta {} no existe"
 
-#: logistics/views.py:498 logistics/views.py:626 logistics/views.py:888
+#: logistics/views.py:345
+#, python-brace-format
+msgid "Routes updated. Issues created for special routes: {}"
+msgstr ""
+
+#: logistics/views.py:368
+#, fuzzy
+#| msgid "Change route"
+msgid "Change routes"
+msgstr "Cambiar ruta"
+
+#: logistics/views.py:531 logistics/views.py:659 logistics/views.py:921
 msgid "MONDAY"
 msgstr "LUNES"
 
-#: logistics/views.py:500 logistics/views.py:628 logistics/views.py:890
+#: logistics/views.py:533 logistics/views.py:661 logistics/views.py:923
 msgid "TUESDAY"
 msgstr "MARTES"
 
-#: logistics/views.py:502 logistics/views.py:630 logistics/views.py:892
+#: logistics/views.py:535 logistics/views.py:663 logistics/views.py:925
 msgid "WEDNESDAY"
 msgstr "MIÉRCOLES"
 
-#: logistics/views.py:504 logistics/views.py:632 logistics/views.py:894
+#: logistics/views.py:537 logistics/views.py:665 logistics/views.py:927
 msgid "THURSDAY"
 msgstr "JUEVES"
 
-#: logistics/views.py:506 logistics/views.py:634 logistics/views.py:896
+#: logistics/views.py:539 logistics/views.py:667 logistics/views.py:929
 msgid "FRIDAY"
 msgstr "VIERNES"
 
-#: logistics/views.py:825
+#: logistics/views.py:858
 msgid "Columns count is wrong"
 msgstr "La cantidad de columnas es incorrecta"
 
-#: logistics/views.py:898
+#: logistics/views.py:931
 msgid "SATURDAY"
 msgstr "SÁBADO"
 
-#: logistics/views.py:900
+#: logistics/views.py:933
 msgid "SUNDAY"
 msgstr "DOMINGO"
 
-#: logistics/views.py:902
+#: logistics/views.py:935
 msgid "WEEKEND"
 msgstr "FIN DE SEMANA"
 
-#: logistics/views.py:1029
+#: logistics/views.py:1124
 #, python-brace-format
 msgid "{} time"
 msgstr "{} veces"
 
-#: logistics/views.py:1191
+#: logistics/views.py:1286
 #, python-brace-format
 msgid "Route {} does not exist"
 msgstr "Ruta {} no existe"
 
-#: logistics/views.py:1247
+#: logistics/views.py:1342
 msgid "All orders have been converted to tens."
 msgstr "Todas las órdenes han sido convertidas a decenas."
+
+#: logistics/views.py:1584
+#, fuzzy
+#| msgid "addresses"
+msgid "Merge addresses"
+msgstr "direcciones"
+
+#: logistics/views.py:1639
+msgid "Contact must have at least 2 addresses to merge"
+msgstr ""
+
+#: logistics/views.py:1647
+#, fuzzy, python-brace-format
+#| msgid "Route {} does not exist"
+msgid "Contact {id} does not exist"
+msgstr "Ruta {} no existe"
+
+#: logistics/views.py:1653
+msgid "Address IDs must be different"
+msgstr ""
+
+#: logistics/views.py:1659 logistics/views.py:1665
+#, fuzzy, python-brace-format
+#| msgid "Route {} does not exist"
+msgid "Address {id} does not exist"
+msgstr "Ruta {} no existe"
+
+#: logistics/views.py:1733
+#, fuzzy
+#| msgid "Route {} does not exist"
+msgid "One of the addresses does not exist"
+msgstr "Ruta {} no existe"
+
+#: logistics/views.py:1796
+#, python-brace-format
+msgid ""
+"Addresses merged into address {id}. Address {source_id} has been deleted."
+msgstr ""
+
+#: logistics/views.py:1850
+#, fuzzy, python-brace-format
+#| msgid "Contact {} - Product {}: Route {} does not exist"
+msgid "Product {}: Route {} does not exist"
+msgstr "Contacto {} - Producto {}: Ruta {} no existe"
+
+#: logistics/views.py:1856
+#, fuzzy
+#| msgid "Subscription product"
+msgid "Subscription product not found"
+msgstr "Producto de suscripción"
+
+#: logistics/views.py:1868
+#, python-brace-format
+msgid "Routes updated. Issue created for special routes: {}"
+msgstr ""
+
+#: logistics/views.py:1871 logistics/views.py:1873
+#, fuzzy
+#| msgid "Contact saved successfully"
+msgid "Routes updated successfully"
+msgstr "Contacto guardado exitosamente"
 
 #: migration_settings.py:37 settings.py:30
 msgid "English"
@@ -4510,315 +5547,455 @@ msgstr "INGLÉS"
 msgid "Spanish"
 msgstr "ESPAÑOL"
 
+#: support/admin.py:110
+#, fuzzy
+#| msgid "Products"
+msgid "Products & price"
+msgstr "Productos"
+
+#: support/admin.py:112
+#, fuzzy
+#| msgid "Commission"
+msgid "Commissions"
+msgstr "Comisión"
+
 #: support/apps.py:7 support/templates/assign_sellers.html:7
 #: support/templates/distribute_campaigns.html:7
 #: support/templates/dynamic_contact_filter.html:7
 #: support/templates/dynamic_contact_filter_details.html:9
 #: support/templates/invoicing_issues.html:34
 #: support/templates/scheduled_task_filter.html:25
-#: support/templates/seller_console_start_promo.html:75
-#: support/templates/tag_contacts.html:19
-#: support/templates/tag_contacts.html:24
+#: support/templates/seller_console_start_promo.html:100
+#: support/templates/tag_contacts.html:7
 #: support/templates/upload_do_not_call_numbers.html:7
 #: templates/components/sidebar_items/_support.html:14
 msgid "Support"
 msgstr "Soporte"
 
-#: support/choices.py:6
+#: support/choices.py:16 support/choices.py:35
+#: support/templates/new_issue.html:209
+msgid "Collections"
+msgstr "Cobranza"
+
+#: support/choices.py:17 support/choices.py:36
+#: support/templates/new_issue.html:216
+msgid "Contents"
+msgstr "Contenido"
+
+#: support/choices.py:18 support/choices.py:37
+#: support/templates/new_issue.html:223
+msgid "Web"
+msgstr "Web"
+
+#: support/choices.py:19 support/choices.py:38
+#: support/templates/new_issue.html:230
+msgid "Service"
+msgstr "Servicio"
+
+#: support/choices.py:24
 #: support/templates/new_scheduled_task_address_change.html:4
 msgid "Address change"
 msgstr "Cambio de dirección"
 
-#: support/choices.py:7
+#: support/choices.py:25
 msgid "Start of pause"
 msgstr "Inicio de pausa"
 
-#: support/choices.py:8
+#: support/choices.py:26
 msgid "End of pause"
 msgstr "Fin de pausa"
 
-#: support/choices.py:9
+#: support/choices.py:27
 msgid "Start of partial pause"
 msgstr "Inicio de pausa parcial"
 
-#: support/choices.py:10
+#: support/choices.py:28
 msgid "End of partial pause"
 msgstr "Fin de pausa parcial"
 
-#: support/choices.py:16 support/templates/new_issue.html:84
-msgid "Collections"
-msgstr "Cobranza"
-
-#: support/choices.py:17 support/templates/new_issue.html:87
-msgid "Contents"
-msgstr "Contenido"
-
-#: support/choices.py:18 support/templates/new_issue.html:90
-msgid "Web"
-msgstr "Web"
-
-#: support/choices.py:19 support/templates/new_issue.html:93
-msgid "Service"
-msgstr "Servicio"
-
-#: support/choices.py:30
+#: support/choices.py:55
 msgid "Did not arrive"
 msgstr "No llegó"
 
-#: support/choices.py:31
+#: support/choices.py:56
 msgid "Arrived late"
 msgstr "Llegó tarde"
 
-#: support/choices.py:32
+#: support/choices.py:57
 msgid "Arrived wet"
 msgstr "Llegó mojado"
 
-#: support/choices.py:33
+#: support/choices.py:58
 msgid "Changed delivery place"
 msgstr "Cambio de lugar de entrega"
 
-#: support/choices.py:34 support/choices.py:97
+#: support/choices.py:59 support/choices.py:122
 msgid "Not delivered"
 msgstr "No entregado"
 
-#: support/choices.py:35
+#: support/choices.py:60
 msgid "Delivered to a wrong place"
 msgstr "Entregado a un lugar incorrecto"
 
-#: support/choices.py:36
+#: support/choices.py:61
 msgid "Wrong label"
 msgstr "Etiqueta incorrecta"
 
-#: support/choices.py:37
+#: support/choices.py:62
 msgid "Wrong invoice delivered"
 msgstr "Factura entregada incorrectamente"
 
-#: support/choices.py:38
+#: support/choices.py:63
 msgid "Paused route"
 msgstr "Ruta pausada"
 
-#: support/choices.py:39
+#: support/choices.py:64
 msgid "Invoice wasn't delivered"
 msgstr "Factura no entregada"
 
-#: support/choices.py:40
+#: support/choices.py:65
 msgid "Uncategorized logistics issue"
 msgstr "Problema de logística no categorizado"
 
-#: support/choices.py:42
+#: support/choices.py:67
 msgid "Product doesn't belong"
 msgstr "El producto no es correcto"
 
-#: support/choices.py:43
+#: support/choices.py:68
 msgid "Price issue"
 msgstr "Incidente de precio"
 
-#: support/choices.py:44
+#: support/choices.py:69
 msgid "Payment type issue"
 msgstr "Incidente de tipo de pago"
 
-#: support/choices.py:45
+#: support/choices.py:70
 msgid "Subscription not being billed"
 msgstr "Suscripción no facturada"
 
-#: support/choices.py:46
+#: support/choices.py:71
 msgid "Payment type change"
 msgstr "Cambio de tipo de pago"
 
-#: support/choices.py:47
+#: support/choices.py:72
 msgid "Collection issue"
 msgstr "Incidente de cobranza"
 
-#: support/choices.py:48
+#: support/choices.py:73
 msgid "Collection issue (inactive subscription)"
 msgstr "Incidente de cobranza (suscripción inactiva)"
 
-#: support/choices.py:49
+#: support/choices.py:74
 msgid "Credit card expiration"
 msgstr "Vencimiento de tarjeta de crédito"
 
-#: support/choices.py:50
+#: support/choices.py:75
 msgid "Debt issue"
 msgstr "Incidente de deuda"
 
-#: support/choices.py:51
+#: support/choices.py:76
 msgid "Uncategorized invoicing issue"
 msgstr "Incidente de facturación no categorizado"
 
-#: support/choices.py:53
+#: support/choices.py:78
 msgid "Suggestions"
 msgstr "Sugerencias"
 
-#: support/choices.py:54
+#: support/choices.py:79
 msgid "Complaints"
 msgstr "Reclamos"
 
-#: support/choices.py:55
+#: support/choices.py:80
 msgid "Corrections"
 msgstr "Correcciones"
 
-#: support/choices.py:56
+#: support/choices.py:81
 msgid "Requests"
 msgstr "Solicitudes"
 
-#: support/choices.py:57
+#: support/choices.py:82
 msgid "Contact journalist"
 msgstr "Contactar al periodista"
 
-#: support/choices.py:58
+#: support/choices.py:83
 msgid "Forward content"
 msgstr "Reenviar contenido"
 
-#: support/choices.py:60
+#: support/choices.py:85
 msgid "Access (sign-in)"
 msgstr "Acceso (ingreso a la web)"
 
-#: support/choices.py:61
+#: support/choices.py:86
 msgid "Registry (sign-up)"
 msgstr "Registro (registro en la web)"
 
-#: support/choices.py:62
+#: support/choices.py:87
 msgid "Website not available"
 msgstr "Sitio web no disponible"
 
-#: support/choices.py:63
+#: support/choices.py:88
 msgid "Settings issue"
 msgstr "Incidente de configuración"
 
-#: support/choices.py:64
+#: support/choices.py:89
 msgid "Articles limit reached"
 msgstr "Límite de artículos alcanzado"
 
-#: support/choices.py:65
+#: support/choices.py:90
 msgid "Not using service"
 msgstr "No utilizando el servicio"
 
-#: support/choices.py:67
+#: support/choices.py:92
 msgid "Promotion request"
 msgstr "Solicitud de promoción"
 
-#: support/choices.py:68
+#: support/choices.py:93
 msgid "Register new subscription"
 msgstr "Registro de nueva suscripción"
 
-#: support/choices.py:69
+#: support/choices.py:94
 msgid "End subscription"
 msgstr "Finalizar suscripción"
 
-#: support/choices.py:70
+#: support/choices.py:95
 msgid "Schedule subscription pause"
 msgstr "Programar pausa de suscripción"
 
-#: support/choices.py:71
+#: support/choices.py:96
 msgid "Schedule address change"
 msgstr "Programar cambio de dirección"
 
-#: support/choices.py:72
+#: support/choices.py:97
 msgid "Vacation (Resorts)"
 msgstr "Vacaciones (Balnearios)"
 
-#: support/choices.py:74
+#: support/choices.py:99
 msgid "Complaints on service"
 msgstr "Reclamos sobre el servicio"
 
-#: support/choices.py:75
+#: support/choices.py:100
 msgid "Payment types"
 msgstr "Tipos de pago"
 
-#: support/choices.py:76
+#: support/choices.py:101
 msgid "Errors in data"
 msgstr "Errores en los datos"
 
-#: support/choices.py:77
+#: support/choices.py:102
 msgid "Special cases"
 msgstr "Casos especiales"
 
-#: support/choices.py:78
+#: support/choices.py:103
 msgid "Schedule task"
 msgstr "Tarea programada"
 
-#: support/choices.py:79
+#: support/choices.py:104
 msgid "Change in subscription"
 msgstr "Cambio en suscripción"
 
-#: support/choices.py:81
+#: support/choices.py:106
 msgid "Community Benefits"
 msgstr "Beneficios comunitarios"
 
-#: support/choices.py:82
+#: support/choices.py:107
 msgid "Community Events"
 msgstr "Eventos comunitarios"
 
-#: support/choices.py:83
+#: support/choices.py:108
 msgid "Café"
 msgstr "Café"
 
-#: support/choices.py:84
+#: support/choices.py:109
 msgid "Media-lab"
 msgstr "Laboratorio de medios"
 
-#: support/choices.py:85
+#: support/choices.py:110
 msgid "Shop"
 msgstr "Tienda"
 
-#: support/choices.py:86
+#: support/choices.py:111
 msgid "Community Suggestions"
 msgstr "Sugerencias comunitarias"
 
-#: support/choices.py:87
+#: support/choices.py:112
 msgid "Community Complaints"
 msgstr "Reclamos comunitarios"
 
-#: support/choices.py:88
+#: support/choices.py:113
 msgid "Community Requests"
 msgstr "Solicitudes comunitarias"
 
-#: support/choices.py:89
+#: support/choices.py:114
 msgid "Polls/Surveys"
 msgstr "Encuestas"
 
-#: support/choices.py:91
+#: support/choices.py:116
 msgid "No sub-category"
 msgstr "Sin sub-categoría"
 
-#: support/choices.py:95
+#: support/choices.py:120
 msgid "Collected"
 msgstr "Recolectado"
 
-#: support/choices.py:96
+#: support/choices.py:121
 msgid "Delivered again"
 msgstr "Reentregado"
 
-#: support/choices.py:98
+#: support/choices.py:123
 msgid "Can't be delivered that way"
 msgstr "No se puede entregar de esa manera"
 
-#: support/choices.py:99
+#: support/choices.py:124
 msgid "Delivered late"
 msgstr "Entregado tarde"
 
-#: support/choices.py:100
+#: support/choices.py:125
 msgid "Problems to be delivered"
 msgstr "Problemas para entregar"
 
-#: support/choices.py:101
+#: support/choices.py:126
 msgid "Delivered in a specific way"
 msgstr "Entregado de manera específica"
 
-#: support/filters.py:74 support/templates/scheduled_activities.html:61
+#: support/filters.py:28
+#, fuzzy
+#| msgid "Last 7 days"
+msgid "Next 7 days"
+msgstr "Últimos 7 días"
+
+#: support/filters.py:32 support/templates/community_console.html:126
+msgid "No date set"
+msgstr ""
+
+#: support/filters.py:42
+#, fuzzy
+#| msgid "History was created"
+msgid "When the issue was created"
+msgstr "Historial creado"
+
+#: support/filters.py:59
+#, fuzzy
+#| msgid "Next action date"
+msgid "Next Action Date"
+msgstr "Fecha de próxima acción"
+
+#: support/filters.py:60
+msgid "When the next action is scheduled"
+msgstr ""
+
+#: support/filters.py:81 support/forms.py:493 support/forms.py:560
+#: support/forms.py:622 support/models.py:199
+#: support/templates/contact_detail/tabs/_campaigns.html:110
+#: support/templates/contact_detail/tabs/_issues.html:16
+#: support/templates/list_issues.html:167
+#: support/templates/list_issues.html:264 support/views/all_views.py:692
+msgid "Resolution"
+msgstr "Resolución"
+
+#: support/filters.py:85 support/templates/list_issues.html:218
+#, fuzzy
+#| msgid "Assigned to"
+msgid "Unassigned only"
+msgstr "Asignado a"
+
+#: support/filters.py:90 support/templates/list_issues.html:224
+msgid "Exclude finished"
+msgstr ""
+
+#: support/filters.py:172 support/templates/scheduled_activities.html:83
+msgid "Past (overdue)"
+msgstr ""
+
+#: support/filters.py:175 support/templates/scheduled_activities.html:92
+#, fuzzy
+#| msgid "Last 7 days"
+msgid "Past + Today"
+msgstr "Últimos 7 días"
+
+#: support/filters.py:176 support/templates/scheduled_activities.html:95
+#, fuzzy
+#| msgid "Future"
+msgid "Today + Future"
+msgstr "Futuro"
+
+#: support/filters.py:191 support/templates/scheduled_activities.html:79
+#, fuzzy
+#| msgid "Activity type"
+msgid "Activity Date"
+msgstr "Tipo de actividad"
+
+#: support/filters.py:197 support/templates/scheduled_activities.html:107
+#, fuzzy
+#| msgid "Date from"
+msgid "Date From"
+msgstr "Fecha desde"
+
+#: support/filters.py:203 support/templates/scheduled_activities.html:113
+#, fuzzy
+#| msgid "Date to"
+msgid "Date To"
+msgstr "Fecha hasta"
+
+#: support/filters.py:209 support/templates/scheduled_activities.html:122
 msgid "Subscription End Date From"
 msgstr "Fecha de fin de suscripción mínima"
 
-#: support/filters.py:79 support/templates/scheduled_activities.html:67
+#: support/filters.py:214 support/templates/scheduled_activities.html:128
 msgid "Subscription End Date To"
 msgstr "Fecha de fin de suscripción máxima"
 
-#: support/forms.py:43
+#: support/filters.py:361 support/filters.py:399
+#: support/templates/sales_record_filter.html:77
+#, fuzzy
+#| msgid "Subscription start date"
+msgid "Subscription start date (min)"
+msgstr "Fecha de inicio de la suscripción"
+
+#: support/filters.py:367 support/filters.py:405
+#: support/templates/sales_record_filter.html:83
+#, fuzzy
+#| msgid "Subscription start date"
+msgid "Subscription start date (max)"
+msgstr "Fecha de inicio de la suscripción"
+
+#: support/filters.py:451 support/filters.py:485 support/models.py:681
+#: support/models.py:685
+msgid "Justified"
+msgstr ""
+
+#: support/filters.py:452 support/models.py:685
+msgid "Unjustified"
+msgstr ""
+
+#: support/filters.py:460 support/templates/seller_performance_by_time.html:56
+msgid "Date from"
+msgstr "Fecha desde"
+
+#: support/filters.py:466 support/templates/seller_performance_by_time.html:60
+msgid "Date to"
+msgstr "Fecha hasta"
+
+#: support/filters.py:471 support/templates/campaign_statistics_list.html:84
+msgid "Sellers"
+msgstr "Vendedores"
+
+#: support/filters.py:475 support/models.py:723
+#: support/templates/support/seller_attendance.html:51
+#: support/templates/support/seller_attendance_filter.html:120
+#: support/views/all_views.py:3423
+msgid "Absence reason"
+msgstr ""
+
+#: support/filters.py:479
+msgid "Absences only"
+msgstr ""
+
+#: support/forms.py:47
 #, python-brace-format
 msgid "This user is already set in seller {}"
 msgstr "Este usuario ya está asignado al vendedor {}"
 
-#: support/forms.py:70 support/forms.py:94
+#: support/forms.py:74 support/forms.py:98
 msgid ""
 "There must be at least 1 day difference between date 2 and 1. Date 1 must be "
 "smaller than date 2"
@@ -4826,23 +6003,25 @@ msgstr ""
 "Debe haber al menos 1 día de diferencia entre la fecha 2 y 1. La fecha 1 "
 "debe ser menor que la fecha 2"
 
-#: support/forms.py:77
+#: support/forms.py:81
 msgid "Date of deactivation"
 msgstr "Fecha de desactivación"
 
-#: support/forms.py:81
+#: support/forms.py:85
 msgid "Date of activation (Products will be activated this exact day)"
 msgstr "Fecha de activación (Los productos se activarán exactamente este día)"
 
-#: support/forms.py:108 support/forms.py:403
+#: support/forms.py:112 support/forms.py:466
+#: support/templates/free_subscription_form.html:173
+#: support/templates/seller_console_start_promo.html:170
 msgid "New address"
 msgstr "Nueva dirección"
 
-#: support/forms.py:139
+#: support/forms.py:143
 msgid "Please select an existing address or create a new one."
 msgstr "Por favor, seleccione una dirección existente o cree una nueva."
 
-#: support/forms.py:143
+#: support/forms.py:147
 msgid ""
 "Please complete the new address first line, city and state if new address is "
 "selected"
@@ -4850,73 +6029,202 @@ msgstr ""
 "Por favor, complete la nueva dirección, la línea 1, la ciudad y el "
 "departamento si selecciona una nueva dirección"
 
-#: support/forms.py:251
-msgid "ID Document"
-msgstr "Documento de identificación"
-
-#: support/forms.py:258
-msgid "Unique Taxpayer ID"
-msgstr "NIT"
-
-#: support/forms.py:262
+#: support/forms.py:187 support/forms.py:301 support/forms.py:1023
 msgid "Default address"
 msgstr "Dirección principal"
 
-#: support/forms.py:381
+#: support/forms.py:210 support/forms.py:1056
+#, python-format
+msgid ""
+"This email is already registered to another contact (ID: %(contact_id)s)."
+msgstr ""
+
+#: support/forms.py:290
+msgid "ID Document"
+msgstr "Documento de identificación"
+
+#: support/forms.py:297
+msgid "Unique Taxpayer ID"
+msgstr "NIT"
+
+#: support/forms.py:437
 msgid "Sub Category (Required)"
 msgstr "Subcategoría (Requerida)"
 
-#: support/forms.py:425
+#: support/forms.py:442
+#, fuzzy
+#| msgid "Activity type"
+msgid "Activity Type (Required)"
+msgstr "Tipo de actividad"
+
+#: support/forms.py:444
+#, fuzzy
+#| msgid "Activity type"
+msgid "Select an activity type"
+msgstr "Tipo de actividad"
+
+#: support/forms.py:454 support/forms.py:563 support/forms.py:628
+#: support/models.py:161 support/templates/contact_detail/tabs/_issues.html:18
+#: support/templates/invoicing_issues.html:49
+#: support/templates/invoicing_issues.html:118
+#: support/templates/list_issues.html:163
+#: support/templates/list_issues.html:273 support/templates/new_issue.html:347
+#: support/views/all_views.py:696 support/views/all_views.py:2029
+msgid "Assigned to"
+msgstr "Asignado a"
+
+#: support/forms.py:487
+#, fuzzy
+#| msgid "Address type"
+msgid "Address Type"
+msgstr "Tipo de dirección"
+
+#: support/forms.py:510
 #, python-brace-format
 msgid "{} is not a subcategory of {}"
 msgstr "{} no es una subcategoría de {}"
 
-#: support/forms.py:537
+#: support/forms.py:548 support/forms.py:610 support/models.py:147
+#: support/models.py:174 support/models.py:410
+#: support/templates/community_console.html:214
+#: support/templates/community_manager_dashboard.html:210
+#: support/templates/contact_detail/tabs/_issues.html:15
+#: support/templates/invoicing_issues.html:53
+#: support/templates/invoicing_issues.html:106
+#: support/templates/list_issues.html:159
+#: support/templates/list_issues.html:263 support/templates/view_issue.html:186
+#: support/views/all_views.py:691
+msgid "Subcategory"
+msgstr "Subcategoría"
+
+#: support/forms.py:555 support/forms.py:617 support/models.py:177
+#: support/templates/invoicing_issues.html:108
+#: support/templates/list_issues.html:269 support/views/all_views.py:695
+#: support/views/all_views.py:2025
+msgid "Next action date"
+msgstr "Fecha de próxima acción"
+
+#: support/forms.py:668
 msgid "Pause"
 msgstr "Pausa"
 
-#: support/forms.py:538 support/templates/new_issue.html:67
+#: support/forms.py:669 support/templates/new_issue.html:167
 #: support/templates/new_scheduled_task_address_change.html:9
-#: support/templates/new_scheduled_task_address_change.html:79
-#: support/templates/new_scheduled_task_partial_pause.html:61
-#: support/templates/new_scheduled_task_total_pause.html:43
+#: support/templates/new_scheduled_task_address_change.html:103
+#: support/templates/new_scheduled_task_partial_pause.html:89
+#: support/templates/new_scheduled_task_total_pause.html:67
 msgid "Change address"
 msgstr "Cambiar dirección"
 
-#: support/forms.py:602 support/models.py:375
-#: support/templates/scheduled_activities.html:99
+#: support/forms.py:734 support/models.py:444
+#: support/templates/scheduled_activities.html:167
 msgid "Date and time"
 msgstr "Fecha y hora"
 
-#: support/forms.py:718 support/forms.py:736
+#: support/forms.py:810
+#, fuzzy
+#| msgid "Start date for new product"
+msgid "Start date for new subscription"
+msgstr "Fecha de inicio para el nuevo producto"
+
+#: support/forms.py:821
+#, fuzzy
+#| msgid "Unsubscription channel"
+msgid "Petition channel"
+msgstr "Canal de baja"
+
+#: support/forms.py:885 support/forms.py:908
 msgid "Override amount"
 msgstr "Reemplazar monto"
 
-#: support/forms.py:795
+#: support/forms.py:936 support/forms.py:968 support/forms.py:1074
 msgid "CSV File"
 msgstr "Archivo CSV"
 
-#: support/forms.py:795
+#: support/forms.py:936 support/forms.py:968
 msgid "Please upload a CSV file"
 msgstr "Por favor, suba un archivo CSV"
 
-#: support/forms.py:802
+#: support/forms.py:939
+msgid "CSV file has headers"
+msgstr ""
+
+#: support/forms.py:942
+msgid "Check this if your CSV file has column headers in the first row"
+msgstr ""
+
+#: support/forms.py:946
+#, fuzzy
+#| msgid "Import new contacts"
+msgid "Tags for new contacts"
+msgstr "Importar nuevos contactos"
+
+#: support/forms.py:947
+msgid "Comma-separated tags"
+msgstr ""
+
+#: support/forms.py:950
+#, fuzzy
+#| msgid "Check for existing contacts"
+msgid "Tags for existing inactive contacts"
+msgstr "Verificar contactos existentes"
+
+#: support/forms.py:952 support/templates/import_contacts.html:95
+#, fuzzy
+#| msgid "Check for existing contacts"
+msgid "Tags for existing contacts"
+msgstr "Verificar contactos existentes"
+
+#: support/forms.py:955
+#, fuzzy
+#| msgid "Check for existing contacts"
+msgid "Tags for existing active contacts"
+msgstr "Verificar contactos existentes"
+
+#: support/forms.py:957 support/templates/import_contacts.html:90
+#, fuzzy
+#| msgid "for the contact"
+msgid "Tags for active contacts"
+msgstr "para el contacto"
+
+#: support/forms.py:960 support/templates/import_contacts.html:85
+#, fuzzy
+#| msgid "Add contacts to campaign"
+msgid "Tags for contacts in campaigns"
+msgstr "Agregar contactos a la campaña"
+
+#: support/forms.py:962
+#, fuzzy
+#| msgid "Add contacts to campaign"
+msgid "Tags for contacts in campaign"
+msgstr "Agregar contactos a la campaña"
+
+#: support/forms.py:975
 msgid "Upload CSV file"
 msgstr "Subir archivo CSV"
 
-#: support/forms.py:808
+#: support/forms.py:981 support/forms.py:1089
 msgid "File must be a CSV file"
 msgstr "El archivo debe ser un archivo CSV"
 
+#: support/forms.py:1075
+msgid ""
+"Upload a CSV file with contact IDs. Expected column: contact_id, id, or "
+"similar."
+msgstr ""
+
+#: support/forms.py:1082
+msgid "Select the campaign to delete status records from"
+msgstr ""
+
 #: support/location.py:95 support/location.py:241
-#: support/templates/contact_detail/tabs/_information.html:148
 #: support/templates/location/editar_direccion.html:25
 #: support/templates/location/normalizar_direccion.html:147
 msgid "Edit address"
 msgstr "Editar dirección"
 
 #: support/location.py:193
-#: support/templates/contact_detail/tabs/_overview.html:79
+#: support/templates/contact_detail/tabs/_overview.html:128
 #: support/templates/location/agregar_direccion.html:25
 msgid "Add address"
 msgstr "Agregar dirección"
@@ -4980,32 +6288,117 @@ msgstr "Proceso de sincronización terminado"
 msgid "Cannot select filter"
 msgstr "No se puede seleccionar el filtro"
 
-#: support/models.py:33
+#: support/models.py:28
+#, fuzzy
+#| msgid "End Time"
+msgid "End time"
+msgstr "Hora de fin"
+
+#: support/models.py:34
+msgid "shift"
+msgstr ""
+
+#: support/models.py:35
+msgid "shifts"
+msgstr ""
+
+#: support/models.py:46
 msgid "Is internal?"
 msgstr "¿Es interno?"
 
-#: support/models.py:108
+#: support/models.py:47
+#, fuzzy
+#| msgid "Do not call numbers"
+msgid "Works in call center?"
+msgstr "Números de no llamar"
+
+#: support/models.py:53
+msgid "Shift"
+msgstr ""
+
+#: support/models.py:129
 msgid "seller"
 msgstr "vendedor"
 
-#: support/models.py:109
+#: support/models.py:130
 msgid "sellers"
 msgstr "vendedores"
 
-#: support/models.py:217
+#: support/models.py:140
+#, fuzzy
+#| msgid "Date billed"
+msgid "Date modified"
+msgstr "Fecha de facturación"
+
+#: support/models.py:142
+#, fuzzy
+#| msgid "Debt issue"
+msgid "Date of the issue"
+msgstr "Incidente de deuda"
+
+#: support/models.py:144 support/templates/contact_detail/tabs/_issues.html:14
+#: support/templates/contact_detail/tabs/_tasks.html:12
+#: support/templates/list_issues.html:155
+#: support/templates/list_issues.html:262 support/templates/new_issue.html:188
+#: support/templates/scheduled_task_filter.html:45
+#: support/templates/scheduled_task_filter.html:86
+#: support/templates/view_issue.html:184 support/views/all_views.py:690
+#: support/views/scheduled_tasks.py:234
+msgid "Category"
+msgstr "Categoría"
+
+#: support/models.py:149
+msgid "Inside"
+msgstr ""
+
+#: support/models.py:167
+msgid "Progress"
+msgstr "Progreso"
+
+#: support/models.py:168
+#, fuzzy
+#| msgid "Answer"
+msgid "Answer 1"
+msgstr "Respuesta"
+
+#: support/models.py:169
+#, fuzzy
+#| msgid "Answer"
+msgid "Answer 2"
+msgstr "Respuesta"
+
+#: support/models.py:178
+#, fuzzy
+#| msgid "CMS join date"
+msgid "Closing date"
+msgstr "Fecha de registro en el CMS"
+
+#: support/models.py:183
+msgid "Subscription product"
+msgstr "Producto de suscripción"
+
+#: support/models.py:207
+msgid "Can access community management console"
+msgstr ""
+
+#: support/models.py:208
+msgid "Can manage community console (assign issues)"
+msgstr ""
+
+#: support/models.py:266
 #, python-brace-format
 msgid "Issue of category {category} for {contact} with status {status}"
 msgstr "Problema de categoría {category} para {contact} con estado {status}"
 
-#: support/models.py:235
+#: support/models.py:284
 msgid "Date of execution"
 msgstr "Fecha de ejecución"
 
-#: support/models.py:241
+#: support/models.py:290
 msgid "Modification date"
 msgstr "Fecha de modificación"
 
-#: support/models.py:313
+#: support/models.py:362
 #, python-brace-format
 msgid ""
 "Task {id} of type {category} for contact {contact} completed successfully."
@@ -5013,97 +6406,457 @@ msgstr ""
 "Tarea {id} de tipo {category} para contacto {contact} completada "
 "exitosamente."
 
-#: support/models.py:321
+#: support/models.py:370
 msgid "Scheduled task"
 msgstr "Tarea programada"
 
-#: support/models.py:322 templates/components/sidebar_items/_support.html:50
-msgid "Scheduled tasks"
-msgstr "Tareas programadas"
-
-#: support/models.py:339
+#: support/models.py:388
 msgid "Issue Status"
 msgstr "Estado de incidencia"
 
-#: support/models.py:340
+#: support/models.py:389
 msgid "Issue Statuses"
 msgstr "Estados de incidencia"
 
-#: support/models.py:356
+#: support/models.py:405
 msgid "Issue Subcategory"
 msgstr "Subcategoría de incidencia"
 
-#: support/models.py:357
+#: support/models.py:406
 msgid "Issue Subcategories"
 msgstr "Subcategorías de incidencia"
 
-#: support/models.py:368
+#: support/models.py:412
+msgid "Slug"
+msgstr ""
+
+#: support/models.py:416
+#, fuzzy
+#| msgid "Resolution"
+msgid "Issue Resolution"
+msgstr "Resolución"
+
+#: support/models.py:417
+#, fuzzy
+#| msgid "Resolution"
+msgid "Issue Resolutions"
+msgstr "Resolución"
+
+#: support/models.py:435
 msgid "Full"
 msgstr "Completo"
 
-#: support/models.py:369
+#: support/models.py:436
 msgid "Partial"
 msgstr "Parcial"
 
-#: support/models.py:382
+#: support/models.py:437
+#, fuzzy
+#| msgid "Product change"
+msgid "Product Change"
+msgstr "Cambio de producto"
+
+#: support/models.py:451
 msgid "Commission for payment type"
 msgstr "Comisión por tipo de pago"
 
-#: support/models.py:385
+#: support/models.py:454
 msgid "Commission for products sold"
 msgstr "Comisión por productos vendidos"
 
-#: support/models.py:388
+#: support/models.py:457
 msgid "Commission for subscription frequency"
 msgstr "Comisión por frecuencia de suscripción"
 
-#: support/models.py:391
+#: support/models.py:460
 msgid "Total commission value"
 msgstr "Valor total de la comisión"
 
-#: support/models.py:393
-#: support/templates/validate_subscription_sales_record.html:254
+#: support/models.py:462
+#: support/templates/validate_subscription_sales_record.html:394
 msgid "Can be commissioned"
 msgstr "Puede ser comisionado"
 
-#: support/models.py:396
+#: support/models.py:465
 msgid "Sales record"
 msgstr "Registro de ventas"
 
-#: support/models.py:397
+#: support/models.py:466
 msgid "Sales records"
 msgstr "Registros de ventas"
 
-#: support/models.py:575
+#: support/models.py:612
+#, fuzzy
+#| msgid "Select products"
+msgid "specific products"
+msgstr "Seleccionar productos"
+
+#: support/models.py:642
 msgid "Success"
 msgstr "Exitoso"
 
-#: support/models.py:576
+#: support/models.py:643
 msgid "Declined"
 msgstr "Rechazado"
 
-#: support/models.py:578
+#: support/models.py:645
 msgid "No contact"
 msgstr "No contactado"
 
-#: support/models.py:591
+#: support/models.py:659
 msgid "Campaign status to set when this action is performed"
 msgstr "Estado de campaña a asignar cuando se utilice esta acción"
 
-#: support/models.py:598
+#: support/models.py:666
+#, fuzzy
+#| msgid "Campaign status to set when this action is performed"
+msgid "Campaign resolution to set when this action is performed"
+msgstr "Estado de campaña a asignar cuando se utilice esta acción"
+
+#: support/models.py:673
 msgid "Seller Console Action"
 msgstr "Acción de consola de ventas"
 
-#: support/models.py:599
+#: support/models.py:674
 msgid "Seller Console Actions"
 msgstr "Acciones de consola de ventas"
+
+#: support/models.py:689
+msgid "absence reason"
+msgstr ""
+
+#: support/models.py:690
+msgid "absence reasons"
+msgstr ""
+
+#: support/models.py:697 support/templates/support/seller_attendance.html:71
+#: support/templates/support/seller_attendance.html:75
+msgid "Present"
+msgstr ""
+
+#: support/models.py:698 support/templates/support/seller_attendance.html:72
+#: support/templates/support/seller_attendance.html:76
+msgid "Absent"
+msgstr ""
+
+#: support/models.py:709
+#, fuzzy
+#| msgid "Sales record"
+msgid "attendance record"
+msgstr "Registro de ventas"
+
+#: support/models.py:710
+#, fuzzy
+#| msgid "Sales records"
+msgid "attendance records"
+msgstr "Registros de ventas"
+
+#: support/models.py:725 support/templates/support/seller_attendance.html:52
+#, fuzzy
+#| msgid "Start"
+msgid "Shift start"
+msgstr "Inicio"
+
+#: support/models.py:726 support/templates/support/seller_attendance.html:53
+msgid "Shift end"
+msgstr ""
+
+#: support/models.py:730
+#, fuzzy
+#| msgid "Sellers performance"
+msgid "seller attendance"
+msgstr "Rendimiento de vendedores"
+
+#: support/models.py:731
+msgid "seller attendances"
+msgstr ""
+
+#: support/templates/activities/activity_detail.html:4
+#: support/templates/activities/activity_detail.html:8
+#: support/templates/activities/activity_detail.html:158
+#: support/templates/reactivate_subscription.html:105
+#: support/views/activities.py:233
+msgid "Activity"
+msgstr "Actividad"
+
+#: support/templates/activities/activity_detail.html:17
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:10
+#, fuzzy
+#| msgid "activity topics"
+msgid "Activity Details"
+msgstr "temas de actividad"
+
+#: support/templates/activities/activity_detail.html:22
+#: support/templates/contact_detail/tabs/_information.html:15
+#: support/templates/contact_detail/tabs/_issues.html:12
+#: support/templates/contact_detail/tabs/_overview.html:14
+#: support/templates/debtor_contacts.html:88
+#: support/templates/seller_console_special_routes.html:21
+msgid "ID"
+msgstr "ID"
+
+#: support/templates/activities/activity_detail.html:36
+#, fuzzy
+#| msgid "Date/time"
+msgid "Date/Time"
+msgstr "Fecha/hora"
+
+#: support/templates/activities/activity_detail.html:93
+#, fuzzy
+#| msgid "This contact has no subscriptions"
+msgid "This activity contains unsubscription data"
+msgstr "Este contacto no tiene suscripciones"
+
+#: support/templates/activities/activity_detail.html:97
+#: support/templates/activities/activity_detail.html:142
+#: support/templates/reactivate_subscription.html:38
+#: support/templates/seller_console_special_routes.html:23
+msgid "Subscription ID"
+msgstr "ID de suscripción"
+
+#: support/templates/activities/activity_detail.html:113
+#: support/templates/contact_detail/tabs/_campaigns.html:120
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:132
+#: support/templates/reactivate_subscription.html:87
+#: support/templates/unsubscription_statistics.html:276
+#: support/templates/unsubscription_statistics.html:305
+msgid "Reason"
+msgstr "Motivo"
+
+#: support/templates/activities/activity_detail.html:117
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:136
+#: support/templates/reactivate_subscription.html:91
+#, fuzzy
+#| msgid "Change"
+msgid "Channel"
+msgstr "Cambiar"
+
+#: support/templates/activities/activity_detail.html:122
+#: support/templates/reactivate_subscription.html:96
+msgid "Addendum"
+msgstr ""
+
+#: support/templates/activities/activity_detail.html:128
+#, fuzzy
+#| msgid "Notes"
+msgid "Note"
+msgstr "Notas"
+
+#: support/templates/activities/activity_detail.html:131
+msgid ""
+"This data was created during reactivation (original activity was not found)"
+msgstr ""
+
+#: support/templates/activities/activity_detail.html:138
+msgid "This activity contains reactivation data"
+msgstr ""
+
+#: support/templates/activities/activity_detail.html:146
+#, fuzzy
+#| msgid "Creation date"
+msgid "Reactivation date"
+msgstr "Fecha de creación"
+
+#: support/templates/activities/activity_detail.html:150
+#, fuzzy
+#| msgid "Replaced by"
+msgid "Reactivated by"
+msgstr "Reemplazada por"
+
+#: support/templates/activities/activity_detail.html:155
+#, fuzzy
+#| msgid "Partial unsubscription"
+msgid "Original unsubscription activity"
+msgstr "Desuscripción parcial"
+
+#: support/templates/activities/activity_detail.html:166
+msgid "This activity contains structured metadata"
+msgstr ""
+
+#: support/templates/activities/activity_detail.html:180
+#, fuzzy
+#| msgid "Back to contact"
+msgid "Back to Contacts"
+msgstr "Volver al contacto"
+
+#: support/templates/activities/activity_detail.html:190
+msgid "Quick Info"
+msgstr ""
+
+#: support/templates/activities/activity_detail.html:207
+#, fuzzy
+#| msgid "See related issue"
+msgid "Related Issue"
+msgstr "Ver incidencia relacionado"
 
 #: support/templates/activities/create_activity.html:5
 msgid "Register Activity"
 msgstr "Registrar actividad"
 
+#: support/templates/add_retention_discount.html:4
+#: support/templates/add_retention_discount.html:61
+#: support/views/subscriptions.py:1185
+#, fuzzy
+#| msgid "Percentage discount"
+msgid "Add retention discount"
+msgstr "Descuento porcentaje"
+
+#: support/templates/add_retention_discount.html:30
+msgid ""
+"Cannot remove all subscription products without adding new ones - at least "
+"one must remain"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:35
+#: support/templates/add_retention_discount.html:218
+msgid ""
+"Select at least one retention discount, add new products, or mark products "
+"to remove"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:63
+msgid "Select retention discount products to add to the subscription"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:81
+msgid "How to use this form:"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:83
+#, fuzzy
+#| msgid "Select products"
+msgid "Select retention discounts"
+msgstr "Seleccionar productos"
+
+#: support/templates/add_retention_discount.html:83
+msgid "Choose one or more retention discount products to offer to the customer"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:84
+#, fuzzy
+#| msgid "Add products"
+msgid "Add new products (optional)"
+msgstr "Agregar productos"
+
+#: support/templates/add_retention_discount.html:84
+msgid ""
+"If the customer wants to add new subscription products, check them in the "
+"'Add these products' section"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:85
+#, fuzzy
+#| msgid "Products Total"
+msgid "Remove products (optional)"
+msgstr "Total de productos"
+
+#: support/templates/add_retention_discount.html:85
+msgid ""
+"If the customer wants to remove any products, check the boxes in the 'Remove "
+"these products' section"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:86
+#, fuzzy
+#| msgid "Start date"
+msgid "Set start date"
+msgstr "Fecha de inicio"
+
+#: support/templates/add_retention_discount.html:86
+msgid ""
+"Choose when the new subscription should start (must be at least tomorrow)"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:87
+msgid "Add petition channel and notes"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:87
+msgid "Select how the customer contacted you and add any relevant notes"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:93
+msgid ""
+"You must select at least one retention discount, add new products, OR mark "
+"products to remove"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:94
+msgid ""
+"You cannot remove all subscription products - at least one must remain "
+"(discounts alone are not sufficient)"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:95
+msgid "The start date must be at least tomorrow"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:96
+msgid ""
+"Adding new products is optional and useful when the customer wants to change "
+"their subscription during retention"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:108
+#, fuzzy
+#| msgid "Percentage discount"
+msgid "Retention discounts"
+msgstr "Descuento porcentaje"
+
+#: support/templates/add_retention_discount.html:130
+#, fuzzy
+#| msgid "Target product"
+msgid "Current products"
+msgstr "Producto objetivo"
+
+#: support/templates/add_retention_discount.html:138
+msgid "Add these retention discounts"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:156
+msgid ""
+"No retention discount products available. Please create retention discount "
+"products first."
+msgstr ""
+
+#: support/templates/add_retention_discount.html:161
+#, fuzzy
+#| msgid "Add products"
+msgid "Add these products"
+msgstr "Agregar productos"
+
+#: support/templates/add_retention_discount.html:161
+#: support/templates/add_retention_discount.html:202
+#, fuzzy
+#| msgid "Optional"
+msgid "optional"
+msgstr "Opcional"
+
+#: support/templates/add_retention_discount.html:178
+msgid ""
+"No additional products available (customer already has all offerable "
+"products)"
+msgstr ""
+
+#: support/templates/add_retention_discount.html:187
+#, fuzzy
+#| msgid "Amount of contacts tomorrow"
+msgid "Must be at least tomorrow"
+msgstr "Cantidad de contactos mañana"
+
+#: support/templates/add_retention_discount.html:196
+#: support/templates/book_additional_product.html:128
+msgid "For old subscription"
+msgstr "Para la suscripción anterior"
+
+#: support/templates/add_retention_discount.html:202
+#, fuzzy
+#| msgid "Advertise in these products"
+msgid "Remove these products"
+msgstr "Anunciar en estos productos"
+
 #: support/templates/assign_campaigns.html:5
-#: support/templates/assign_campaigns.html:9 support/views/all_views.py:152
+#: support/templates/assign_campaigns.html:9
 msgid "Assign campaigns"
 msgstr "Asignar campañas"
 
@@ -5117,6 +6870,7 @@ msgid "Use contacts with the following tags"
 msgstr "Usar contactos con las siguientes etiquetas"
 
 #: support/templates/assign_campaigns.html:37
+#: support/templates/validate_subscription_sales_record.html:27
 msgid "Select campaign"
 msgstr "Seleccionar campaña"
 
@@ -5142,6 +6896,9 @@ msgstr ""
 "suscripciones, dando prioridad a aquellas con fechas de fin más antiguas"
 
 #: support/templates/assign_sellers.html:40
+#: support/templates/community_manager_assign.html:140
+#: support/templates/community_manager_assign.html:200
+#: support/templates/community_manager_dashboard.html:276
 msgid "Assign"
 msgstr "Asignar"
 
@@ -5149,7 +6906,7 @@ msgstr "Asignar"
 #: support/templates/book_partial_unsubscription.html:4
 #: support/templates/book_unsubscription.html:4
 #: support/templates/book_unsubscription.html:8
-#: support/views/subscriptions.py:519
+#: support/views/subscriptions.py:565
 msgid "Book unsubscription"
 msgstr "Registrar baja"
 
@@ -5170,25 +6927,29 @@ msgstr "Agregar productos"
 #: support/templates/book_partial_unsubscription.html:33
 #: support/templates/book_product_change.html:43
 #: support/templates/book_unsubscription.html:18
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:109
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:175
 msgid "Unsubscription"
 msgstr "Baja"
+
+#: support/templates/book_additional_product.html:64
+#: support/templates/book_partial_unsubscription.html:35
+#: support/templates/book_product_change.html:45
+#: support/templates/book_unsubscription.html:20
+#: support/templates/validate_subscription_sales_record.html:59
+msgid "Product change"
+msgstr "Cambio de producto"
 
 #: support/templates/book_additional_product.html:68
 #: support/templates/book_partial_unsubscription.html:36
 #: support/templates/book_product_change.html:46
 #: support/templates/book_unsubscription.html:21
-#: support/templates/seller_console.html:341
+#: support/templates/seller_console.html:378
 msgid "Add product"
 msgstr "Agregar producto"
 
 #: support/templates/book_additional_product.html:122
 msgid "Start date for new product"
 msgstr "Fecha de inicio para el nuevo producto"
-
-#: support/templates/book_additional_product.html:128
-msgid "For old subscription"
-msgstr "Para la suscripción anterior"
 
 #: support/templates/book_additional_product.html:135
 msgid "Select a product to continue"
@@ -5199,7 +6960,7 @@ msgid "Book unsubscription of some products"
 msgstr "Registrar baja de algunos productos"
 
 #: support/templates/book_product_change.html:4
-#: support/views/subscriptions.py:712
+#: support/views/subscriptions.py:1005
 msgid "Book product change"
 msgstr "Registrar cambio de producto"
 
@@ -5207,61 +6968,482 @@ msgstr "Registrar cambio de producto"
 msgid "Book product change(s)"
 msgstr "Registrar cambios de producto(s)"
 
-#: support/templates/campaign_statistics_detail.html:13
-#: support/templates/campaign_statistics_detail.html:18
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:4
+#: support/templates/campaign_management_menu.html:294
+#: support/views/campaign_management.py:53
+#: templates/components/sidebar_items/_campaign_management.html:105
+#, fuzzy
+#| msgid "Contact Campaign Status"
+msgid "Bulk Delete Campaign Status"
+msgstr "Estado de contacto en la campaña"
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:19
+#, fuzzy
+#| msgid "Contact Campaign Statuses"
+msgid "Bulk Delete Campaign Status Records"
+msgstr "Estados de contacto en la campaña"
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:22
+#: support/templates/import_contacts.html:23
+msgid "Download CSV Template"
+msgstr "Descargar plantilla CSV"
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:29
+#, fuzzy
+#| msgid "Warning!"
+msgid "Warning"
+msgstr "Advertencia!"
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:30
+msgid "This action will permanently delete ContactCampaignStatus records."
+msgstr ""
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:31
+msgid ""
+"Use this tool to remove contacts from a campaign by uploading a CSV file "
+"with contact IDs."
+msgstr ""
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:41
+msgid ""
+"Prepare a CSV file with contact IDs (one column named 'contact_id', 'id', or "
+"similar)"
+msgstr ""
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:42
+msgid "Select the campaign from which you want to remove these contacts"
+msgstr ""
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:43
+msgid "Upload the CSV file and click 'Delete Campaign Status Records'"
+msgstr ""
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:44
+msgid ""
+"The system will delete all ContactCampaignStatus records matching the "
+"contact IDs and selected campaign"
+msgstr ""
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:48
+msgid "CSV Format:"
+msgstr ""
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:49
+msgid ""
+"Your CSV file should have a column with contact IDs. Accepted column names: "
+"contact_id, id, contact id, or contactid (case-insensitive)."
+msgstr ""
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:50
+msgid "Example:"
+msgstr ""
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:115
+#, fuzzy
+#| msgid "Contact Campaign Statuses"
+msgid "Delete Campaign Status Records"
+msgstr "Estados de contacto en la campaña"
+
+#: support/templates/campaign_management/bulk_delete_campaign_status.html:151
+#, fuzzy
+#| msgid "Select campaign"
+msgid "Select a campaign"
+msgstr "Seleccionar campaña"
+
+#: support/templates/campaign_management_menu.html:85
+#, fuzzy
+#| msgid "Campaign statistics"
+msgid "Campaign tools and statistics"
+msgstr "Estadísticas de campaña"
+
+#: support/templates/campaign_management_menu.html:110
+#, fuzzy
+#| msgid "Search"
+msgid "Search…"
+msgstr "Buscar"
+
+#: support/templates/campaign_management_menu.html:113
+#: support/templates/support/seller_attendance_filter.html:102
+#: support/templates/tag_analysis.html:36
+msgid "Clear"
+msgstr "Limpiar"
+
+#: support/templates/campaign_management_menu.html:120
+#, fuzzy
+#| msgid "No tags found matching your search criteria."
+msgid "No results found matching the search."
+msgstr "No se encontraron etiquetas para sus criterios de búsqueda."
+
+#: support/templates/campaign_management_menu.html:127
+#, fuzzy
+#| msgid "Campaign start"
+msgid "Campaign preparation"
+msgstr "Inicio de campaña"
+
+#: support/templates/campaign_management_menu.html:130
+msgid "Import contacts, assign tags and sellers, and create new campaigns."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:135
+#: support/templates/import_contacts.html:329 support/views/contacts.py:562
+#: templates/components/sidebar_items/_campaign_management.html:30
+msgid "Import Contacts"
+msgstr "Importar contactos"
+
+#: support/templates/campaign_management_menu.html:138
+msgid "Import contacts from a CSV file to add them to the database."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:140
+#, fuzzy
+#| msgid "Go to contact"
+msgid "Go to import"
+msgstr "Ir al contacto"
+
+#: support/templates/campaign_management_menu.html:148
+#: support/views/contacts.py:895
+#: templates/components/sidebar_items/_campaign_management.html:37
+msgid "Check for existing contacts"
+msgstr "Verificar contactos existentes"
+
+#: support/templates/campaign_management_menu.html:151
+msgid "Upload a CSV to check which contacts already exist in the database."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:153
+#, fuzzy
+#| msgid "Go to contact"
+msgid "Go to check"
+msgstr "Ir al contacto"
+
+#: support/templates/campaign_management_menu.html:161
+#: support/views/all_views.py:2733
+#: templates/components/sidebar_items/_campaign_management.html:44
+msgid "Tag Contacts"
+msgstr "Etiquetar contactos"
+
+#: support/templates/campaign_management_menu.html:164
+msgid "Upload a CSV to add tags to a set of contacts."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:166
+#, fuzzy
+#| msgid "Go to Mailtrain"
+msgid "Go to tagging"
+msgstr "Ir a Mailtrain"
+
+#: support/templates/campaign_management_menu.html:174
+#: support/views/all_views.py:169
+#: templates/components/sidebar_items/_campaign_management.html:51
+msgid "Assign contacts by tag"
+msgstr "Asignar contactos por etiqueta"
+
+#: support/templates/campaign_management_menu.html:177
+#, fuzzy
+#| msgid "This contact is not present in any campaign"
+msgid "Assign contacts with a specific tag to a campaign."
+msgstr "Este contacto no está presente en ninguna campaña"
+
+#: support/templates/campaign_management_menu.html:179
+#: support/templates/campaign_management_menu.html:192
+#, fuzzy
+#| msgid "Not assigned"
+msgid "Go to assignment"
+msgstr "No asignados"
+
+#: support/templates/campaign_management_menu.html:187
+#: support/templates/distribute_campaigns.html:13
+#: support/views/all_views.py:255 support/views/all_views.py:291
+#: templates/components/sidebar_items/_campaign_management.html:58
+msgid "Assign contacts to sellers"
+msgstr "Asignar contactos a vendedores"
+
+#: support/templates/campaign_management_menu.html:190
+#, fuzzy
+#| msgid "Assign contacts to sellers"
+msgid "Distribute campaign contacts among sellers."
+msgstr "Asignar contactos a vendedores"
+
+#: support/templates/campaign_management_menu.html:200
+#: templates/components/sidebar_items/_campaign_management.html:64
+msgid "New campaign"
+msgstr "Nueva campaña"
+
+#: support/templates/campaign_management_menu.html:203
+msgid "Create a new campaign in the admin panel."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:205
+#, fuzzy
+#| msgid "Go to Mailtrain"
+msgid "Go to admin"
+msgstr "Ir a Mailtrain"
+
+#: support/templates/campaign_management_menu.html:221
+msgid "Tracking and reports"
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:224
+msgid "Monitor campaign progress, seller performance, and manage contacts."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:229
+#: support/templates/campaign_statistics_detail.html:12
+#: support/templates/campaign_statistics_detail.html:16
 #: support/templates/campaign_statistics_list.html:23
 #: support/templates/campaign_statistics_list.html:27
-#: templates/components/sidebar_items/_campaign_management.html:66
+#: support/views/all_views.py:2190 support/views/all_views.py:2213
+#: templates/components/sidebar_items/_campaign_management.html:70
 msgid "Campaign statistics"
 msgstr "Estadísticas de campaña"
 
-#: support/templates/campaign_statistics_detail.html:14
-#: support/templates/campaign_statistics_per_seller.html:25
-msgid "Statistics for"
-msgstr "Estadísticas para"
+#: support/templates/campaign_management_menu.html:232
+#, fuzzy
+#| msgid "Times contacted in this campaign:"
+msgid "View contact and call statistics per campaign."
+msgstr "Veces contactado en esta campaña:"
 
-#: support/templates/campaign_statistics_detail.html:26
+#: support/templates/campaign_management_menu.html:234
+#, fuzzy
+#| msgid "Issues statistics"
+msgid "Go to statistics"
+msgstr "Estadísticas de incidencias"
+
+#: support/templates/campaign_management_menu.html:242
+#: support/views/all_views.py:2568
+#: templates/components/sidebar_items/_campaign_management.html:77
+msgid "Sellers performance"
+msgstr "Rendimiento de vendedores"
+
+#: support/templates/campaign_management_menu.html:245
+msgid "Review seller performance metrics by time period."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:247
+#, fuzzy
+#| msgid "Sellers performance"
+msgid "Go to performance"
+msgstr "Rendimiento de vendedores"
+
+#: support/templates/campaign_management_menu.html:255
+#: support/views/all_views.py:541
+#: templates/components/sidebar_items/_campaign_management.html:84
+msgid "Release seller contacts"
+msgstr "Liberar contactos de vendedores"
+
+#: support/templates/campaign_management_menu.html:258
+#, fuzzy
+#| msgid "Release contacts from sellers"
+msgid "Release unworked contacts from a seller so they can be reassigned."
+msgstr "Liberar contactos de los vendedores"
+
+#: support/templates/campaign_management_menu.html:260
+#, fuzzy
+#| msgid "Go to issue"
+msgid "Go to release"
+msgstr "Ir al incidencia"
+
+#: support/templates/campaign_management_menu.html:268
+#: support/views/all_views.py:2693
+#: templates/components/sidebar_items/_campaign_management.html:91
+msgid "Upload do not call list"
+msgstr "Subir lista de no contactar"
+
+#: support/templates/campaign_management_menu.html:271
+msgid "Upload a CSV of numbers that should not be called."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:273
+#, fuzzy
+#| msgid "Go to contact"
+msgid "Go to upload"
+msgstr "Ir al contacto"
+
+#: support/templates/campaign_management_menu.html:281
+#: support/templates/sales_record_filter.html:4
+#: support/templates/sales_record_filter.html:52
+#: support/views/all_views.py:2873 support/views/all_views.py:2941
+#: templates/components/sidebar_items/_campaign_management.html:98
+msgid "Sales Records"
+msgstr "Registros de ventas"
+
+#: support/templates/campaign_management_menu.html:284
+msgid "View and filter sales records across all sellers."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:286
+#, fuzzy
+#| msgid "Go to contacts"
+msgid "Go to records"
+msgstr "Ir a contactos"
+
+#: support/templates/campaign_management_menu.html:297
+msgid ""
+"Delete campaign status records in bulk by uploading a CSV of contact IDs."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:299
+msgid "Go to bulk delete"
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:307
+#: support/templates/support/seller_attendance.html:4
+#: support/templates/support/seller_attendance.html:13
+#: support/views/all_views.py:3079 support/views/all_views.py:3254
+#: templates/components/sidebar_items/_campaign_management.html:112
+#, fuzzy
+#| msgid "Sellers performance"
+msgid "Seller Attendance"
+msgstr "Rendimiento de vendedores"
+
+#: support/templates/campaign_management_menu.html:310
+msgid "Track and manage call center seller attendance records."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:312
+#, fuzzy
+#| msgid "Go to Mailtrain"
+msgid "Go to attendance"
+msgstr "Ir a Mailtrain"
+
+#: support/templates/campaign_management_menu.html:314
+#, fuzzy
+#| msgid "Standard"
+msgid "Calendar"
+msgstr "Estándar"
+
+#: support/templates/campaign_management_menu.html:323
+#: support/templates/support/seller_attendance_filter.html:5
+#: support/templates/support/seller_attendance_filter.html:14
+#: support/views/all_views.py:3398
+msgid "Seller Attendance Filter"
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:326
+msgid ""
+"Filter and export seller attendance records by date range, seller, and "
+"absence reason."
+msgstr ""
+
+#: support/templates/campaign_management_menu.html:328
+#, fuzzy
+#| msgid "Go to Mailtrain"
+msgid "Go to filter"
+msgstr "Ir a Mailtrain"
+
+#: support/templates/campaign_statistics_detail.html:25
 msgid "Campaign summary"
 msgstr "Resumen de la campaña"
 
-#: support/templates/campaign_statistics_detail.html:26
+#: support/templates/campaign_statistics_detail.html:27
 msgid "Filtered"
 msgstr "Filtrado"
 
-#: support/templates/campaign_statistics_detail.html:31
+#: support/templates/campaign_statistics_detail.html:37
 #: support/templates/campaign_statistics_per_seller.html:43
 msgid "Amount of contacts"
 msgstr "Cantidad de contactos"
 
-#: support/templates/campaign_statistics_detail.html:32
-#: support/templates/campaign_statistics_detail.html:33
+#: support/templates/campaign_statistics_detail.html:40
+#: support/templates/campaign_statistics_detail.html:44
 #: support/templates/campaign_statistics_per_seller.html:44
 msgid "Assigned"
 msgstr "Asignados"
 
-#: support/templates/campaign_statistics_detail.html:33
+#: support/templates/campaign_statistics_detail.html:44
 msgid "this seller only"
 msgstr "solo este vendedor"
 
-#: support/templates/campaign_statistics_detail.html:34
+#: support/templates/campaign_statistics_detail.html:48
 #: support/templates/campaign_statistics_per_seller.html:45
+#: support/templates/contact_detail/edit_campaign_status.html:31
+#: support/templates/contact_detail/tabs/_campaigns.html:47
 msgid "Not assigned"
 msgstr "No asignados"
 
-#: support/templates/campaign_statistics_detail.html:48
+#: support/templates/campaign_statistics_detail.html:68
 msgid "Filter by seller"
 msgstr "Filtrar por vendedor"
 
-#: support/templates/campaign_statistics_detail.html:64
-#: support/templates/contact_detail/detail.html:99
+#: support/templates/campaign_statistics_detail.html:72
+#, fuzzy
+#| msgid "Filter by seller"
+msgid "Filter by status"
+msgstr "Filtrar por vendedor"
+
+#: support/templates/campaign_statistics_detail.html:78
+#, fuzzy
+#| msgid "Not assigned"
+msgid "Date assigned (from)"
+msgstr "No asignados"
+
+#: support/templates/campaign_statistics_detail.html:80
+msgid "Filter contacts assigned from this date onwards"
+msgstr ""
+
+#: support/templates/campaign_statistics_detail.html:83
+#, fuzzy
+#| msgid "Assigned to"
+msgid "Date assigned (to)"
+msgstr "Asignado a"
+
+#: support/templates/campaign_statistics_detail.html:85
+#, fuzzy
+#| msgid "View contacts with this tag"
+msgid "Filter contacts assigned up to this date"
+msgstr "Ver contactos con esta etiqueta"
+
+#: support/templates/campaign_statistics_detail.html:90
+#, fuzzy
+#| msgid "Creation date (from)"
+msgid "Last action date (from)"
+msgstr "Fecha de creación (desde)"
+
+#: support/templates/campaign_statistics_detail.html:92
+msgid "Filter contacts with last action from this date onwards"
+msgstr ""
+
+#: support/templates/campaign_statistics_detail.html:95
+#, fuzzy
+#| msgid "Creation date (to)"
+msgid "Last action date (to)"
+msgstr "Fecha de creación (hasta)"
+
+#: support/templates/campaign_statistics_detail.html:97
+#, fuzzy
+#| msgid "View contacts with this tag"
+msgid "Filter contacts with last action up to this date"
+msgstr "Ver contactos con esta etiqueta"
+
+#: support/templates/campaign_statistics_detail.html:104
+#, fuzzy
+#| msgid "Clear filter"
+msgid "Apply filters"
+msgstr "Limpiar filtro"
+
+#: support/templates/campaign_statistics_detail.html:109
+#, fuzzy
+#| msgid "Clear filter"
+msgid "Clear filters"
+msgstr "Limpiar filtro"
+
+#: support/templates/campaign_statistics_detail.html:113
+#: support/templates/support/seller_attendance_filter.html:96
+#, fuzzy
+#| msgid "Export to CSV"
+msgid "Export CSV"
+msgstr "Exportar a CSV"
+
+#: support/templates/campaign_statistics_detail.html:122
+#: support/templates/contact_detail/detail.html:123
 msgid "Overview"
 msgstr "Resumen"
 
-#: support/templates/campaign_statistics_detail.html:77
+#: support/templates/campaign_statistics_detail.html:135
 msgid "Not contacted yet"
 msgstr "No contactados todavía"
 
-#: support/templates/campaign_statistics_detail.html:82
+#: support/templates/campaign_statistics_detail.html:140
 msgid "Tried to contact and could not"
 msgstr "Se intentó contactar y no se pudo"
 
@@ -5294,10 +7476,6 @@ msgstr "Por vendedor"
 msgid "Can't find"
 msgstr "No encontrado"
 
-#: support/templates/campaign_statistics_list.html:84
-msgid "Sellers"
-msgstr "Vendedores"
-
 #: support/templates/campaign_statistics_list.html:100
 #: support/templates/campaign_statistics_list.html:102
 #: support/templates/invoicing_issues.html:148
@@ -5316,6 +7494,10 @@ msgstr "primero"
 msgid "last"
 msgstr "último"
 
+#: support/templates/campaign_statistics_per_seller.html:25
+msgid "Statistics for"
+msgstr "Estadísticas para"
+
 #: support/templates/check_for_existing_contacts.html:5
 #: support/templates/check_for_existing_contacts.html:9
 msgid "Check for Existing Contacts"
@@ -5326,157 +7508,943 @@ msgid "Upload Form"
 msgstr "Formulario de subida"
 
 #: support/templates/check_for_existing_contacts.html:18
-msgid "Download CSV Template"
+#, fuzzy
+#| msgid "Download CSV Template"
+msgid "Download Email CSV Template"
 msgstr "Descargar plantilla CSV"
 
-#: support/templates/check_for_existing_contacts.html:27
+#: support/templates/check_for_existing_contacts.html:21
+#, fuzzy
+#| msgid "Download CSV Template"
+msgid "Download Phone CSV Template"
+msgstr "Descargar plantilla CSV"
+
+#: support/templates/check_for_existing_contacts.html:30
 msgid "Form has encountered some errors"
 msgstr "El formulario ha encontrado algunos errores"
 
-#: support/templates/check_for_existing_contacts.html:38
+#: support/templates/check_for_existing_contacts.html:40
+msgid "Instructions - How Contact Matching Works"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:50
+#, fuzzy
+#| msgid "Check for Existing Contacts"
+msgid "Two Ways to Check for Contacts"
+msgstr "Verificar contactos existentes"
+
+#: support/templates/check_for_existing_contacts.html:51
+msgid "This tool can match contacts by EMAIL or by PHONE NUMBER."
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:54
+msgid "Email Match (Case-Insensitive)"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:55
+msgid ""
+"The system searches for contacts by email address. The match is case-"
+"insensitive"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:59
+#, fuzzy
+#| msgid "Phone call"
+msgid "Phone Match"
+msgstr "Llamada telefónica"
+
+#: support/templates/check_for_existing_contacts.html:60
+msgid ""
+"The system searches for contacts by phone or mobile number. It checks both "
+"the 'phone' and 'mobile' fields in the database."
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:65
+msgid "What You'll See in Results"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:66
+msgid "For each matching contact found, you'll see:"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:68
+#, fuzzy
+#| msgid "Contact Name"
+msgid "Contact ID & Name"
+msgstr "Nombre del contacto"
+
+#: support/templates/check_for_existing_contacts.html:68
+#, fuzzy
+#| msgid "Go to contact details"
+msgid "Link to the contact's detail page"
+msgstr "Ir a los detalles del contacto"
+
+#: support/templates/check_for_existing_contacts.html:69
+#, fuzzy
+#| msgid "Route Number"
+msgid "CSV Row Number"
+msgstr "Número de ruta"
+
+#: support/templates/check_for_existing_contacts.html:69
+msgid "Which row in your CSV file matched this contact"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:70
+#: support/templates/check_for_existing_contacts.html:186
+#: support/templates/import_contacts.html:88
+msgid "Has Active Subscription"
+msgstr "Tiene suscripción activa"
+
+#: support/templates/check_for_existing_contacts.html:70
+#, fuzzy
+#| msgid "Customer already has an active subscription."
+msgid "Whether the contact currently has an active subscription"
+msgstr "El cliente ya tiene una suscripción activa."
+
+#: support/templates/check_for_existing_contacts.html:71
+#: support/templates/check_for_existing_contacts.html:187
+#: support/templates/import_contacts.html:83
+msgid "In Active Campaign"
+msgstr "En campaña activa"
+
+#: support/templates/check_for_existing_contacts.html:71
+#, fuzzy
+#| msgid "This contact is not present in any campaign"
+msgid "Whether the contact is currently in an active campaign"
+msgstr "Este contacto no está presente en ninguna campaña"
+
+#: support/templates/check_for_existing_contacts.html:76
+#, fuzzy
+#| msgid "No Matches Found"
+msgid "Matches Found:"
+msgstr "No se encontraron coincidencias"
+
+#: support/templates/check_for_existing_contacts.html:76
+msgid ""
+"These contacts already exist in the database. You can review their status "
+"and decide if you want to add them to a campaign or take other actions."
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:81
+#, fuzzy
+#| msgid "No Matches Found"
+msgid "No Matches Found:"
+msgstr "No se encontraron coincidencias"
+
+#: support/templates/check_for_existing_contacts.html:81
+msgid ""
+"These entries don't exist in the database. These are potential new contacts "
+"that could be imported using the Import Contacts tool."
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:87
+msgid "What to Expect After Checking"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:90
+#, fuzzy
+#| msgid "Matching Contacts Found"
+msgid "Matching Contacts"
+msgstr "Coincidencias encontradas"
+
+#: support/templates/check_for_existing_contacts.html:91
+msgid "You'll see a table with:"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:93
+msgid "Total number of matches found"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:94
+#, fuzzy
+#| msgid "Has active subscriptions"
+msgid "How many have active subscriptions"
+msgstr "Tiene suscripciones activas"
+
+#: support/templates/check_for_existing_contacts.html:95
+#, fuzzy
+#| msgid "In Active Campaigns"
+msgid "How many are in active campaigns"
+msgstr "En campañas activas"
+
+#: support/templates/check_for_existing_contacts.html:96
+msgid "Export option to download results as CSV"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:101
+#, fuzzy
+#| msgid "No Matches Found"
+msgid "No Matches"
+msgstr "No se encontraron coincidencias"
+
+#: support/templates/check_for_existing_contacts.html:102
+msgid "You'll see a separate table with:"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:104
+msgid "Values not found in database"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:105
+msgid "CSV row numbers for reference"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:106
+msgid "Export option to download non-matches"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:113
+#: support/templates/import_contacts.html:245
+msgid "Pro Tip:"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:113
+msgid ""
+"Use this tool before importing contacts to avoid duplicates. Export the 'No "
+"Matches' list and use it with the Import Contacts tool to add only new "
+"contacts."
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:122
 msgid "Choose a CSV file to check for existing contacts"
 msgstr "Elija un archivo CSV para chequear contactos existentes"
 
-#: support/templates/check_for_existing_contacts.html:43
+#: support/templates/check_for_existing_contacts.html:125
+msgid "CSV File Requirements"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:127
+msgid "For Email Checking"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:127
 msgid "Your CSV file must contain an 'email' column header"
 msgstr "Su archivo CSV debe contener un cabezal de ‘email’"
 
-#: support/templates/check_for_existing_contacts.html:44
+#: support/templates/check_for_existing_contacts.html:128
+msgid "For Phone Checking"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:128
+#, fuzzy
+#| msgid "Your CSV file must contain an 'email' column header"
+msgid "Your CSV file must contain a 'phone' column header"
+msgstr "Su archivo CSV debe contener un cabezal de ‘email’"
+
+#: support/templates/check_for_existing_contacts.html:129
 msgid "The system automatically detects comma (,) or semicolon (;) delimiters"
 msgstr ""
 "El sistema detecta automáticamente comas (,) o puntos y comas (;) como "
 "delimitadores"
 
-#: support/templates/check_for_existing_contacts.html:45
-msgid "Only email addresses will be used for matching existing contacts"
-msgstr ""
-"Solo se utilizarán las direcciones de correo electrónico para buscar "
-"contactos existentes"
-
-#: support/templates/check_for_existing_contacts.html:46
-msgid "Download the template above for the correct format"
+#: support/templates/check_for_existing_contacts.html:130
+#, fuzzy
+#| msgid "Download the template above for the correct format"
+msgid "Download the appropriate template above for the correct format"
 msgstr "Descargar la plantilla más arriba para utilizar el formato correcto"
 
-#: support/templates/check_for_existing_contacts.html:51
-msgid "Upload and Check"
-msgstr "Subir y verificar"
+#: support/templates/check_for_existing_contacts.html:137
+msgid "Check by Email"
+msgstr ""
 
-#: support/templates/check_for_existing_contacts.html:59
+#: support/templates/check_for_existing_contacts.html:140
+msgid "Check by Phone"
+msgstr ""
+
+#: support/templates/check_for_existing_contacts.html:151
 msgid "Matching Contacts Found"
 msgstr "Coincidencias encontradas"
 
-#: support/templates/check_for_existing_contacts.html:59
+#: support/templates/check_for_existing_contacts.html:152
 msgid "Active Subscriptions"
 msgstr "Suscripciones activas"
 
-#: support/templates/check_for_existing_contacts.html:59
+#: support/templates/check_for_existing_contacts.html:153
 #: support/templates/tag_analysis.html:96
 msgid "In Active Campaigns"
 msgstr "En campañas activas"
 
-#: support/templates/check_for_existing_contacts.html:61
+#: support/templates/check_for_existing_contacts.html:155
+#: support/templates/check_for_existing_contacts.html:240
+#, fuzzy
+#| msgid "Email count"
+msgid "Email Check"
+msgstr "Cantidad de correos electrónicos"
+
+#: support/templates/check_for_existing_contacts.html:157
+#: support/templates/check_for_existing_contacts.html:242
+#, fuzzy
+#| msgid "Phone call"
+msgid "Phone Check"
+msgstr "Llamada telefónica"
+
+#: support/templates/check_for_existing_contacts.html:161
 msgid "Detected delimiter"
 msgstr "Delimitador detectado"
 
-#: support/templates/check_for_existing_contacts.html:77
-#: support/views/all_views.py:625 support/views/all_views.py:708
-#: support/views/all_views.py:1184 support/views/all_views.py:1342
-#: support/views/all_views.py:1422 support/views/all_views.py:1863
-#: support/views/all_views.py:1989 support/views/scheduled_tasks.py:232
+#: support/templates/check_for_existing_contacts.html:177
+#: support/templates/seller_console_never_paid_issues.html:26
+#: support/views/all_views.py:688 support/views/all_views.py:1863
+#: support/views/all_views.py:2021 support/views/all_views.py:2117
+#: support/views/all_views.py:2284 support/views/all_views.py:2747
+#: support/views/all_views.py:2897 support/views/scheduled_tasks.py:232
 msgid "Contact ID"
 msgstr "ID de contacto"
 
-#: support/templates/check_for_existing_contacts.html:78
-#: support/templates/check_for_existing_contacts.html:136
+#: support/templates/check_for_existing_contacts.html:178
+#: support/templates/check_for_existing_contacts.html:260
 msgid "CSV Row"
 msgstr "Fila CSV"
 
-#: support/templates/check_for_existing_contacts.html:81
-msgid "Has Active Subscription"
-msgstr "Tiene suscripción activa"
+#: support/templates/check_for_existing_contacts.html:183
+#: support/templates/check_for_existing_contacts.html:264
+#, fuzzy
+#| msgid "Phone number"
+msgid "Phone Number"
+msgstr "Número de teléfono"
 
-#: support/templates/check_for_existing_contacts.html:82
-msgid "In Active Campaign"
-msgstr "En campaña activa"
+#: support/templates/check_for_existing_contacts.html:184
+#, fuzzy
+#| msgid "Payment Type"
+msgid "Match Type"
+msgstr "Tipo de pago"
 
-#: support/templates/check_for_existing_contacts.html:120
+#: support/templates/check_for_existing_contacts.html:238
 msgid "No Matches Found"
 msgstr "No se encontraron coincidencias"
 
-#: support/templates/check_for_existing_contacts.html:131
+#: support/templates/check_for_existing_contacts.html:255
 msgid "The following entries had no matching contacts:"
 msgstr "Las siguientes entradas no coincidieron con contactos:"
 
-#: support/templates/contact_detail/detail.html:72
+#: support/templates/community_console.html:4
+#: support/templates/community_console.html:88 support/views/all_views.py:751
+#: templates/components/_sidebar.html:72
+#, fuzzy
+#| msgid "Community Events"
+msgid "Community console"
+msgstr "Eventos comunitarios"
+
+#: support/templates/community_console.html:89
+msgid "Issue management dashboard"
+msgstr ""
+
+#: support/templates/community_console.html:135
+#, fuzzy
+#| msgid "Total price"
+msgid "Total open"
+msgstr "Precio total"
+
+#: support/templates/community_console.html:151
+#: support/templates/community_manager_dashboard.html:147
+msgid "Filter by category or subcategory..."
+msgstr ""
+
+#: support/templates/community_console.html:156
+#: support/templates/community_manager_dashboard.html:152
+#, fuzzy
+#| msgid "Expand"
+msgid "Expand all"
+msgstr "Expandir"
+
+#: support/templates/community_console.html:159
+#: support/templates/community_manager_dashboard.html:155
+#, fuzzy
+#| msgid "Replace all"
+msgid "Collapse all"
+msgstr "Reemplazar todo"
+
+#: support/templates/community_console.html:180
+#: support/templates/community_manager_dashboard.html:176
+#, fuzzy
+#| msgid "Issue Subcategories"
+msgid "subcategories"
+msgstr "Subcategorías de incidencia"
+
+#: support/templates/community_console.html:218
+#: support/templates/community_manager_dashboard.html:214
+#: support/templates/community_manager_dashboard.html:366
+#: support/templates/community_manager_overview.html:169
+#: support/templates/community_manager_overview.html:424
+#, fuzzy
+#| msgid "No day"
+msgid "No date"
+msgstr "Sin día"
+
+#: support/templates/community_console.html:232
+#: support/templates/community_manager_dashboard.html:229
+#: support/templates/community_manager_overview.html:194
+#, fuzzy
+#| msgid "View issue"
+msgid "View overdue issues"
+msgstr "Ver incidencia"
+
+#: support/templates/community_console.html:242
+#: support/templates/community_manager_dashboard.html:239
+#: support/templates/community_manager_overview.html:204
+#, fuzzy
+#| msgid "View issue"
+msgid "View today issues"
+msgstr "Ver incidencia"
+
+#: support/templates/community_console.html:252
+#: support/templates/community_manager_dashboard.html:249
+#: support/templates/community_manager_overview.html:214
+#, fuzzy
+#| msgid "View issue"
+msgid "View future issues"
+msgstr "Ver incidencia"
+
+#: support/templates/community_console.html:262
+#: support/templates/community_manager_dashboard.html:259
+#: support/templates/community_manager_overview.html:224
+msgid "View issues without date"
+msgstr ""
+
+#: support/templates/community_console.html:271
+#: support/templates/community_manager_dashboard.html:268
+#: support/templates/community_manager_overview.html:233
+#, fuzzy
+#| msgid "View issue"
+msgid "View all issues"
+msgstr "Ver incidencia"
+
+#: support/templates/community_console.html:327
+#: support/templates/community_manager_dashboard.html:333
+#, fuzzy
+#| msgid "No tags found matching your search criteria."
+msgid "No categories or subcategories match your search."
+msgstr "No se encontraron etiquetas para sus criterios de búsqueda."
+
+#: support/templates/community_console.html:334
+msgid "No open issues assigned to you"
+msgstr ""
+
+#: support/templates/community_console.html:335
+msgid "All caught up! There are no open issues assigned to you at this time."
+msgstr ""
+
+#: support/templates/community_console.html:343
+msgid "How this console works"
+msgstr ""
+
+#: support/templates/community_console.html:351
+msgid ""
+"This console shows all open issues assigned to you, grouped by category and "
+"subcategory. Issues in a terminal state (finished/resolved) are excluded."
+msgstr ""
+
+#: support/templates/community_console.html:352
+#: support/templates/community_manager_dashboard.html:361
+#, fuzzy
+#| msgid "Date from"
+msgid "Date columns"
+msgstr "Fecha desde"
+
+#: support/templates/community_console.html:354
+#: support/templates/community_manager_overview.html:421
+msgid ""
+"Issues whose next action date is before today. These need immediate "
+"attention."
+msgstr ""
+
+#: support/templates/community_console.html:355
+msgid "Issues whose next action date is today. These are due now."
+msgstr ""
+
+#: support/templates/community_console.html:356
+msgid ""
+"Issues whose next action date is after today. These are scheduled for later."
+msgstr ""
+
+#: support/templates/community_console.html:358
+msgid "Interacting with the console"
+msgstr ""
+
+#: support/templates/community_console.html:360
+#: support/templates/community_manager_dashboard.html:370
+msgid ""
+"Click on any number to open the issue list filtered by that category, "
+"subcategory, and date range."
+msgstr ""
+
+#: support/templates/community_console.html:361
+msgid "Use the search bar to quickly find a specific category or subcategory."
+msgstr ""
+
+#: support/templates/community_console.html:362
+msgid "Click on a category header to expand or collapse its details."
+msgstr ""
+
+#: support/templates/community_console.html:363
+msgid ""
+"Use the Expand All / Collapse All buttons to toggle all categories at once."
+msgstr ""
+
+#: support/templates/community_console.html:365
+msgid ""
+"The date used for grouping is the issue's next action date. Issues without a "
+"next action date appear in the 'No date' column."
+msgstr ""
+
+#: support/templates/community_manager_assign.html:4
+#: support/templates/community_manager_assign.html:45
+#: support/templates/community_manager_dashboard.html:275
+#, fuzzy
+#| msgid "Assign routes"
+msgid "Assign issues"
+msgstr "Asignar rutas"
+
+#: support/templates/community_manager_assign.html:46
+msgid "Distribute unassigned issues to GDC team members"
+msgstr ""
+
+#: support/templates/community_manager_assign.html:50
+#: support/templates/community_manager_assign.html:239
+#: support/templates/community_manager_overview.html:86
+#, fuzzy
+#| msgid "Back to contact"
+msgid "Back to dashboard"
+msgstr "Volver al contacto"
+
+#: support/templates/community_manager_assign.html:53
+#: support/templates/community_manager_dashboard.html:82
+#: support/templates/community_manager_dashboard.html:343
+#: support/templates/community_manager_overview.html:4
+#: support/templates/community_manager_overview.html:81
+#: support/views/all_views.py:1176
+#, fuzzy
+#| msgid "Overview"
+msgid "Team overview"
+msgstr "Resumen"
+
+#: support/templates/community_manager_assign.html:66
+#: support/templates/community_manager_assign.html:75
+#: support/templates/community_manager_assign.html:84
+#: support/templates/community_manager_assign.html:93
+#, fuzzy
+#| msgid "Assigned"
+msgid "(Unassigned)"
+msgstr "Asignados"
+
+#: support/templates/community_manager_assign.html:93
+#, fuzzy
+#| msgid "Contacts available"
+msgid "Total available"
+msgstr "Contactos disponibles"
+
+#: support/templates/community_manager_assign.html:93
+msgid "(includes issues without next action date)"
+msgstr ""
+
+#: support/templates/community_manager_assign.html:103
+#, python-format
+msgid ""
+"\n"
+"        %(count)s issue(s) have no next action date set. Upon assignment, "
+"they will get tomorrow as their next action date.\n"
+"      "
+msgstr ""
+
+#: support/templates/community_manager_assign.html:115
+msgid "Assign issues to team members"
+msgstr ""
+
+#: support/templates/community_manager_assign.html:119
+#, fuzzy, python-format
+#| msgid "None available"
+msgid "%(count)s issues available"
+msgstr "Ninguno disponible"
+
+#: support/templates/community_manager_assign.html:129
+#: support/templates/community_manager_overview.html:158
+msgid "Team member"
+msgstr ""
+
+#: support/templates/community_manager_assign.html:130
+#, fuzzy
+#| msgid "Payment type issue"
+msgid "Current total open issues"
+msgstr "Incidente de tipo de pago"
+
+#: support/templates/community_manager_assign.html:130
+#, fuzzy
+#| msgid "Ended without contact"
+msgid "(includes without date)"
+msgstr "Finalizado sin contacto"
+
+#: support/templates/community_manager_assign.html:185
+msgid ""
+"No GDC team members found. Make sure users have the community console "
+"permission."
+msgstr ""
+
+#: support/templates/community_manager_assign.html:194
+#, fuzzy
+#| msgid "Total Commission"
+msgid "Total to assign:"
+msgstr "Comisión total"
+
+#: support/templates/community_manager_assign.html:214
+msgid "How assignment works"
+msgstr ""
+
+#: support/templates/community_manager_assign.html:223
+msgid "Issues are assigned from oldest to newest (by issue date)."
+msgstr ""
+
+#: support/templates/community_manager_assign.html:224
+msgid ""
+"When assigning to multiple users, a round-robin algorithm distributes issues "
+"evenly. This ensures older/higher-priority issues are spread equally among "
+"all selected users."
+msgstr ""
+
+#: support/templates/community_manager_assign.html:225
+msgid ""
+"Upon assignment, if an issue has no next action date or its date is in the "
+"past, it will be set to tomorrow."
+msgstr ""
+
+#: support/templates/community_manager_assign.html:226
+msgid ""
+"If the issue already has a future next action date, it will remain unchanged."
+msgstr ""
+
+#: support/templates/community_manager_assign.html:227
+msgid ""
+"The issue status will not be changed upon assignment — it keeps its current "
+"status."
+msgstr ""
+
+#: support/templates/community_manager_assign.html:236
+#: support/templates/community_manager_dashboard.html:340
+#, fuzzy
+#| msgid "Not assigned"
+msgid "No unassigned issues"
+msgstr "No asignados"
+
+#: support/templates/community_manager_assign.html:237
+msgid "All issues in this subcategory have been assigned."
+msgstr ""
+
+#: support/templates/community_manager_assign.html:285
+#, fuzzy
+#| msgid "Are you sure you want to cancel this invoice?"
+msgid "Are you sure you want to assign"
+msgstr "¿Confirma la anulación de esta factura?"
+
+#: support/templates/community_manager_assign.html:285
+msgid "issues using round-robin distribution?"
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:4
+#: support/templates/community_manager_dashboard.html:77
+#: support/views/all_views.py:857 support/views/all_views.py:959
+#: support/views/all_views.py:1175
+msgid "Community manager dashboard"
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:78
+#, fuzzy
+#| msgid "Issue Subcategory"
+msgid "Unassigned issues by subcategory"
+msgstr "Subcategoría de incidencia"
+
+#: support/templates/community_manager_dashboard.html:95
+#, fuzzy
+#| msgid "Overdue invoices"
+msgid "Overdue (unassigned)"
+msgstr "Facturas vencidas"
+
+#: support/templates/community_manager_dashboard.html:104
+#, fuzzy
+#| msgid "Not assigned"
+msgid "Today (unassigned)"
+msgstr "No asignados"
+
+#: support/templates/community_manager_dashboard.html:113
+#, fuzzy
+#| msgid "Not assigned"
+msgid "Future (unassigned)"
+msgstr "No asignados"
+
+#: support/templates/community_manager_dashboard.html:122
+#, fuzzy
+#| msgid "Not assigned"
+msgid "No date (unassigned)"
+msgstr "No asignados"
+
+#: support/templates/community_manager_dashboard.html:131
+#, fuzzy
+#| msgid "Not assigned"
+msgid "Total unassigned"
+msgstr "No asignados"
+
+#: support/templates/community_manager_dashboard.html:341
+msgid ""
+"All issues have been assigned. Check the team overview to see how everyone "
+"is doing."
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:352
+msgid "How this dashboard works"
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:360
+msgid ""
+"This dashboard shows all open issues that have not been assigned to anyone, "
+"grouped by category and subcategory."
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:363
+msgid "Issues whose next action date is before today."
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:364
+#: support/templates/community_manager_overview.html:422
+msgid "Issues whose next action date is today."
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:365
+#: support/templates/community_manager_overview.html:423
+msgid "Issues whose next action date is after today."
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:366
+msgid "Issues without a next action date set."
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:368
+#: support/templates/community_manager_overview.html:427
+#, fuzzy
+#| msgid "Internal"
+msgid "Interacting"
+msgstr "Interno"
+
+#: support/templates/community_manager_dashboard.html:371
+msgid ""
+"Click the 'Assign' button next to a subcategory to open the assignment "
+"screen."
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:372
+msgid ""
+"In the assignment screen, you can distribute issues among GDC team members "
+"using round-robin."
+msgstr ""
+
+#: support/templates/community_manager_dashboard.html:373
+msgid ""
+"Use the 'Team overview' button to see how all team members are performing."
+msgstr ""
+
+#: support/templates/community_manager_overview.html:82
+msgid "Issue status for all GDC team members"
+msgstr ""
+
+#: support/templates/community_manager_overview.html:99
+#, fuzzy
+#| msgid "Overdue invoices"
+msgid "Overdue (assigned)"
+msgstr "Facturas vencidas"
+
+#: support/templates/community_manager_overview.html:108
+#, fuzzy
+#| msgid "Not assigned"
+msgid "Today (assigned)"
+msgstr "No asignados"
+
+#: support/templates/community_manager_overview.html:117
+#, fuzzy
+#| msgid "Not assigned"
+msgid "Future (assigned)"
+msgstr "No asignados"
+
+#: support/templates/community_manager_overview.html:126
+#, fuzzy
+#| msgid "Not assigned"
+msgid "No date set (assigned)"
+msgstr "No asignados"
+
+#: support/templates/community_manager_overview.html:137
+#, fuzzy
+#| msgid "Not assigned"
+msgid "Total assigned to team"
+msgstr "No asignados"
+
+#: support/templates/community_manager_overview.html:150
+msgid "Team members"
+msgstr ""
+
+#: support/templates/community_manager_overview.html:172
+#: support/templates/community_manager_overview.html:425
+#, fuzzy
+#| msgid "Distributor"
+msgid "Distribution"
+msgstr "Distribuidor"
+
+#: support/templates/community_manager_overview.html:410
+msgid "How to read this overview"
+msgstr ""
+
+#: support/templates/community_manager_overview.html:418
+msgid "This overview shows the current workload of all GDC team members."
+msgstr ""
+
+#: support/templates/community_manager_overview.html:419
+msgid "Columns"
+msgstr ""
+
+#: support/templates/community_manager_overview.html:424
+msgid "Issues that have no next action date set."
+msgstr ""
+
+#: support/templates/community_manager_overview.html:425
+msgid ""
+"Visual bar showing the proportion of overdue (red), today (yellow), and "
+"future (green) issues."
+msgstr ""
+
+#: support/templates/community_manager_overview.html:429
+msgid ""
+"Click on a team member's row to expand/collapse their per-category and "
+"subcategory breakdown."
+msgstr ""
+
+#: support/templates/community_manager_overview.html:430
+msgid ""
+"Click on any number to open the issue list filtered by that user, category/"
+"subcategory, and date range."
+msgstr ""
+
+#: support/templates/community_manager_overview.html:431
+msgid ""
+"A high proportion of red (overdue) indicates the team member may need help "
+"or reassignment."
+msgstr ""
+
+#: support/templates/community_manager_overview.html:432
+msgid ""
+"Use the dashboard to assign more issues to team members with lighter "
+"workloads."
+msgstr ""
+
+#: support/templates/community_manager_overview.html:441
+msgid "No GDC team members found"
+msgstr ""
+
+#: support/templates/community_manager_overview.html:442
+msgid "Make sure users have the community console permission assigned."
+msgstr ""
+
+#: support/templates/contact_detail/detail.html:44
+#: support/templates/contact_detail/detail.html:55
+#: support/templates/contact_detail/tabs/_overview.html:254
+#: support/templates/contact_detail/tabs/_overview.html:301
+#, fuzzy
+#| msgid "Expand"
+msgid "expand"
+msgstr "Expandir"
+
+#: support/templates/contact_detail/detail.html:44
+#: support/templates/contact_detail/detail.html:55
+msgid "collapse"
+msgstr ""
+
+#: support/templates/contact_detail/detail.html:96
 msgid "New Activity"
 msgstr "Nueva actividad"
 
-#: support/templates/contact_detail/detail.html:74
+#: support/templates/contact_detail/detail.html:98
 msgid "New Issue"
 msgstr "Nuevo incidencia"
 
-#: support/templates/contact_detail/detail.html:78
+#: support/templates/contact_detail/detail.html:102
 msgid "See in Admin"
 msgstr "Ver en Admin"
 
-#: support/templates/contact_detail/detail.html:81
+#: support/templates/contact_detail/detail.html:105
 msgid "Total Pause"
 msgstr "Pausa total"
 
-#: support/templates/contact_detail/detail.html:83
+#: support/templates/contact_detail/detail.html:107
 msgid "Partial Pause"
 msgstr "Pausa parcial"
 
-#: support/templates/contact_detail/detail.html:85
+#: support/templates/contact_detail/detail.html:109
 msgid "Address Change"
 msgstr "Cambio de dirección"
 
-#: support/templates/contact_detail/detail.html:105
-#: support/templates/contact_detail/tabs/_overview.html:139
+#: support/templates/contact_detail/detail.html:129
+#: support/templates/contact_detail/tabs/_overview.html:186
 #: support/templates/history_extended.html:68
 #: support/templates/seller_performance_by_time.html:46
 msgid "Subscriptions"
 msgstr "Suscripciones"
 
-#: support/templates/contact_detail/detail.html:108
-#: support/templates/contact_detail/tabs/_campaigns.html:5
+#: support/templates/contact_detail/detail.html:132
+#: support/templates/contact_detail/tabs/_campaigns.html:6
 #: support/templates/seller_console_list_campaigns.html:3
 msgid "Campaigns"
 msgstr "Campañas"
 
-#: support/templates/contact_detail/detail.html:121
+#: support/templates/contact_detail/detail.html:145
 msgid "Tasks"
 msgstr "Tareas"
 
-#: support/templates/contact_detail/detail.html:126
+#: support/templates/contact_detail/detail.html:150
 #: support/templates/invoicing_issues.html:107
-#: support/templates/list_issues.html:196
-#: support/templates/scheduled_activities.html:20
-#: support/templates/seller_console.html:225
-#: support/templates/view_issue.html:195 support/views/activities.py:29
+#: support/templates/list_issues.html:266
+#: support/templates/scheduled_activities.html:38
+#: support/templates/seller_console.html:259 support/views/activities.py:29
 msgid "Activities"
 msgstr "Actividades"
 
-#: support/templates/contact_detail/detail.html:131
-msgid "Most Read"
-msgstr "Más leído"
-
-#: support/templates/contact_detail/detail.html:134
+#: support/templates/contact_detail/detail.html:155
 msgid "Vouchers"
 msgstr "Cupones"
 
-#: support/templates/contact_detail/detail.html:137
-#: support/templates/contact_detail/tabs/_web_comments.html:5
+#: support/templates/contact_detail/detail.html:158
+#: support/templates/contact_detail/tabs/_last_read.html:6
+msgid "Web Reading"
+msgstr ""
+
+#: support/templates/contact_detail/detail.html:161
+#: support/templates/contact_detail/tabs/_web_comments.html:6
 msgid "Web Comments"
 msgstr "Comentarios web"
 
-#: support/templates/contact_detail/detail.html:140
+#: support/templates/contact_detail/detail.html:164
 #: support/templates/contact_detail/tabs/_whatsapp_messages.html:5
 msgid "WhatsApp Messages"
 msgstr "Mensajes de WhatsApp"
 
+#: support/templates/contact_detail/edit_campaign_status.html:3
+#: support/templates/contact_detail/edit_campaign_status.html:5
+#, fuzzy
+#| msgid "Contact Campaign Status"
+msgid "Edit Campaign Status"
+msgstr "Estado de contacto en la campaña"
+
+#: support/templates/contact_detail/edit_campaign_status.html:38
+#: support/templates/contact_detail/tabs/_campaigns.html:95
+msgid "Assigned to Campaign"
+msgstr "Asignado a la campaña"
+
+#: support/templates/contact_detail/edit_campaign_status.html:42
+#: support/templates/contact_detail/tabs/_campaigns.html:55
+msgid "Date of last action"
+msgstr "Fecha de última acción"
+
+#: support/templates/contact_detail/edit_campaign_status.html:53
+#, fuzzy
+#| msgid "Status"
+msgid "Edit Status"
+msgstr "Estado"
+
 #: support/templates/contact_detail/tabs/_activities.html:5
-#: support/templates/contact_detail/tabs/_overview.html:219
+#: support/templates/contact_detail/tabs/_overview.html:268
 msgid "Latest activities"
 msgstr "Últimas actividades"
 
@@ -5484,34 +8452,28 @@ msgstr "Últimas actividades"
 msgid "Activity type"
 msgstr "Tipo de actividad"
 
-#: support/templates/contact_detail/tabs/_activities.html:59
-#: support/templates/contact_detail/tabs/_overview.html:265
+#: support/templates/contact_detail/tabs/_activities.html:63
+#: support/templates/contact_detail/tabs/_overview.html:309
 msgid "This contact has no activities"
 msgstr "Este contacto no tiene actividades"
 
 #: support/templates/contact_detail/tabs/_campaigns.html:29
-msgid "Date of last action"
-msgstr "Fecha de última acción"
+#, fuzzy
+#| msgid "Edit list"
+msgid "Edit status"
+msgstr "Editar lista"
 
-#: support/templates/contact_detail/tabs/_campaigns.html:43
-msgid "Assigned to Campaign"
-msgstr "Asignado a la campaña"
-
-#: support/templates/contact_detail/tabs/_campaigns.html:49
+#: support/templates/contact_detail/tabs/_campaigns.html:102
 msgid "Assigned to Seller"
 msgstr "Asignado al vendedor"
 
-#: support/templates/contact_detail/tabs/_campaigns.html:56
-msgid "Resolution"
-msgstr "Resolución"
+#: support/templates/contact_detail/tabs/_campaigns.html:133
+#, fuzzy
+#| msgid "Console Action"
+msgid "Last Console Action"
+msgstr "Acción de consola"
 
-#: support/templates/contact_detail/tabs/_campaigns.html:63
-#: support/templates/unsubscription_statistics.html:276
-#: support/templates/unsubscription_statistics.html:305
-msgid "Reason"
-msgstr "Motivo"
-
-#: support/templates/contact_detail/tabs/_campaigns.html:75
+#: support/templates/contact_detail/tabs/_campaigns.html:145
 msgid "This contact is not present in any campaign"
 msgstr "Este contacto no está presente en ninguna campaña"
 
@@ -5520,197 +8482,230 @@ msgid "Redeemed vouchers"
 msgstr "Cupones canjeados"
 
 #: support/templates/contact_detail/tabs/_get_redeemed_vouchers.html:8
-#: support/templates/contact_detail/tabs/_last_read.html:8
-#: support/templates/contact_detail/tabs/_web_comments.html:8
 #: support/templates/contact_detail/tabs/_whatsapp_messages.html:8
 msgid "This is not configured"
 msgstr "Esto no se encuentra configurado"
 
-#: support/templates/contact_detail/tabs/_information.html:14
-#: support/templates/contact_detail/tabs/_overview.html:15
-#: support/templates/contact_list.html:102
-msgid "ID document"
-msgstr "Documento de identificación"
-
-#: support/templates/contact_detail/tabs/_information.html:20
-#: support/templates/contact_detail/tabs/_overview.html:21
-msgid "Indentifier"
-msgstr "Identificador"
-
-#: support/templates/contact_detail/tabs/_information.html:40
-#: support/templates/contact_detail/tabs/_overview.html:40
-#: support/templates/create_contact/tabs/_data.html:43
-#: support/templates/seller_console.html:156 support/views/all_views.py:1190
-msgid "Institutional phone"
-msgstr "Teléfono institucional"
-
+#: support/templates/contact_detail/tabs/_information.html:45
 #: support/templates/contact_detail/tabs/_information.html:46
-#: support/templates/contact_detail/tabs/_overview.html:66
-#: support/templates/contact_list.html:47
+#: support/templates/contact_detail/tabs/_information.html:61
+#: support/templates/contact_detail/tabs/_information.html:62
+#: support/templates/contact_detail/tabs/_information.html:75
+#: support/templates/contact_detail/tabs/_information.html:76
+#: support/templates/contact_detail/tabs/_overview.html:42
+#: support/templates/contact_detail/tabs/_overview.html:43
+#: support/templates/contact_detail/tabs/_overview.html:58
+#: support/templates/contact_detail/tabs/_overview.html:59
+#: support/templates/contact_detail/tabs/_overview.html:72
+#: support/templates/contact_detail/tabs/_overview.html:73
+#: support/templates/create_contact/tabs/_data.html:46
+#: support/templates/create_contact/tabs/_data.html:61
 #: support/templates/create_contact/tabs/_data.html:76
+#: support/templates/new_subscription.html:189
+#: support/templates/new_subscription.html:201
+#, fuzzy
+#| msgid "Upload do not call list"
+msgid "Number in do not call list"
+msgstr "Subir lista de no contactar"
+
+#: support/templates/contact_detail/tabs/_information.html:71
+#: support/templates/contact_detail/tabs/_overview.html:68
+msgid "Work"
+msgstr ""
+
+#: support/templates/contact_detail/tabs/_information.html:87
+#: support/templates/contact_detail/tabs/_overview.html:116
+#: support/templates/contact_list.html:132
+#: support/templates/contact_list.html:177
+#: support/templates/create_contact/tabs/_data.html:114
+#: support/views/contacts.py:158
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: support/templates/contact_detail/tabs/_information.html:65
-#: support/templates/contact_detail/tabs/_overview.html:81
+#: support/templates/contact_detail/tabs/_information.html:99
 msgid "Edit info and newsletters"
 msgstr "Editar información y newsletters"
 
-#: support/templates/contact_detail/tabs/_information.html:72
-#: support/templates/contact_detail/tabs/_overview.html:46
-#: support/templates/contact_list.html:85
-#: support/templates/seller_console.html:210
+#: support/templates/contact_detail/tabs/_information.html:108
+#: support/templates/contact_detail/tabs/_overview.html:83
+#: support/templates/contact_list.html:176
+#: support/templates/seller_console.html:244
 msgid "Addresses"
 msgstr "Direcciones"
 
-#: support/templates/contact_detail/tabs/_information.html:83
+#: support/templates/contact_detail/tabs/_information.html:119
+#, fuzzy
+#| msgid "Billing Address"
+msgid "Missing Address"
+msgstr "Dirección de facturación"
+
+#: support/templates/contact_detail/tabs/_information.html:121
+#: support/templates/contact_detail/tabs/_overview.html:102
 msgid "Verified"
 msgstr "Verificado"
 
-#: support/templates/contact_detail/tabs/_information.html:85
-msgid "Saved without Georef"
-msgstr "Guardado sin georreferenciación"
+#: support/templates/contact_detail/tabs/_information.html:123
+#, fuzzy
+#| msgid "Needs georef"
+msgid "Needs Georef"
+msgstr "Necesita georeferenciación"
 
-#: support/templates/contact_detail/tabs/_information.html:132
-msgid "Address notes"
-msgstr "Notas de dirección"
-
-#: support/templates/contact_detail/tabs/_information.html:144
-#: support/templates/contact_detail/tabs/_overview.html:56
+#: support/templates/contact_detail/tabs/_information.html:173
+#: support/templates/contact_detail/tabs/_overview.html:99
 msgid "Normalize"
 msgstr "Normalizar"
 
-#: support/templates/contact_detail/tabs/_information.html:150
-#: templates/components/sidebar_items/_logistics.html:126
-msgid "Complementary information"
-msgstr "Información complementaria"
-
-#: support/templates/contact_detail/tabs/_information.html:153
+#: support/templates/contact_detail/tabs/_information.html:184
 #: templates/admin/app_index.html:14 templates/admin/base.html:33
 #: templates/admin/change_form.html:30 templates/admin/change_list.html:41
 #: templates/admin/index.html:71 templates/admin/object_history.html:20
 msgid "Admin"
 msgstr "Admin"
 
-#: support/templates/contact_detail/tabs/_information.html:155
-msgid "Delete address"
-msgstr "Eliminar dirección"
+#: support/templates/contact_detail/tabs/_information.html:187
+#: templates/admin/submit_line.html:6
+msgid "Delete"
+msgstr "Eliminar"
 
-#: support/templates/contact_detail/tabs/_information.html:161
+#: support/templates/contact_detail/tabs/_information.html:196
 msgid "This contact has no addresses"
 msgstr "Este contacto no tiene direcciones"
 
-#: support/templates/contact_detail/tabs/_information.html:165
+#: support/templates/contact_detail/tabs/_information.html:203
 msgid "Add Address"
 msgstr "Agregar dirección"
 
-#: support/templates/contact_detail/tabs/_invoices.html:27
+#: support/templates/contact_detail/tabs/_information.html:219
+#, fuzzy
+#| msgid "This contact has no issues"
+msgid "This contact has no notes"
+msgstr "Este contacto no tiene incidencias"
+
+#: support/templates/contact_detail/tabs/_invoices.html:28
 msgid "Loading"
 msgstr "Cargando"
 
 #: support/templates/contact_detail/tabs/_issues.html:5
-#: support/templates/contact_detail/tabs/_overview.html:183
+#: support/templates/contact_detail/tabs/_overview.html:234
 msgid "Latest issues"
 msgstr "Últimos incidencias"
 
-#: support/templates/contact_detail/tabs/_issues.html:12
-#: support/templates/debtor_contacts.html:88
-#: support/templates/seller_console_special_routes.html:21
-msgid "ID"
-msgstr "ID"
-
-#: support/templates/contact_detail/tabs/_issues.html:14
-#: support/templates/contact_detail/tabs/_tasks.html:12
-#: support/templates/list_issues.html:137
-#: support/templates/list_issues.html:193
-#: support/templates/scheduled_task_filter.html:45
-#: support/templates/scheduled_task_filter.html:86
-#: support/templates/view_issue.html:62 support/views/all_views.py:627
-#: support/views/all_views.py:710 support/views/scheduled_tasks.py:234
-msgid "Category"
-msgstr "Categoría"
-
-#: support/templates/contact_detail/tabs/_issues.html:15
-#: support/templates/invoicing_issues.html:53
-#: support/templates/invoicing_issues.html:106
-#: support/templates/list_issues.html:141
-#: support/templates/list_issues.html:194 support/views/all_views.py:628
-#: support/views/all_views.py:711
-msgid "Subcategory"
-msgstr "Subcategoría"
-
-#: support/templates/contact_detail/tabs/_issues.html:17
-#: support/templates/invoicing_issues.html:49
-#: support/templates/invoicing_issues.html:118
-#: support/templates/list_issues.html:145
-#: support/templates/list_issues.html:198 support/templates/new_issue.html:151
-#: support/views/all_views.py:631 support/views/all_views.py:714
-#: support/views/all_views.py:1350
-msgid "Assigned to"
-msgstr "Asignado a"
-
-#: support/templates/contact_detail/tabs/_issues.html:38
-#: support/templates/contact_detail/tabs/_overview.html:211
+#: support/templates/contact_detail/tabs/_issues.html:40
+#: support/templates/contact_detail/tabs/_overview.html:262
 msgid "This contact has no issues"
 msgstr "Este contacto no tiene incidencias"
 
-#: support/templates/contact_detail/tabs/_last_read.html:5
-msgid "Last Read Articles"
-msgstr "Últimos artículos leídos"
+#: support/templates/contact_detail/tabs/_last_read.html:10
+#, fuzzy
+#| msgid "Last name"
+msgid "Last read"
+msgstr "Apellido"
+
+#: support/templates/contact_detail/tabs/_last_read.html:21
+#, fuzzy
+#| msgid "Most Read"
+msgid "Most read"
+msgstr "Más leído"
+
+#: support/templates/contact_detail/tabs/_last_read.html:32
+msgid "Categories reading percentages"
+msgstr ""
+
+#: support/templates/contact_detail/tabs/_last_read.html:43
+msgid "No web reading data available for this contact"
+msgstr ""
 
 #: support/templates/contact_detail/tabs/_overview.html:6
 msgid "Contact information"
 msgstr "Información del contacto"
 
 #: support/templates/contact_detail/tabs/_overview.html:86
+msgid "Merge"
+msgstr ""
+
+#: support/templates/contact_detail/tabs/_overview.html:96
+#, fuzzy
+#| msgid "Needs georef"
+msgid "Needs georeferencing"
+msgstr "Necesita georeferenciación"
+
+#: support/templates/contact_detail/tabs/_overview.html:108
+#, fuzzy
+#| msgid "New address change"
+msgid "No address specified"
+msgstr "Nuevo cambio de dirección"
+
+#: support/templates/contact_detail/tabs/_overview.html:138
 msgid "Payments"
 msgstr "Pagos"
 
-#: support/templates/contact_detail/tabs/_overview.html:94
-msgid "Latest payment"
-msgstr "Último pago"
-
-#: support/templates/contact_detail/tabs/_overview.html:99
-msgid "Total invoices paid"
-msgstr "Total de facturas pagadas"
-
-#: support/templates/contact_detail/tabs/_overview.html:108
-msgid "Payment type of last invoice"
-msgstr "Tipo de pago de la última factura"
-
-#: support/templates/contact_detail/tabs/_overview.html:116
-#: support/templates/view_issue.html:111
+#: support/templates/contact_detail/tabs/_overview.html:148
+#: support/templates/view_issue.html:202
 msgid "overdue invoices"
 msgstr "oacturas vencidas"
 
-#: support/templates/contact_detail/tabs/_overview.html:121
+#: support/templates/contact_detail/tabs/_overview.html:154
+msgid "Latest payment"
+msgstr "Último pago"
+
+#: support/templates/contact_detail/tabs/_overview.html:158
+#, fuzzy
+#| msgid "Not paid"
+msgid "Total paid"
+msgstr "No pagado"
+
+#: support/templates/contact_detail/tabs/_overview.html:169
 msgid "This contact has no payment data"
 msgstr "Este contacto no tiene datos de pago"
 
-#: support/templates/contact_detail/tabs/_overview.html:165
+#: support/templates/contact_detail/tabs/_overview.html:212
 msgid "This contact has no subscriptions to show"
 msgstr "Este contacto no tiene suscripciones para mostrar"
 
-#: support/templates/contact_detail/tabs/_overview.html:172
+#: support/templates/contact_detail/tabs/_overview.html:219
 #: support/templates/contact_detail/tabs/_subscriptions.html:32
 msgid "Create corporate subscription"
 msgstr "Crear suscripción corporativa"
 
-#: support/templates/contact_detail/tabs/_overview.html:175
-#: support/templates/contact_detail/tabs/_subscriptions.html:36
-#: support/views/subscriptions.py:65
+#: support/templates/contact_detail/tabs/_overview.html:223
+#: support/templates/contact_detail/tabs/_subscriptions.html:37
+#: support/templates/free_subscription_form.html:4
+#: support/templates/free_subscription_form.html:11
+#: support/templates/free_subscription_form.html:106
+#: support/views/subscriptions.py:2022
+#, fuzzy
+#| msgid "Create corporate subscription"
+msgid "Create free subscription"
+msgstr "Crear suscripción corporativa"
+
+#: support/templates/contact_detail/tabs/_overview.html:226
+#: support/templates/contact_detail/tabs/_subscriptions.html:41
+#: support/views/subscriptions.py:70
 msgid "Add subscription"
 msgstr "Agregar suscripción"
 
-#: support/templates/contact_detail/tabs/_overview.html:278
+#: support/templates/contact_detail/tabs/_overview.html:246
+#: support/templates/seller_console.html:547
+#: support/templates/seller_console_never_paid_issues.html:68
+#: support/templates/view_issue.html:4
+msgid "View issue"
+msgstr "Ver incidencia"
+
+#: support/templates/contact_detail/tabs/_overview.html:287
+#: support/templates/seller_console.html:273
+#: templates/admin/object_history.html:48
+msgid "Action"
+msgstr "Acción"
+
+#: support/templates/contact_detail/tabs/_overview.html:320
 msgid "active"
 msgstr "activo"
 
-#: support/templates/contact_detail/tabs/_overview.html:279
+#: support/templates/contact_detail/tabs/_overview.html:321
 msgid "inactive"
 msgstr "inactivo"
 
-#: support/templates/contact_detail/tabs/_overview.html:296
+#: support/templates/contact_detail/tabs/_overview.html:338
 msgid "This contact has no newsletter subscriptions"
 msgstr "Este contacto no tiene suscripciones a la newsletter"
 
@@ -5736,140 +8731,250 @@ msgstr "Tarea vinculada"
 msgid "This contact has no scheduled tasks"
 msgstr "Este contacto no tiene tareas programadas"
 
-#: support/templates/contact_detail/tabs/includes/_activity_modal.html:9
-msgid "Activity"
-msgstr "Actividad"
+#: support/templates/contact_detail/tabs/_web_comments.html:19
+msgid "No web comments available for this contact"
+msgstr ""
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:4
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:20
+#, fuzzy
+#| msgid "Information"
+msgid "Basic Information"
+msgstr "Información"
+
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:78
+#, fuzzy
+#| msgid "Select campaign"
+msgid "People & Campaign"
+msgstr "Seleccionar campaña"
+
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:115
+#, fuzzy
+#| msgid "Contact Details"
+msgid "Interaction Details"
+msgstr "Detalles de contacto"
+
+#: support/templates/contact_detail/tabs/includes/_activity_modal.html:152
+msgid "Close"
+msgstr ""
+
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:20
 msgid "Future Subscription (Not yet started)"
 msgstr "Suscripción futura (No ha comenzado)"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:8
-msgid "Subscription paused until"
-msgstr "Suscripción pausada hasta"
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:25
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:31
+#, fuzzy
+#| msgid "Replaced Subscription"
+msgid "Replaced by subscription"
+msgstr "Suscripción reemplazada"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:13
-msgid "Warning: Subscription in special route. It might not be billed."
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:30
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:21
+msgid "Paused until"
+msgstr "Pausado hasta"
+
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:35
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:26
+#, fuzzy
+#| msgid "Warning: Subscription in special route. It might not be billed."
+msgid "Special route - may not be billed"
 msgstr "Advertencia: Suscripción en ruta especial. Podría no ser facturada."
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:18
-msgid "Subscription awaiting payment"
-msgstr "Suscripción esperando pago"
-
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:39
-msgid "because of pause"
-msgstr "por pausa"
-
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:44
-#: support/templates/seller_console.html:467
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:46
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:96
+#: support/templates/seller_console.html:505
 msgid "Start"
 msgstr "Inicio"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:46
-#: support/templates/seller_console.html:471
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:48
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:99
+#: support/templates/seller_console.html:509
 msgid "End"
 msgstr "Fin"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:52
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:53
 msgid "Next"
 msgstr "Siguiente"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:58
-msgid "Positive Balance (Discount)"
-msgstr "Saldo positivo (Descuento)"
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:66
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:73
+#, fuzzy
+#| msgid "Payments"
+msgid "Payment"
+msgstr "Pagos"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:60
-msgid "Negative Balance (Surcharge)"
-msgstr "Saldo negativo (Recargo)"
-
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:80
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:94
 msgid "View payment certificate"
 msgstr "Ver certificado de pago"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:96
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:100
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:160
+#, fuzzy
+#| msgid "Parent route"
+msgid "Parent"
+msgstr "Ruta padre"
+
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:115
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:154
+#, fuzzy
+#| msgid "Updated from"
+msgid "Update Promo"
+msgstr "Actualizado de"
+
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:121
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:136
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:184
+#: support/templates/contact_detail/tabs/includes/_subscription_actions.html:12
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:159
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:171
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:188
+msgid "Advanced"
+msgstr "Avanzado"
+
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:130
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:166
+#, fuzzy
+#| msgid "Validate Subscription"
+msgid "Update Free Subscription"
+msgstr "Validar Suscripción"
+
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:143
+msgid "Offer retention"
+msgstr ""
+
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:149
 #: support/templates/contact_detail/tabs/includes/_subscription_actions.html:6
-#: support/templates/new_issue.html:145 support/templates/view_issue.html:166
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:178
+#: support/templates/new_issue.html:332 support/templates/view_issue.html:279
 #: templates/admin/index.html:109
 msgid "Add"
 msgstr "Agregar"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:100
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:155
 msgid "Add Affiliate"
 msgstr "Agregar Afiliado"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:103
-msgid "Go to parent subscription"
-msgstr "Ir a la suscripción padre"
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:170
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:199
+#, fuzzy
+#| msgid "active"
+msgid "Reactivate"
+msgstr "activo"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:115
-#: support/templates/contact_detail/tabs/includes/_subscription_actions.html:12
-msgid "Advanced"
-msgstr "Avanzado"
-
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:118
-#: support/templates/sales_record_filter.html:135
-#: support/templates/validate_subscription_sales_record.html:259
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:189
+#: support/templates/sales_record_filter.html:190
+#: support/templates/validate_subscription_sales_record.html:403
 msgid "Validate"
 msgstr "Validar"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:121
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:194
 msgid "Register Sale"
 msgstr "Registrar Venta"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:126
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:201
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:194
+#, fuzzy
+#| msgid "Replaced by"
+msgid "Replaced"
+msgstr "Reemplazada por"
+
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:208
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:211
+msgid "Envelopes"
+msgstr "Sobres"
+
+#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:212
+msgid "Certificados de pago"
+msgstr ""
+
 #: support/templates/contact_detail/tabs/includes/_subscription_actions.html:16
 msgid "Replaced Subscription"
 msgstr "Suscripción reemplazada"
 
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:130
-msgid "Envelopes"
-msgstr "Sobres"
-
-#: support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html:132
-msgid "Payment Certificate"
-msgstr "Certificado de Pago"
-
 #: support/templates/contact_detail/tabs/includes/_subscription_actions.html:19
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:204
 #: support/templates/create_contact/tabs/_newsletters.html:41
 msgid "Unsubscribe"
 msgstr "Cancelar suscripción"
 
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:33
-msgid "because of Pause"
-msgstr "por pausa"
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:37
+#, fuzzy
+#| msgid "Product Bundles"
+msgid "Products & Addresses"
+msgstr "Paquetes de productos"
 
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:58
-msgid "Paused until"
-msgstr "Pausado hasta"
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:60
+#, fuzzy
+#| msgid "Pricing & Discounts"
+msgid "Pricing & Payment"
+msgstr "Precios y descuentos"
 
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:64
-#: support/templates/seller_console_special_routes.html:4
-msgid "Special route"
-msgstr "Ruta especial"
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:86
+#, fuzzy
+#| msgid "Payment Status"
+msgid "Dates & Status"
+msgstr "Estado del pago"
 
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:70
-msgid "Last paid invoice"
-msgstr "Factura pagada más reciente"
-
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:75
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:107
 msgid "Next invoice"
 msgstr "Factura siguiente"
 
-#: support/templates/contact_detail/tabs/includes/_subscription_card.html:95
-msgid "Replaced by"
-msgstr "Reemplazada por"
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:112
+#, fuzzy
+#| msgid "Not paid"
+msgid "Last paid"
+msgstr "No pagado"
 
-#: support/templates/contact_list.html:75
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:122
+#, fuzzy
+#| msgid "Unsubscription"
+msgid "Unsubscription Info"
+msgstr "Baja"
+
+#: support/templates/contact_detail/tabs/includes/_subscription_card.html:215
+msgid "Payment Certificate"
+msgstr "Certificado de Pago"
+
+#: support/templates/contact_list.html:106
+#, fuzzy
+#| msgid "Search"
+msgid "Main Search"
+msgstr "Buscar"
+
+#: support/templates/contact_list.html:108
+msgid ""
+"Search by: ID, Name, Last Name, Email, Phone, Mobile, Work Phone, or ID "
+"Document"
+msgstr ""
+
+#: support/templates/contact_list.html:112
+msgid ""
+"You can search by: Contact ID, Name, Last Name, Email, Phone, Mobile, Work "
+"Phone, or ID Document"
+msgstr ""
+
+#: support/templates/contact_list.html:135
+msgid ""
+"Enter tag names separated by commas. Tags will appear as removable chips."
+msgstr ""
+
+#: support/templates/contact_list.html:161
 msgid "All contacts"
 msgstr "Todos los contactos"
 
-#: support/templates/contact_list.html:76
+#: support/templates/contact_list.html:162
 msgid "Create contact"
 msgstr "Crear contacto"
 
-#: support/templates/contact_list.html:86 support/views/contacts.py:90
+#: support/templates/contact_list.html:178
 msgid "Last activity"
 msgstr "Ultima actividad"
+
+#: support/templates/contact_list.html:236
+#, fuzzy
+#| msgid "Filter by seller"
+msgid "Filter by this tag"
+msgstr "Filtrar por vendedor"
 
 #: support/templates/create_contact/create_contact.html:42
 #: support/templates/create_contact/create_contact.html:50
@@ -5884,15 +8989,25 @@ msgstr "Editar contacto"
 msgid "Newsletters and communications"
 msgstr "Newsletters y comunicaciones"
 
-#: support/templates/create_contact/tabs/_data.html:32
+#: support/templates/create_contact/tabs/_data.html:54
 msgid "Enter a valid local or international phone number"
-msgstr "Ingrese un número válido. Para Colombia no es necesario el código +57, pero para números de otros países sí debe incluirse (ej: +1 212 5551234)."
+msgstr ""
+"Ingrese un número válido. Para Colombia no es necesario el código +57, pero "
+"para números de otros países sí debe incluirse (ej: +1 212 5551234)."
 
-#: support/templates/create_contact/tabs/_data.html:39
+#: support/templates/create_contact/tabs/_data.html:69
 msgid "Enter a valid local or international mobile number"
-msgstr "Ingrese un número válido. Para Colombia no es necesario el código +57, pero para números de otros países sí debe incluirse (ej: +1 212 5551234)."
+msgstr ""
+"Ingrese un número válido. Para Colombia no es necesario el código +57, pero "
+"para números de otros países sí debe incluirse (ej: +1 212 5551234)."
 
-#: support/templates/create_contact/tabs/_data.html:46
+#: support/templates/create_contact/tabs/_data.html:76
+#: support/templates/create_contact/tabs/_data.html:79
+#: support/templates/seller_console.html:183 support/views/all_views.py:1869
+msgid "Institutional phone"
+msgstr "Teléfono institucional"
+
+#: support/templates/create_contact/tabs/_data.html:84
 msgid ""
 "Use this field for non-standard numbers such as internal extensions, "
 "government hotlines, or institutional contact numbers like 1950."
@@ -5900,23 +9015,23 @@ msgstr ""
 "Utilice este campo para números de teléfono no convencionales como "
 "extensiones internas, números de teléfono del gobierno o institucionales."
 
-#: support/templates/create_contact/tabs/_data.html:52
+#: support/templates/create_contact/tabs/_data.html:90
 msgid "Id document type"
 msgstr "Tipo de documento"
 
-#: support/templates/create_contact/tabs/_data.html:56
+#: support/templates/create_contact/tabs/_data.html:94
 msgid "Id document"
 msgstr "Documento de identidad"
 
-#: support/templates/create_contact/tabs/_data.html:79
+#: support/templates/create_contact/tabs/_data.html:117
 msgid "Scroll to view all tags"
 msgstr "Deslice para ver todas las etiquetas"
 
-#: support/templates/create_contact/tabs/_data.html:91
+#: support/templates/create_contact/tabs/_data.html:129
 msgid "Allow polls"
 msgstr "Permitir encuestas"
 
-#: support/templates/create_contact/tabs/_data.html:95
+#: support/templates/create_contact/tabs/_data.html:133
 msgid "Allow promotions"
 msgstr "Permitir promociones"
 
@@ -5963,24 +9078,24 @@ msgstr "Ordenar por"
 #: support/templates/debtor_contacts.html:55
 #: support/templates/debtor_contacts.html:91
 #: support/templates/invoicing_issues.html:64
-#: support/templates/invoicing_issues.html:110 support/views/all_views.py:1347
-#: support/views/all_views.py:1425
+#: support/templates/invoicing_issues.html:110 support/views/all_views.py:2026
+#: support/views/all_views.py:2120
 msgid "Owed invoices"
 msgstr "Facturas adeudadas"
 
 #: support/templates/debtor_contacts.html:56
 #: support/templates/debtor_contacts.html:93
 #: support/templates/invoicing_issues.html:65
-#: support/templates/invoicing_issues.html:113 support/views/all_views.py:1348
-#: support/views/all_views.py:1428
+#: support/templates/invoicing_issues.html:113 support/views/all_views.py:2027
+#: support/views/all_views.py:2123
 msgid "Debt amount"
 msgstr "Monto adeudado"
 
 #: support/templates/debtor_contacts.html:58
 #: support/templates/debtor_contacts.html:94
 #: support/templates/invoicing_issues.html:66
-#: support/templates/invoicing_issues.html:116 support/views/all_views.py:1349
-#: support/views/all_views.py:1429
+#: support/templates/invoicing_issues.html:116 support/views/all_views.py:2028
+#: support/views/all_views.py:2124
 msgid "Oldest invoice"
 msgstr "Factura más antigua"
 
@@ -6027,11 +9142,6 @@ msgstr "sí"
 #: support/templates/distribute_campaigns.html:4
 msgid "Distribute campaigns"
 msgstr "Distribuir campañas"
-
-#: support/templates/distribute_campaigns.html:13
-#: templates/components/sidebar_items/_campaign_management.html:55
-msgid "Assign contacts to sellers"
-msgstr "Asignar contactos a vendedores"
 
 #: support/templates/distribute_campaigns.html:20
 msgid "Morning"
@@ -6134,10 +9244,15 @@ msgid "Address complementary information"
 msgstr "Información complementaria de dirección"
 
 #: support/templates/edit_address_complementary_information.html:13
-#, python-format
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "            Upload payment address complementary information for address "
+#| "%(address_1)s for contact %(name)s\n"
+#| "        "
 msgid ""
 "\n"
-"            Upload payment address complementary information for address "
+"            Upload address complementary information for address "
 "%(address_1)s for contact %(name)s\n"
 "        "
 msgstr ""
@@ -6156,10 +9271,6 @@ msgstr "Subir la información complementaria de la dirección"
 msgid "Edit envelopes"
 msgstr "Editar sobres"
 
-#: support/templates/edit_envelopes.html:36
-msgid "Subscription products"
-msgstr "Productos de suscripción"
-
 #: support/templates/email_suggestion_dialog.html:4
 msgid "Email suggestion"
 msgstr "Sugerencia de correo electrónico"
@@ -6168,11 +9279,45 @@ msgstr "Sugerencia de correo electrónico"
 msgid "Do you accept the replacement?"
 msgstr "¿Acepta el reemplazo?"
 
+#: support/templates/free_subscription_form.html:4
+#: support/templates/free_subscription_form.html:11
+#: support/templates/free_subscription_form.html:106
+#: support/views/subscriptions.py:2112
+#, fuzzy
+#| msgid "Can add free subscription"
+msgid "Update free subscription"
+msgstr "Puede agregar una suscripción gratuita"
+
+#: support/templates/free_subscription_form.html:169
+#: support/templates/seller_console_start_promo.html:166
+#, fuzzy
+#| msgid "Product Bundles"
+msgid "Products and Addresses"
+msgstr "Paquetes de productos"
+
+#: support/templates/free_subscription_form.html:175
+#: support/templates/seller_console_start_promo.html:172
+#, fuzzy
+#| msgid "Old address"
+msgid "Reload addresses"
+msgstr "Dirección antigua"
+
+#: support/templates/free_subscription_form.html:329
+#: support/templates/seller_console_start_promo.html:228
+#: support/templates/view_issue.html:412
+msgid "Update"
+msgstr "Actualizar"
+
+#: support/templates/free_subscription_form.html:329
+#: support/views/contacts.py:545
+msgid "Create"
+msgstr "Crear"
+
 #: support/templates/history_extended.html:4
 msgid "Extended history"
 msgstr "Historial extendido"
 
-#: support/templates/history_extended.html:8 support/views/all_views.py:1792
+#: support/templates/history_extended.html:8 support/views/all_views.py:2655
 #: templates/admin/change_form.html:68
 msgid "History"
 msgstr "Historial"
@@ -6221,7 +9366,6 @@ msgid "Go to issue"
 msgstr "Ir al incidencia"
 
 #: support/templates/import_contacts.html:4
-#: support/templates/tag_contacts.html:4
 msgid "Import contacts"
 msgstr "Importar contactos"
 
@@ -6233,26 +9377,359 @@ msgstr "Administración de campaña"
 msgid "Import new contacts"
 msgstr "Importar nuevos contactos"
 
-#: support/templates/import_contacts.html:19
-msgid "Import has encountered some errors"
-msgstr "La importación ha encontrado algunos errores"
+#: support/templates/import_contacts.html:20
+#, fuzzy
+#| msgid "Import Contacts"
+msgid "Import Contacts from CSV"
+msgstr "Importar contactos"
 
 #: support/templates/import_contacts.html:31
-msgid ""
-"Choose file to send. It has to be a csv file with the following header and "
-"columns"
+msgid "Follow these steps to import contacts:"
 msgstr ""
-"Elija el archivo para enviar. Debe ser un archivo csv con el siguiente "
-"encabezado y columnas"
 
 #: support/templates/import_contacts.html:33
-msgid "All columns must be present in the header."
-msgstr "Todos los campos deben estar presentes en el encabezado."
+#, fuzzy
+#| msgid "Download the template above for the correct format"
+msgid "Download the CSV template using the button above"
+msgstr "Descargar la plantilla más arriba para utilizar el formato correcto"
 
-#: support/templates/import_contacts.html:56
-#: support/templates/tag_contacts.html:45
-msgid "Import"
-msgstr "Importar"
+#: support/templates/import_contacts.html:34
+msgid "Fill in the template with your contact data"
+msgstr ""
+
+#: support/templates/import_contacts.html:35
+#, fuzzy
+#| msgid "Upload CSV file"
+msgid "Upload the completed CSV file below"
+msgstr "Subir archivo CSV"
+
+#: support/templates/import_contacts.html:36
+msgid "Configure tags for different contact types"
+msgstr ""
+
+#: support/templates/import_contacts.html:37
+msgid "Click Import to process the file"
+msgstr ""
+
+#: support/templates/import_contacts.html:44
+msgid "How Contact Matching Works"
+msgstr ""
+
+#: support/templates/import_contacts.html:47
+msgid "The system uses a two-step matching process to find existing contacts:"
+msgstr ""
+
+#: support/templates/import_contacts.html:52
+msgid "Step 1: Email Match"
+msgstr ""
+
+#: support/templates/import_contacts.html:53
+msgid ""
+"The system first tries to find contacts by email address (exact match, case-"
+"insensitive)."
+msgstr ""
+
+#: support/templates/import_contacts.html:54
+#: support/templates/import_contacts.html:62
+msgid "If found:"
+msgstr ""
+
+#: support/templates/import_contacts.html:54
+msgid "The contact is considered a match and will be categorized accordingly."
+msgstr ""
+
+#: support/templates/import_contacts.html:60
+msgid "Step 2: Phone Match"
+msgstr ""
+
+#: support/templates/import_contacts.html:61
+msgid ""
+"If no email match is found, the system tries to match by phone number "
+"(checks both phone and mobile fields)."
+msgstr ""
+
+#: support/templates/import_contacts.html:62
+msgid ""
+"The contact is matched and the email from CSV will be added if the contact "
+"doesn't have one."
+msgstr ""
+
+#: support/templates/import_contacts.html:69
+msgid "What Happens When Contacts Are Found (Coincidences)"
+msgstr ""
+
+#: support/templates/import_contacts.html:70
+msgid ""
+"When a contact is found in the database, it will be categorized into one of "
+"these groups and tagged accordingly:"
+msgstr ""
+
+#: support/templates/import_contacts.html:76
+#, fuzzy
+#| msgid "Contact data"
+msgid "Contact Status"
+msgstr "Datos del contacto"
+
+#: support/templates/import_contacts.html:77
+msgid "What Happens"
+msgstr ""
+
+#: support/templates/import_contacts.html:78
+msgid "Tags Applied"
+msgstr ""
+
+#: support/templates/import_contacts.html:84
+msgid ""
+"Contact is already in an active campaign. No new data is added to avoid "
+"conflicts."
+msgstr ""
+
+#: support/templates/import_contacts.html:89
+msgid ""
+"Contact has an active subscription. Phone numbers may be added if missing."
+msgstr ""
+
+#: support/templates/import_contacts.html:93
+#, fuzzy
+#| msgid "Check for Existing Contacts"
+msgid "Existing Inactive Contact"
+msgstr "Verificar contactos existentes"
+
+#: support/templates/import_contacts.html:94
+msgid ""
+"Contact exists but has no active subscription or campaign. Phone numbers may "
+"be added if missing."
+msgstr ""
+
+#: support/templates/import_contacts.html:103
+#, fuzzy
+#| msgid "Phone number"
+msgid "Phone Number Updates:"
+msgstr "Número de teléfono"
+
+#: support/templates/import_contacts.html:103
+msgid ""
+"If only one matching contact is found, the system will add phone numbers "
+"from the CSV if the contact is missing them. If the contact already has a "
+"phone number, the CSV phone will be added to the mobile field."
+msgstr ""
+
+#: support/templates/import_contacts.html:108
+msgid "What Happens When No Coincidences Are Found"
+msgstr ""
+
+#: support/templates/import_contacts.html:109
+msgid ""
+"When no matching contact is found (neither by email nor phone), a completely "
+"new contact will be created with:"
+msgstr ""
+
+#: support/templates/import_contacts.html:111
+msgid "All data from the CSV file (name, email, phone, address, etc.)"
+msgstr ""
+
+#: support/templates/import_contacts.html:112
+msgid "A physical address if address_1 is provided"
+msgstr ""
+
+#: support/templates/import_contacts.html:113
+msgid "The tags configured for new contacts"
+msgstr ""
+
+#: support/templates/import_contacts.html:118
+msgid "Result:"
+msgstr ""
+
+#: support/templates/import_contacts.html:118
+msgid ""
+"You will see a success message showing how many new contacts were created."
+msgstr ""
+
+#: support/templates/import_contacts.html:126
+#, fuzzy
+#| msgid "CSV File"
+msgid "CSV File Format"
+msgstr "Archivo CSV"
+
+#: support/templates/import_contacts.html:129
+msgid "Required columns (in order):"
+msgstr ""
+
+#: support/templates/import_contacts.html:134
+#, fuzzy
+#| msgid "Contact Name"
+msgid "Column Name"
+msgstr "Nombre del contacto"
+
+#: support/templates/import_contacts.html:136
+#, fuzzy
+#| msgid "Requested"
+msgid "Required"
+msgstr "Solicitado"
+
+#: support/templates/import_contacts.html:142
+#, fuzzy
+#| msgid "Last name"
+msgid "First name"
+msgstr "Apellido"
+
+#: support/templates/import_contacts.html:152
+#, fuzzy
+#| msgid "Edit address"
+msgid "Email address"
+msgstr "Editar dirección"
+
+#: support/templates/import_contacts.html:157
+#: support/templates/seller_console_special_routes.html:26
+msgid "Phone number"
+msgstr "Número de teléfono"
+
+#: support/templates/import_contacts.html:162
+#, fuzzy
+#| msgid "Phone number"
+msgid "Mobile number"
+msgstr "Número de teléfono"
+
+#: support/templates/import_contacts.html:167
+#, fuzzy
+#| msgid "Additional copies"
+msgid "Additional notes"
+msgstr "Copia adicional"
+
+#: support/templates/import_contacts.html:172
+#, fuzzy
+#| msgid "Normalize address"
+msgid "Primary address"
+msgstr "Normalizar dirección"
+
+#: support/templates/import_contacts.html:177
+#, fuzzy
+#| msgid "Save address"
+msgid "Secondary address"
+msgstr "Guardar dirección"
+
+#: support/templates/import_contacts.html:187
+#, fuzzy
+#| msgid "Department"
+msgid "State/Department"
+msgstr "Departamento"
+
+#: support/templates/import_contacts.html:197
+#, fuzzy
+#| msgid "Id document type"
+msgid "ID document type"
+msgstr "Tipo de documento"
+
+#: support/templates/import_contacts.html:202
+#, fuzzy
+#| msgid "ID document"
+msgid "ID document number"
+msgstr "Documento de identificación"
+
+#: support/templates/import_contacts.html:210
+msgid ""
+"All columns must be present in the CSV file, even if they are empty. Use the "
+"template to ensure correct formatting."
+msgstr ""
+
+#: support/templates/import_contacts.html:218
+msgid "What to Expect After Import"
+msgstr ""
+
+#: support/templates/import_contacts.html:221
+msgid ""
+"After processing your CSV file, you will receive detailed feedback messages "
+"showing:"
+msgstr ""
+
+#: support/templates/import_contacts.html:225
+#, fuzzy
+#| msgid "Label Message"
+msgid "Success Messages"
+msgstr "Mensaje de etiqueta"
+
+#: support/templates/import_contacts.html:227
+#, fuzzy
+#| msgid "Import new contacts"
+msgid "Number of new contacts created"
+msgstr "Importar nuevos contactos"
+
+#: support/templates/import_contacts.html:228
+#, fuzzy
+#| msgid "Check for existing contacts"
+msgid "Number of emails added to existing contacts"
+msgstr "Verificar contactos existentes"
+
+#: support/templates/import_contacts.html:229
+msgid "Number of phone numbers added"
+msgstr ""
+
+#: support/templates/import_contacts.html:234
+#, fuzzy
+#| msgid "WhatsApp Messages"
+msgid "Warning Messages"
+msgstr "Mensajes de WhatsApp"
+
+#: support/templates/import_contacts.html:236
+#, fuzzy
+#| msgid "No valid contacts found in this campaign"
+msgid "Contacts found in active campaigns"
+msgstr "No se encontraron contactos válidos en esta campaña"
+
+#: support/templates/import_contacts.html:237
+#, fuzzy
+#| msgid "Has active subscriptions"
+msgid "Contacts with active subscriptions"
+msgstr "Tiene suscripciones activas"
+
+#: support/templates/import_contacts.html:238
+#, fuzzy
+#| msgid "Contacted contacts"
+msgid "Existing inactive contacts"
+msgstr "Contactos contactados"
+
+#: support/templates/import_contacts.html:245
+msgid ""
+"Use different tags for each contact type to easily filter and manage them "
+"after import. This helps you track which contacts were new vs. existing, and "
+"their current status."
+msgstr ""
+
+#: support/templates/import_contacts.html:256
+#, fuzzy
+#| msgid "Upload CSV file"
+msgid "Upload CSV File"
+msgstr "Subir archivo CSV"
+
+#: support/templates/import_contacts.html:286
+msgid "Configure Tags"
+msgstr ""
+
+#: support/templates/import_contacts.html:290
+msgid ""
+"Tags help you categorize and organize contacts. Enter comma-separated tags "
+"for each contact type."
+msgstr ""
+
+#: support/templates/import_contacts.html:297
+msgid "These tags will be applied to newly created contacts"
+msgstr ""
+
+#: support/templates/import_contacts.html:305
+msgid ""
+"Applied to existing contacts without active subscriptions or campaigns "
+"(optional)"
+msgstr ""
+
+#: support/templates/import_contacts.html:313
+msgid "Applied to existing contacts with active subscriptions (optional)"
+msgstr ""
+
+#: support/templates/import_contacts.html:321
+#, fuzzy
+#| msgid "Assign contacts in campaigns to sellers"
+msgid "Applied to existing contacts in active campaigns (optional)"
+msgstr "Asignar contactos en campañas a vendedores"
 
 #: support/templates/invoicing_issues.html:4
 msgid "Invoicing issues"
@@ -6263,15 +9740,20 @@ msgstr "Incidentes de facturación"
 msgid "Collection issues"
 msgstr "Incidentes de cobranza"
 
+#: support/templates/invoicing_issues.html:79
+#: support/templates/unsubscription_statistics.html:53
+msgid "Creation date (from)"
+msgstr "Fecha de creación (desde)"
+
+#: support/templates/invoicing_issues.html:83
+#: support/templates/unsubscription_statistics.html:57
+msgid "Creation date (to)"
+msgstr "Fecha de creación (hasta)"
+
 #: support/templates/invoicing_issues.html:90
 #: support/templates/scheduled_task_filter.html:72
 msgid "issues"
 msgstr "incidencias"
-
-#: support/templates/invoicing_issues.html:108
-#: support/templates/list_issues.html:197 support/views/all_views.py:1346
-msgid "Next action date"
-msgstr "Fecha de próxima acción"
 
 #: support/templates/list_issues.html:4 support/templates/list_issues.html:15
 msgid "List issues"
@@ -6281,48 +9763,141 @@ msgstr "Lista de incidencias"
 msgid "List of issues"
 msgstr "Lista de incidencias"
 
-#: support/templates/list_issues.html:29
+#: support/templates/list_issues.html:32
+#: support/templates/support/seller_attendance_filter.html:23
 msgid "No results match"
 msgstr "No hay coincidencias"
 
-#: support/templates/list_issues.html:30
+#: support/templates/list_issues.html:33
+#: support/templates/support/seller_attendance_filter.html:25
 msgid "Select an option"
 msgstr "Seleccionar opciones"
 
-#: support/templates/list_issues.html:169
+#: support/templates/list_issues.html:229
 msgid "issues found"
 msgstr "incidencias encontradas"
+
+#: support/templates/list_issues.html:258
+msgid ""
+"Creation date: automatically set when the issue was opened. Issue date "
+"(shown below if different): editable field representing the date the issue "
+"refers to."
+msgstr ""
+
+#: support/templates/list_issues.html:287 support/templates/view_issue.html:335
+msgid "Issue date: editable field representing the date the issue refers to."
+msgstr ""
+
+#: support/templates/list_issues.html:288 support/templates/view_issue.html:336
+#: support/views/all_views.py:687
+#, fuzzy
+#| msgid "Issue Date"
+msgid "Issue date"
+msgstr "Fecha de emisión"
 
 #: support/templates/location/normalizar_direccion.html:46
 msgid "Normalize address"
 msgstr "Normalizar dirección"
 
-#: support/templates/new_issue.html:4 support/templates/new_issue.html:53
-#: support/views/all_views.py:754
+#: support/templates/new_issue.html:4 support/templates/new_issue.html:144
+#: support/views/all_views.py:1311
 msgid "New issue"
 msgstr "Nuevo incidencia"
 
-#: support/templates/new_issue.html:64
-#: support/templates/new_scheduled_task_address_change.html:75
-#: support/templates/new_scheduled_task_partial_pause.html:60
-#: support/templates/new_scheduled_task_total_pause.html:39
+#: support/templates/new_issue.html:154
+#: support/templates/new_scheduled_task_address_change.html:90
+#: support/templates/new_scheduled_task_partial_pause.html:76
+#: support/templates/new_scheduled_task_total_pause.html:54
+#, fuzzy
+#| msgid "Issue type"
+msgid "Issue Type"
+msgstr "Tipo de incidencia"
+
+#: support/templates/new_issue.html:160
+#: support/templates/new_scheduled_task_address_change.html:96
+#: support/templates/new_scheduled_task_partial_pause.html:82
+#: support/templates/new_scheduled_task_total_pause.html:60
 msgid "Regular issues"
 msgstr "Incidentes regulares"
 
-#: support/templates/new_issue.html:70
-#: support/templates/new_scheduled_task_address_change.html:83
-#: support/templates/new_scheduled_task_partial_pause.html:62
-#: support/templates/new_scheduled_task_total_pause.html:47
+#: support/templates/new_issue.html:174
+#: support/templates/new_scheduled_task_address_change.html:110
+#: support/templates/new_scheduled_task_partial_pause.html:96
+#: support/templates/new_scheduled_task_total_pause.html:74
 msgid "Pause subscription"
 msgstr "Pausar suscripción"
 
-#: support/templates/new_issue.html:73
-#: support/templates/new_scheduled_task_address_change.html:87
-#: support/templates/new_scheduled_task_partial_pause.html:50
-#: support/templates/new_scheduled_task_partial_pause.html:63
-#: support/templates/new_scheduled_task_total_pause.html:51
+#: support/templates/new_issue.html:181
+#: support/templates/new_scheduled_task_address_change.html:117
+#: support/templates/new_scheduled_task_partial_pause.html:65
+#: support/templates/new_scheduled_task_partial_pause.html:103
+#: support/templates/new_scheduled_task_total_pause.html:81
 msgid "Partial pause"
 msgstr "Pausa parcial"
+
+#: support/templates/new_issue.html:250
+#, fuzzy
+#| msgid "Please correct the errors below."
+msgid "Please correct the following errors:"
+msgstr "Por favor, corrija los errores abajo."
+
+#: support/templates/new_issue.html:276
+#, fuzzy
+#| msgid "Issue details"
+msgid "Issue Details"
+msgstr "Detalles del incidencia"
+
+#: support/templates/new_issue.html:291
+msgid "Date when the issue occurred"
+msgstr ""
+
+#: support/templates/new_issue.html:308
+#, fuzzy
+#| msgid "Select a reason before selecting one of these options"
+msgid "Select a resolution for this issue (optional)"
+msgstr "Seleccione una razón antes de seleccionar una de estas opciones"
+
+#: support/templates/new_issue.html:317
+#, fuzzy
+#| msgid "Products Total"
+msgid "Product Details"
+msgstr "Total de productos"
+
+#: support/templates/new_issue.html:342
+msgid "Assignment & Tracking"
+msgstr ""
+
+#: support/templates/new_issue.html:369
+msgid "Related Items"
+msgstr ""
+
+#: support/templates/new_issue.html:373
+msgid ""
+"Please select at least one related item to provide information about what "
+"the contact had issues with."
+msgstr ""
+
+#: support/templates/new_issue.html:401
+msgid "Add any additional details about this issue"
+msgstr ""
+
+#: support/templates/new_issue.html:408
+#, fuzzy
+#| msgid "Information"
+msgid "Address Information"
+msgstr "Información"
+
+#: support/templates/new_issue.html:424
+#, fuzzy
+#| msgid "New address"
+msgid "New Address Details"
+msgstr "Nueva dirección"
+
+#: support/templates/new_issue.html:469
+#, fuzzy
+#| msgid "Create list"
+msgid "Create Issue"
+msgstr "Crear lista"
 
 #: support/templates/new_scheduled_task_address_change.html:4
 #: support/templates/new_scheduled_task_partial_pause.html:6
@@ -6330,21 +9905,22 @@ msgstr "Pausa parcial"
 msgid "New scheduled task"
 msgstr "Nueva tarea programada"
 
-#: support/templates/new_scheduled_task_address_change.html:194
+#: support/templates/new_scheduled_task_address_change.html:225
 msgid "Select products to apply address change to"
 msgstr "Seleccionar productos para aplicar el cambio de dirección"
 
-#: support/templates/new_scheduled_task_address_change.html:209
-#: support/templates/new_scheduled_task_partial_pause.html:135
+#: support/templates/new_scheduled_task_address_change.html:240
+#: support/templates/new_scheduled_task_partial_pause.html:177
 msgid "currently on address"
 msgstr "actualmente en dirección"
 
-#: support/templates/new_scheduled_task_address_change.html:229
-#: support/templates/new_scheduled_task_total_pause.html:124
+#: support/templates/new_scheduled_task_address_change.html:260
+#: support/templates/new_scheduled_task_total_pause.html:155
 msgid "Apply now"
 msgstr "Aplicar ahora"
 
-#: support/templates/new_scheduled_task_partial_pause.html:119
+#: support/templates/new_scheduled_task_partial_pause.html:161
+#: support/templates/sales_record_filter.html:42
 msgid "Select products"
 msgstr "Seleccionar productos"
 
@@ -6355,13 +9931,14 @@ msgstr "Pausa total"
 
 #: support/templates/new_subscription.html:4
 #: support/templates/new_subscription.html:18
-#: support/templates/new_subscription.html:103
+#: support/templates/new_subscription.html:128
+#: support/templates/validate_subscription_sales_record.html:55
 msgid "New subscription"
 msgstr "Nueva suscripción"
 
 #: support/templates/new_subscription.html:16
-#: support/templates/new_subscription.html:101
-#: support/templates/seller_console.html:338 support/views/subscriptions.py:65
+#: support/templates/new_subscription.html:126
+#: support/templates/seller_console.html:375 support/views/subscriptions.py:70
 msgid "Edit subscription"
 msgstr "Editar suscripción"
 
@@ -6376,13 +9953,125 @@ msgstr ""
 "      para %(contact_name)s\n"
 "    "
 
-#: support/templates/new_subscription.html:215
+#: support/templates/new_subscription.html:266
 msgid "Show extra billing information"
 msgstr "Mostrar información adicional de facturación"
 
-#: support/templates/new_subscription.html:339
+#: support/templates/new_subscription.html:392
 msgid "Total price is"
 msgstr "El precio total es"
+
+#: support/templates/reactivate_subscription.html:4
+#: support/templates/reactivate_subscription.html:8
+#: support/views/subscriptions.py:777
+#, fuzzy
+#| msgid "Inactive subscriptions"
+msgid "Reactivate subscription"
+msgstr "Suscripciones inactivas"
+
+#: support/templates/reactivate_subscription.html:17
+#, fuzzy
+#| msgid "Unsubscription reason"
+msgid "Confirm subscription reactivation"
+msgstr "Motivo de baja"
+
+#: support/templates/reactivate_subscription.html:22
+#, fuzzy
+#| msgid "You don't have permission to set this subscription as free"
+msgid "You are about to reactivate this subscription. This will:"
+msgstr "No tienes permiso para marcar esta suscripción como gratuita"
+
+#: support/templates/reactivate_subscription.html:24
+msgid "Remove the end date"
+msgstr ""
+
+#: support/templates/reactivate_subscription.html:25
+#, fuzzy
+#| msgid "Unsubscription reason"
+msgid "Clear the unsubscription reason"
+msgstr "Motivo de baja"
+
+#: support/templates/reactivate_subscription.html:26
+#, fuzzy
+#| msgid "Corporate subscription data"
+msgid "Clear all unsubscription metadata"
+msgstr "Datos de suscripción corporativa"
+
+#: support/templates/reactivate_subscription.html:27
+msgid "Allow the customer to continue receiving products"
+msgstr ""
+
+#: support/templates/reactivate_subscription.html:31
+#, fuzzy
+#| msgid "Subscription data"
+msgid "Subscription details"
+msgstr "Datos de suscripción"
+
+#: support/templates/reactivate_subscription.html:50
+#, fuzzy
+#| msgid "Current contact"
+msgid "Current end date"
+msgstr "Contacto actual"
+
+#: support/templates/reactivate_subscription.html:60
+#, fuzzy
+#| msgid "No data for this period"
+msgid "(adjusted for inactive period)"
+msgstr "No hay datos para este periodo"
+
+#: support/templates/reactivate_subscription.html:76
+#, fuzzy
+#| msgid "Partial unsubscription"
+msgid "Original unsubscription information"
+msgstr "Desuscripción parcial"
+
+#: support/templates/reactivate_subscription.html:102
+#, fuzzy
+#| msgid "activity response"
+msgid "Activity reference"
+msgstr "respuesta de actividad"
+
+#: support/templates/reactivate_subscription.html:113
+msgid ""
+"The original unsubscription data has been stored and can be reviewed in the "
+"activity history."
+msgstr ""
+
+#: support/templates/reactivate_subscription.html:120
+#, fuzzy
+#| msgid "Unspecified payment method"
+msgid "Update payment method"
+msgstr "Método de pago no especificado"
+
+#: support/templates/reactivate_subscription.html:141
+#, fuzzy
+#| msgid "Confirm action"
+msgid "Confirm reactivation"
+msgstr "Confirmar acción"
+
+#: support/templates/reactivate_subscription.html:152
+#, fuzzy
+#| msgid "Importance"
+msgid "Important notes"
+msgstr "Importancia"
+
+#: support/templates/reactivate_subscription.html:155
+#, fuzzy
+#| msgid "This contact has no newsletter subscriptions"
+msgid "This action only works for complete unsubscriptions."
+msgstr "Este contacto no tiene suscripciones a la newsletter"
+
+#: support/templates/reactivate_subscription.html:157
+msgid ""
+"Partial unsubscriptions and product changes create new subscriptions and "
+"cannot be reactivated using this method."
+msgstr ""
+
+#: support/templates/reactivate_subscription.html:161
+msgid ""
+"After reactivation, the subscription will continue as if the unsubscription "
+"never happened."
+msgstr ""
 
 #: support/templates/release_seller_contacts.html:4
 #: support/templates/release_seller_contacts_by_campaign.html:4
@@ -6406,58 +10095,57 @@ msgstr "Liberar %(contacts_not_worked)s contactos"
 
 #: support/templates/sales_record_create.html:4
 #: support/templates/validate_subscription_sales_record.html:4
-#: support/views/all_views.py:2037
+#: support/views/all_views.py:2942 support/views/all_views.py:2950
 msgid "Validate subscription"
 msgstr "Validar suscripción"
 
 #: support/templates/sales_record_create.html:10
-#: support/templates/validate_subscription_sales_record.html:9
+#: support/templates/validate_subscription_sales_record.html:36
 msgid "Validate Subscription"
 msgstr "Validar Suscripción"
 
 #: support/templates/sales_record_create.html:36
-#: support/templates/validate_subscription_sales_record.html:35
+#: support/templates/validate_subscription_sales_record.html:154
 msgid "Digital product"
 msgstr "Producto digital"
 
 #: support/templates/sales_record_create.html:44
-#: support/templates/validate_subscription_sales_record.html:43
+#: support/templates/validate_subscription_sales_record.html:162
 msgid "Paper product"
 msgstr "Producto papel"
 
 #: support/templates/sales_record_create.html:84
-#: support/templates/validate_subscription_sales_record.html:83
+#: support/templates/validate_subscription_sales_record.html:202
 msgid "for pause."
 msgstr "por pausa."
 
 #: support/templates/sales_record_create.html:112
-#: support/templates/validate_subscription_sales_record.html:111
+#: support/templates/validate_subscription_sales_record.html:230
 msgid "paused until"
 msgstr "pausa hasta"
 
 #: support/templates/sales_record_create.html:146
-#: support/templates/validate_subscription_sales_record.html:145
+#: support/templates/validate_subscription_sales_record.html:264
 msgid "Billing information"
 msgstr "Información de facturación"
 
 #: support/templates/sales_record_create.html:170
-#: support/templates/validate_subscription_sales_record.html:169
+#: support/templates/validate_subscription_sales_record.html:288
 msgid "Billing ID"
 msgstr "ID de facturación"
 
 #: support/templates/sales_record_create.html:178
-#: support/templates/validate_subscription_sales_record.html:177
+#: support/templates/validate_subscription_sales_record.html:296
 msgid "RUT"
 msgstr "NIT"
 
 #: support/templates/sales_record_create.html:213
-#: support/templates/sales_record_filter.html:30
-#: support/templates/validate_subscription_sales_record.html:212
+#: support/templates/validate_subscription_sales_record.html:331
 msgid "Sales Record"
 msgstr "Registro de ventas"
 
 #: support/templates/sales_record_create.html:224
-#: support/templates/sales_record_filter.html:107
+#: support/templates/sales_record_filter.html:149
 msgid "Commission"
 msgstr "Comisión"
 
@@ -6470,103 +10158,122 @@ msgid "Add this sale manually"
 msgstr "Agregar esta venta manualmente"
 
 #: support/templates/sales_record_create.html:248
-#: support/templates/validate_subscription_sales_record.html:265
+#: support/templates/validate_subscription_sales_record.html:409
 msgid "View in admin"
 msgstr "Ver en admin"
 
-#: support/templates/sales_record_filter.html:4
-#: templates/components/sidebar_items/_campaign_management.html:86
-msgid "Sales Records"
-msgstr "Registros de ventas"
+#: support/templates/sales_record_filter.html:28
+#, fuzzy
+#| msgid "sellers"
+msgid "Select sellers"
+msgstr "vendedores"
 
-#: support/templates/sales_record_filter.html:27
-#: support/templates/seller_console.html:4
-#: support/templates/seller_console.html:11
-#: support/templates/seller_console_list_campaigns.html:6
-#: support/views/activities.py:28 templates/components/_sidebar.html:72
-msgid "Seller console"
-msgstr "Consola de ventas"
+#: support/templates/sales_record_filter.html:35
+#, fuzzy
+#| msgid "Payment method"
+msgid "Select payment methods"
+msgstr "Método de pago"
 
-#: support/templates/sales_record_filter.html:27
-#: templates/components/_sidebar.html:79
-msgid "My Sales"
-msgstr "Mis Ventas"
+#: support/templates/sales_record_filter.html:65
+#, fuzzy
+#| msgid "Transaction date"
+msgid "Transaction date (min)"
+msgstr "Fecha de transacción"
 
-#: support/templates/sales_record_filter.html:30
-#: templates/components/sidebar_items/_campaign_management.html:18
-msgid "Campaign Management"
-msgstr "Gestión de campañas"
+#: support/templates/sales_record_filter.html:71
+#, fuzzy
+#| msgid "Transaction date"
+msgid "Transaction date (max)"
+msgstr "Fecha de transacción"
 
-#: support/templates/sales_record_filter.html:75
+#: support/templates/sales_record_filter.html:117
 msgid "sales records"
 msgstr "registros de ventas"
 
-#: support/templates/sales_record_filter.html:79
+#: support/templates/sales_record_filter.html:121
 msgid "Export"
 msgstr "Exportar"
 
-#: support/templates/sales_record_filter.html:101
+#: support/templates/sales_record_filter.html:143
 msgid "Transaction date"
 msgstr "Fecha de transacción"
 
-#: support/templates/sales_record_filter.html:108
+#: support/templates/sales_record_filter.html:150
 msgid "Valid"
 msgstr "Válido"
 
-#: support/templates/sales_record_filter.html:132
+#: support/templates/sales_record_filter.html:168
+#: support/templates/validate_subscription_sales_record.html:361
+msgid "Payment method is only relevant for full sales"
+msgstr ""
+
+#: support/templates/sales_record_filter.html:181
 msgid "OK"
 msgstr "OK"
 
-#: support/templates/sales_record_filter.html:150
+#: support/templates/sales_record_filter.html:184
+#, fuzzy
+#| msgid "Route details"
+msgid "View details"
+msgstr "Detalles de la ruta"
+
+#: support/templates/sales_record_filter.html:205
 msgid "My commissions"
 msgstr "Mis comisiones"
 
-#: support/templates/sales_record_filter.html:157
+#: support/templates/sales_record_filter.html:212
 msgid "Totals by product amount"
 msgstr "Totales por cantidad de producto"
 
-#: support/templates/sales_record_filter.html:164
-#: support/templates/sales_record_filter.html:187
-#: support/templates/sales_record_filter.html:210
+#: support/templates/sales_record_filter.html:219
+#: support/templates/sales_record_filter.html:242
+#: support/templates/sales_record_filter.html:265
 msgid "Quantity"
 msgstr "Cantidad"
 
-#: support/templates/sales_record_filter.html:180
+#: support/templates/sales_record_filter.html:235
 msgid "Totals by payment type"
 msgstr "Totales por tipo de pago"
 
-#: support/templates/sales_record_filter.html:203
+#: support/templates/sales_record_filter.html:258
 msgid "Totals by subscription frequency"
 msgstr "Totales por frecuencia de suscripción"
 
-#: support/templates/scheduled_activities.html:21
+#: support/templates/scheduled_activities.html:39
 msgid "All your upcoming and scheduled activities."
 msgstr "Todas tus actividades futuras y programadas."
 
-#: support/templates/scheduled_activities.html:53
-#: support/templates/scheduled_activities.html:112
+#: support/templates/scheduled_activities.html:71
+#: support/templates/scheduled_activities.html:180
 msgid "Console Action"
 msgstr "Acción de consola"
 
-#: support/templates/scheduled_activities.html:89
+#: support/templates/scheduled_activities.html:150
 msgid "Scheduled Activities"
 msgstr "Actividades programadas"
 
-#: support/templates/scheduled_activities.html:102
+#: support/templates/scheduled_activities.html:170
 msgid "Latest Subscription End Date"
 msgstr "Fecha de fin de la última suscripción"
 
-#: support/templates/scheduled_activities.html:128
+#: support/templates/scheduled_activities.html:195
 msgid "See in console"
 msgstr "Ver en consola"
 
-#: support/templates/scheduled_activities.html:130
+#: support/templates/scheduled_activities.html:197
 msgid "Console"
 msgstr "Consola"
 
-#: support/templates/scheduled_activities.html:132
+#: support/templates/scheduled_activities.html:199
 msgid "Contact Details"
 msgstr "Detalles de contacto"
+
+#: support/templates/scheduled_activities.html:230
+#: support/templates/support/seller_attendance_filter.html:24
+#, fuzzy
+#| msgid "Select day"
+msgid "Select..."
+msgstr "Seleccionar día"
 
 #: support/templates/scheduled_task_filter.html:4
 #: support/templates/scheduled_task_filter.html:26
@@ -6593,172 +10300,234 @@ msgstr "Fecha de ejecución máxima"
 msgid "All issues"
 msgstr "Todos los incidencias"
 
-#: support/templates/seller_console.html:119
+#: support/templates/seller_console.html:4
+#: support/templates/seller_console.html:11
+#: support/templates/seller_console_list_campaigns.html:6
+#: support/views/activities.py:28 support/views/all_views.py:2779
+#: templates/components/_sidebar.html:92
+msgid "Seller console"
+msgstr "Consola de ventas"
+
+#: support/templates/seller_console.html:140
+#, fuzzy
+#| msgid "This contact has no issues"
+msgid "This contact has open issues — check the right panel"
+msgstr "Este contacto no tiene incidencias"
+
+#: support/templates/seller_console.html:142
+#, python-format
+msgid "%(count)s open issue(s) — check right panel"
+msgstr ""
+
+#: support/templates/seller_console.html:146
 msgid "Contact "
 msgstr "Contacto "
 
-#: support/templates/seller_console.html:119
+#: support/templates/seller_console.html:146
 msgid "of"
 msgstr "de"
 
-#: support/templates/seller_console.html:121
+#: support/templates/seller_console.html:148
 msgid "Times contacted in this campaign:"
 msgstr "Veces contactado en esta campaña:"
 
-#: support/templates/seller_console.html:178
+#: support/templates/seller_console.html:205
 msgid "Phone duplicates"
 msgstr "Duplicados por teléfono"
 
-#: support/templates/seller_console.html:181
+#: support/templates/seller_console.html:208
 msgid "other contact(s) with same phone number"
 msgstr "otro(s) contacto(s) con el mismo número de teléfono"
 
-#: support/templates/seller_console.html:218
+#: support/templates/seller_console.html:252
 msgid "The contact has no registered addresses"
 msgstr "El contacto no tiene direcciones registradas"
 
-#: support/templates/seller_console.html:239
-#: templates/admin/object_history.html:48
-msgid "Action"
-msgstr "Acción"
-
-#: support/templates/seller_console.html:252
+#: support/templates/seller_console.html:286
 msgid "There are no previous activities"
 msgstr "No hay actividades previas"
 
-#: support/templates/seller_console.html:264
-#: support/templates/view_issue.html:200 support/templates/view_issue.html:237
-#: support/views/activities.py:151
+#: support/templates/seller_console.html:298 support/views/activities.py:152
 msgid "Register activity"
 msgstr "Registrar actividad"
 
-#: support/templates/seller_console.html:277
+#: support/templates/seller_console.html:307
 msgid "Select a reason before selecting one of these options"
 msgstr "Seleccione una razón antes de seleccionar una de estas opciones"
 
-#: support/templates/seller_console.html:293
-#: support/templates/seller_console.html:297
-#: support/templates/seller_console.html:318
-#: support/templates/seller_console.html:322
+#: support/templates/seller_console.html:334
+#: support/templates/seller_console.html:338
+#: support/templates/seller_console.html:357
+#: support/templates/seller_console.html:361
 msgid "Do you want to continue?"
 msgstr "¿Desea continuar?"
 
-#: support/templates/seller_console.html:333
-#: support/templates/seller_console_start_promo.html:76
-#: support/templates/seller_console_start_promo.html:82
+#: support/templates/seller_console.html:370
+#: support/templates/seller_console_start_promo.html:101
+#: support/templates/seller_console_start_promo.html:107
 msgid "Send promo"
 msgstr "Enviar promoción"
 
-#: support/templates/seller_console.html:343
+#: support/templates/seller_console.html:380
 msgid "Change product"
 msgstr "Cambiar producto"
 
-#: support/templates/seller_console.html:346
+#: support/templates/seller_console.html:383
 msgid "Sell"
 msgstr "Vender"
 
-#: support/templates/seller_console.html:366
+#: support/templates/seller_console.html:404
 msgid "Time"
 msgstr "Hora"
 
-#: support/templates/seller_console.html:380
+#: support/templates/seller_console.html:418
 msgid "Schedule"
 msgstr "Programar"
 
-#: support/templates/seller_console.html:396
+#: support/templates/seller_console.html:434
 msgid "Other campaigns"
 msgstr "Otras campañas"
 
-#: support/templates/seller_console.html:408
-msgid "Status:"
-msgstr "Estado:"
-
-#: support/templates/seller_console.html:410
+#: support/templates/seller_console.html:448
 msgid "Last action:"
 msgstr "Ultima accion:"
 
-#: support/templates/seller_console.html:413
+#: support/templates/seller_console.html:451
 msgid "Seller:"
 msgstr "Vendedor:"
 
-#: support/templates/seller_console.html:416
+#: support/templates/seller_console.html:454
 msgid "Resolution:"
 msgstr "Resolución:"
 
-#: support/templates/seller_console.html:421
+#: support/templates/seller_console.html:459
 msgid "Reason:"
 msgstr "Razon:"
 
-#: support/templates/seller_console.html:434
+#: support/templates/seller_console.html:472
 msgid "Other subscriptions"
 msgstr "Otras suscripciones"
 
-#: support/templates/seller_console.html:441
-msgid "Type:"
-msgstr "Tipo:"
-
-#: support/templates/seller_console.html:452
+#: support/templates/seller_console.html:490
 msgid "Expand"
 msgstr "Expandir"
+
+#: support/templates/seller_console.html:535
+#, fuzzy
+#| msgid "Collection issues"
+msgid "Contact's open issues"
+msgstr "Incidentes de cobranza"
 
 #: support/templates/seller_console_list_campaigns.html:8
 msgid "Manage promotions and sales"
 msgstr "Gestionar promociones y ventas"
 
-#: support/templates/seller_console_list_campaigns.html:15
+#: support/templates/seller_console_list_campaigns.html:17
 msgid "Contacts in special routes"
 msgstr "Contactos en rutas especiales"
 
-#: support/templates/seller_console_list_campaigns.html:49
+#: support/templates/seller_console_list_campaigns.html:51
+#: support/templates/seller_console_never_paid_issues.html:18
 msgid "Contacts that never paid their first invoice"
 msgstr "Contactos que nunca pagaron su primer recibo"
 
-#: support/templates/seller_console_list_campaigns.html:75
+#: support/templates/seller_console_list_campaigns.html:58
+#, fuzzy
+#| msgid "Country"
+msgid "Count"
+msgstr "País"
+
+#: support/templates/seller_console_list_campaigns.html:64
+#: support/templates/seller_console_never_paid_issues.html:5
+#, fuzzy
+#| msgid "See related issue"
+msgid "Never paid issues"
+msgstr "Ver incidencia relacionado"
+
+#: support/templates/seller_console_list_campaigns.html:79
 msgid "Not contacted"
 msgstr "No contactado"
 
-#: support/templates/seller_console_list_campaigns.html:82
-#: support/templates/seller_console_list_campaigns.html:121
+#: support/templates/seller_console_list_campaigns.html:86
+#: support/templates/seller_console_list_campaigns.html:125
 msgid "Campaign name"
 msgstr "Nombre de la campaña"
 
-#: support/templates/seller_console_list_campaigns.html:83
+#: support/templates/seller_console_list_campaigns.html:87
 msgid "Campaign count"
 msgstr "Cantidad de campañas"
 
-#: support/templates/seller_console_list_campaigns.html:84
-#: support/templates/seller_console_list_campaigns.html:124
+#: support/templates/seller_console_list_campaigns.html:88
+#: support/templates/seller_console_list_campaigns.html:128
 msgid "Campaign end date"
 msgstr "Fecha final de la campaña"
 
-#: support/templates/seller_console_list_campaigns.html:85
-#: support/templates/seller_console_list_campaigns.html:125
+#: support/templates/seller_console_list_campaigns.html:89
+#: support/templates/seller_console_list_campaigns.html:129
 msgid "Successful"
 msgstr "Exitoso"
 
-#: support/templates/seller_console_list_campaigns.html:108
+#: support/templates/seller_console_list_campaigns.html:112
 msgid "There is nothing here now."
 msgstr "No hay nada aqui ahora."
 
-#: support/templates/seller_console_list_campaigns.html:114
+#: support/templates/seller_console_list_campaigns.html:118
 msgid "Activities to do"
 msgstr "Tareas por hacer"
 
-#: support/templates/seller_console_list_campaigns.html:141
+#: support/templates/seller_console_list_campaigns.html:145
 msgid "List activities"
 msgstr "Listar actividades"
 
-#: support/templates/seller_console_list_campaigns.html:155
+#: support/templates/seller_console_list_campaigns.html:159
 msgid "Congratulations! Everything seems to be done."
 msgstr "¡Felicidades! Todo parece estar listo."
 
-#: support/templates/seller_console_list_campaigns.html:158
+#: support/templates/seller_console_list_campaigns.html:162
 msgid "Next upcoming activity"
 msgstr "Proxima actividad programada"
 
-#: support/templates/seller_console_list_campaigns.html:161
+#: support/templates/seller_console_list_campaigns.html:165
 msgid "List all pending and scheduled activities"
 msgstr "Listar todas las actividades pendientes y programadas"
+
+#: support/templates/seller_console_never_paid_issues.html:6
+#, fuzzy
+#| msgid "Contacts that never paid their first invoice"
+msgid "Contacts who never paid their first invoice"
+msgstr "Contactos que nunca pagaron su primer recibo"
+
+#: support/templates/seller_console_never_paid_issues.html:12
+#, fuzzy
+#| msgid "Priority"
+msgid "Priority order"
+msgstr "Prioridad"
+
+#: support/templates/seller_console_never_paid_issues.html:13
+msgid ""
+"Issues are shown with the most overdue invoices first, then by oldest "
+"subscription start date. This helps you focus on the most urgent cases."
+msgstr ""
+
+#: support/templates/seller_console_never_paid_issues.html:24
+#, fuzzy
+#| msgid "Issue Date"
+msgid "Issue ID"
+msgstr "Fecha de emisión"
+
+#: support/templates/seller_console_never_paid_issues.html:27
+#: support/views/all_views.py:2299 support/views/all_views.py:2900
+msgid "Subscription start date"
+msgstr "Fecha de inicio de la suscripción"
+
+#: support/templates/seller_console_never_paid_issues.html:28
+#: support/views/contacts.py:161
+msgid "Overdue invoices"
+msgstr "Facturas vencidas"
+
+#: support/templates/seller_console_special_routes.html:4
+msgid "Special route"
+msgstr "Ruta especial"
 
 #: support/templates/seller_console_special_routes.html:5
 msgid "Manage contacts in this route"
@@ -6775,25 +10544,23 @@ msgstr ""
 "        Lista de contactos en ruta %(route_number)s\n"
 "      "
 
-#: support/templates/seller_console_special_routes.html:23
-msgid "Subscription ID"
-msgstr "ID de suscripción"
-
-#: support/templates/seller_console_special_routes.html:26
-msgid "Phone number"
-msgstr "Número de teléfono"
+#: support/templates/seller_console_start_promo.html:4
+#: support/views/subscriptions.py:1622
+#, fuzzy
+#| msgid "Started promotion"
+msgid "Update promotion"
+msgstr "Promoción iniciada"
 
 #: support/templates/seller_console_start_promo.html:4
 msgid "Start promotion"
 msgstr "Iniciar promoción"
 
-#: support/templates/seller_console_start_promo.html:199
-msgid "Add new address"
-msgstr "Agregar nueva dirección"
-
-#: support/templates/seller_console_start_promo.html:219
-msgid "Save address"
-msgstr "Guardar dirección"
+#: support/templates/seller_console_start_promo.html:101
+#: support/templates/seller_console_start_promo.html:107
+#, fuzzy
+#| msgid "Updated from"
+msgid "Update promo"
+msgstr "Actualizado de"
 
 #: support/templates/seller_performance_by_time.html:43
 msgid "Amount of worked contacts"
@@ -6807,46 +10574,10 @@ msgstr "Contactos llamados"
 msgid "Contacted contacts"
 msgstr "Contactos contactados"
 
-#: support/templates/seller_performance_by_time.html:56
-msgid "Date from"
-msgstr "Fecha desde"
-
-#: support/templates/seller_performance_by_time.html:60
-msgid "Date to"
-msgstr "Fecha hasta"
-
 #: support/templates/seller_performance_by_time.html:88
 #: support/templates/seller_performance_by_time.html:108
 msgid "View console"
 msgstr "Ver consola"
-
-#: support/templates/subscriptions/affiliate_subscriptions.html:5
-msgid "Bulk Subscriptions"
-msgstr "Suscripciones corporativas"
-
-#: support/templates/subscriptions/affiliate_subscriptions.html:9
-msgid "Bulk Subscriptions for Main Subscription"
-msgstr "Suscripciones corporativas para la suscripción principal"
-
-#: support/templates/subscriptions/affiliate_subscriptions.html:17
-msgid "Main Subscription Details"
-msgstr "Detalles de la suscripción principal"
-
-#: support/templates/subscriptions/affiliate_subscriptions.html:32
-msgid "Add New Bulk Subscription"
-msgstr "Agregar nueva suscripción corporativa"
-
-#: support/templates/subscriptions/affiliate_subscriptions.html:53
-msgid "Add Bulk Subscription"
-msgstr "Agregar suscripción corporativa"
-
-#: support/templates/subscriptions/affiliate_subscriptions.html:62
-msgid "Current Bulk Subscriptions"
-msgstr "Suscripciones corporativas actuales"
-
-#: support/templates/subscriptions/affiliate_subscriptions.html:87
-msgid "No bulk subscriptions found."
-msgstr "No se encontraron suscripciones corporativas."
 
 #: support/templates/subscriptions/corporate_subscription.html:9
 #: support/templates/subscriptions/corporate_subscription.html:28
@@ -6883,7 +10614,78 @@ msgstr "Fecha de fin de suscripción"
 msgid "No subscriptions found"
 msgstr "No se encontraron suscripciones."
 
-#: support/templates/tag_analysis.html:5 support/views/contacts.py:735
+#: support/templates/support/seller_attendance.html:21
+#, fuzzy
+#| msgid "Loading"
+msgid "Load"
+msgstr "Cargando"
+
+#: support/templates/support/seller_attendance.html:25
+#, fuzzy
+#| msgid "Monthly"
+msgid "Monthly calendar"
+msgstr "Mensual"
+
+#: support/templates/support/seller_attendance.html:31
+msgid ""
+"There are no active absence reasons configured. Please create at least one "
+"in the admin before recording attendance."
+msgstr ""
+
+#: support/templates/support/seller_attendance.html:38
+msgid "Attendance defaults to Present for all sellers with an assigned shift."
+msgstr ""
+
+#: support/templates/support/seller_attendance.html:39
+msgid ""
+"Update any absences before saving. Note: if you save now, sellers who have "
+"not yet started their shift will also be recorded as present — remember to "
+"return and correct any absences after each shift ends."
+msgstr ""
+
+#: support/templates/support/seller_attendance.html:62
+#, fuzzy
+#| msgid "Not assigned"
+msgid "No shift assigned"
+msgstr "No asignados"
+
+#: support/templates/support/seller_attendance.html:63
+msgid "No shift"
+msgstr ""
+
+#: support/templates/support/seller_attendance.html:122
+#, fuzzy
+#| msgid "Save and add another"
+msgid "Save attendance"
+msgstr "Guardar y agregar otro"
+
+#: support/templates/support/seller_attendance.html:128
+msgid ""
+"No call center sellers found. Mark sellers as 'Works in call center' in the "
+"admin to use this tool."
+msgstr ""
+
+#: support/templates/support/seller_attendance.html:189
+msgid "shift times are required."
+msgstr ""
+
+#: support/templates/support/seller_attendance.html:193
+msgid "absence reason is required when marking as absent."
+msgstr ""
+
+#: support/templates/support/seller_attendance_filter.html:93
+#, fuzzy
+#| msgid "Sales records"
+msgid "records"
+msgstr "Registros de ventas"
+
+#: support/templates/support/seller_attendance_filter.html:133
+#, fuzzy
+#| msgid "No subscriptions found"
+msgid "No records found."
+msgstr "No se encontraron suscripciones."
+
+#: support/templates/tag_analysis.html:5 support/views/contacts.py:1141
 msgid "Tag Analysis"
 msgstr "Análisis de etiquetas"
 
@@ -6899,10 +10701,6 @@ msgstr "Nombre de la etiqueta"
 #: support/templates/tag_analysis.html:31
 msgid "Search by tag name..."
 msgstr "Buscar por nombre de etiqueta..."
-
-#: support/templates/tag_analysis.html:36
-msgid "Clear"
-msgstr "Limpiar"
 
 #: support/templates/tag_analysis.html:47
 msgid "Tag Analysis Summary"
@@ -6960,15 +10758,55 @@ msgstr "para ver todas las etiquetas."
 msgid "No tags found in the system."
 msgstr "No se encontraron etiquetas en el sistema."
 
+#: support/templates/tag_contacts.html:4 support/templates/tag_contacts.html:8
+#: support/templates/tag_contacts.html:13
 #: support/templates/tag_contacts.html:20
-#: support/templates/tag_contacts.html:25
-#: support/templates/tag_contacts.html:32
 msgid "Tag multiple contacts"
 msgstr "Etiquetar múltiples contactos"
 
-#: support/templates/tag_contacts.html:38
-msgid "Choose file to send. It mustn't have a header"
-msgstr "Elija el archivo para subir. No debe tener encabezado"
+#: support/templates/tag_contacts.html:23
+msgid ""
+"Upload a CSV file with two columns: contact ID and tag. No header row is "
+"needed."
+msgstr ""
+
+#: support/templates/tag_contacts.html:24
+msgid ""
+"For each row, the tag will be added to the corresponding contact. Multiple "
+"tags can be used in the same file but only one per row."
+msgstr ""
+
+#: support/templates/tag_contacts.html:25
+msgid ""
+"Tag characters will be converted to lowercase. We recommend avoiding spaces "
+"and using hyphens or underscores instead."
+msgstr ""
+
+#: support/templates/tag_contacts.html:29
+msgid "Expected CSV format"
+msgstr ""
+
+#: support/templates/tag_contacts.html:35
+#, fuzzy
+#| msgid "Contact ID"
+msgid "Column 1: contact ID"
+msgstr "ID de contacto"
+
+#: support/templates/tag_contacts.html:36
+msgid "Column 2: tag"
+msgstr ""
+
+#: support/templates/tag_contacts.html:47
+msgid "The file must not have a header row. Accepts UTF-8 or Latin-1 encoding."
+msgstr ""
+
+#: support/templates/tag_contacts.html:54
+msgid "Choose file to upload"
+msgstr ""
+
+#: support/templates/tag_contacts.html:58
+msgid "Import"
+msgstr "Importar"
 
 #: support/templates/unsubscription_statistics.html:4
 #: support/templates/unsubscription_statistics.html:34
@@ -7052,203 +10890,469 @@ msgstr "Subir"
 msgid "Upload payment certificate"
 msgstr "Subir certificado de pago"
 
-#: support/templates/validate_subscription_sales_record.html:219
+#: support/templates/validate_subscription_sales_record.html:20
+#, fuzzy
+#| msgid "Per seller"
+msgid "Select seller"
+msgstr "Por vendedor"
+
+#: support/templates/validate_subscription_sales_record.html:57
+msgid "Partial sale — products added"
+msgstr ""
+
+#: support/templates/validate_subscription_sales_record.html:69
+#, fuzzy
+#| msgid "Use contacts with the following tags"
+msgid "New subscription created with the following products:"
+msgstr "Usar contactos con las siguientes etiquetas"
+
+#: support/templates/validate_subscription_sales_record.html:74
+#: support/templates/validate_subscription_sales_record.html:99
+#: support/templates/validate_subscription_sales_record.html:122
+#, fuzzy
+#| msgid "products"
+msgid "No products"
+msgstr "productos"
+
+#: support/templates/validate_subscription_sales_record.html:80
+#, fuzzy
+#| msgid "Allow product to be shown in the new subscription forms"
+msgid "The following products were added to the existing subscription:"
+msgstr ""
+"Permitir que el producto se muestre en los nuevos formularios de suscripción"
+
+#: support/templates/validate_subscription_sales_record.html:85
+msgid "No new products recorded"
+msgstr ""
+
+#: support/templates/validate_subscription_sales_record.html:93
+msgid "Before"
+msgstr ""
+
+#: support/templates/validate_subscription_sales_record.html:103
+#, fuzzy
+#| msgid "No subscriptions found"
+msgid "Previous subscription not found"
+msgstr "No se encontraron suscripciones."
+
+#: support/templates/validate_subscription_sales_record.html:110
+#, fuzzy
+#| msgid "Afternoon"
+msgid "After"
+msgstr "Tarde"
+
+#: support/templates/validate_subscription_sales_record.html:115
+#, fuzzy
+#| msgid "New address"
+msgid "Newly added"
+msgstr "Nueva dirección"
+
+#: support/templates/validate_subscription_sales_record.html:338
 msgid "Date and Time"
 msgstr "Fecha y hora"
 
-#: support/templates/validate_subscription_sales_record.html:223
+#: support/templates/validate_subscription_sales_record.html:342
 msgid "Added Products"
 msgstr "Productos agregados"
 
-#: support/templates/validate_subscription_sales_record.html:231
-#: support/views/all_views.py:1995
+#: support/templates/validate_subscription_sales_record.html:351
+msgid ""
+"Price reduction — the subscription's new price is lower than before (product "
+"change or retention)"
+msgstr ""
+
+#: support/templates/validate_subscription_sales_record.html:356
+#: support/views/all_views.py:2903
 msgid "Sale Type"
 msgstr "Tipo de venta"
 
-#: support/templates/validate_subscription_sales_record.html:235
+#: support/templates/validate_subscription_sales_record.html:364
 msgid "Calculated Commission"
 msgstr "Comisión calculada"
 
-#: support/templates/validate_subscription_sales_record.html:251
+#: support/templates/validate_subscription_sales_record.html:388
 msgid "Add Commission Value Manually"
 msgstr "Agregar valor de comisión manualmente"
 
-#: support/templates/view_issue.html:4
-msgid "View issue"
-msgstr "Ver incidencia"
+#: support/templates/validate_subscription_sales_record.html:397
+msgid ""
+"If checked, the seller will receive commission for this sale. Uncheck to "
+"exclude it from commission calculations (e.g. retention discounts or non-"
+"commissionable changes)."
+msgstr ""
 
-#: support/templates/view_issue.html:36
+#: support/templates/validate_subscription_sales_record.html:420
+#, fuzzy
+#| msgid "Sales Records"
+msgid "Back to Sales Records"
+msgstr "Registros de ventas"
+
+#: support/templates/view_issue.html:160 support/templates/view_issue.html:402
+#, fuzzy
+#| msgid "Show hidden"
+msgid "Show more"
+msgstr "Mostrar ocultos"
+
+#: support/templates/view_issue.html:160
+#, fuzzy
+#| msgid "Show hidden"
+msgid "lines hidden"
+msgstr "Mostrar ocultos"
+
+#: support/templates/view_issue.html:161
+msgid "Collapse"
+msgstr ""
+
+#: support/templates/view_issue.html:181
 msgid "Issue details"
 msgstr "Detalles del incidencia"
 
-#: support/templates/view_issue.html:52
-msgid "Contact phone"
-msgstr "Teléfono de contacto"
+#: support/templates/view_issue.html:208
+#, fuzzy
+#| msgid "New invoice"
+msgid "View invoices"
+msgstr "Nueva factura"
 
-#: support/templates/view_issue.html:57
-msgid "Contact mobile phone"
-msgstr "Celular de contacto"
+#: support/templates/view_issue.html:208
+msgid "new tab"
+msgstr ""
 
-#: support/templates/view_issue.html:77
-msgid "Subscription product"
-msgstr "Producto de suscripción"
-
-#: support/templates/view_issue.html:117
+#: support/templates/view_issue.html:213
 msgid "This contact doesn't have a debt"
 msgstr "Este contacto no tiene una deuda"
 
-#: support/templates/view_issue.html:126
-msgid "Progress"
-msgstr "Progreso"
+#: support/templates/view_issue.html:227
+msgid "Classification"
+msgstr ""
 
-#: support/templates/view_issue.html:188
-msgid "Update"
-msgstr "Actualizar"
+#: support/templates/view_issue.html:246
+msgid "Status & Assignment"
+msgstr ""
 
-#: support/templates/view_issue.html:205
-msgid "Activity:"
-msgstr "Actividad:"
+#: support/templates/view_issue.html:288
+#, fuzzy
+#| msgid "Address notes"
+msgid "Progress notes"
+msgstr "Notas de dirección"
 
-#: support/templates/view_issue.html:265
-msgid "Contact invoices"
-msgstr "Facturas del contacto"
+#: support/templates/view_issue.html:328
+msgid ""
+"Creation date: automatically set when the issue was opened. Issue date: "
+"editable field representing the date the issue refers to."
+msgstr ""
 
-#: support/views/activities.py:202
+#: support/views/activities.py:203
 msgid "Update activity"
 msgstr "Actualizar actividad"
 
-#: support/views/all_views.py:266
+#: support/views/all_views.py:292
 msgid "Assign sellers"
 msgstr "Asignar vendedores"
 
-#: support/views/all_views.py:629 support/views/all_views.py:712
-#: support/views/all_views.py:1344
+#: support/views/all_views.py:693 support/views/all_views.py:2023
 msgid "Activities count"
 msgstr "Cuenta de actividades"
 
-#: support/views/all_views.py:840
+#: support/views/all_views.py:795 support/views/all_views.py:895
+#: support/views/all_views.py:1241
+#, fuzzy
+#| msgid "Uncategorized logistics issue"
+msgid "Uncategorized"
+msgstr "Problema de logística no categorizado"
+
+#: support/views/all_views.py:808 support/views/all_views.py:908
+#: support/views/all_views.py:1254
+#, fuzzy
+#| msgid "No sub-category"
+msgid "No subcategory"
+msgstr "Sin sub-categoría"
+
+#: support/views/all_views.py:960
+#, fuzzy, python-format
+#| msgid "Issue Subcategory"
+msgid "Assign issues: %(subcategory)s"
+msgstr "Subcategoría de incidencia"
+
+#: support/views/all_views.py:1106
+#, fuzzy
+#| msgid "No agents registered"
+msgid "No assignments specified."
+msgstr "No hay agentes registrados"
+
+#: support/views/all_views.py:1116
+#, python-format
+msgid ""
+"Requested %(requested)s assignments but only %(available)s issues are "
+"available."
+msgstr ""
+
+#: support/views/all_views.py:1153
+#, python-format
+msgid ""
+"%(count)s issues were assigned successfully using round-robin distribution."
+msgstr ""
+
+#: support/views/all_views.py:1455
 msgid "See related issue"
 msgstr "Ver incidencia relacionado"
 
-#: support/views/all_views.py:868
+#: support/views/all_views.py:1463
+#, python-brace-format
+msgid ""
+"Issue <a href=\"{url}\">#{issue_id}</a> created for contact {contact_name}"
+msgstr ""
+
+#: support/views/all_views.py:1491
 #, python-brace-format
 msgid "Issue #{}"
 msgstr "Incidente #{}"
 
-#: support/views/all_views.py:1187
+#: support/views/all_views.py:1590
+#, python-brace-format
+msgid "Issue #{issue_id} updated for contact {contact_name}"
+msgstr ""
+
+#: support/views/all_views.py:1866
 msgid "id document"
 msgstr "documento de identificación"
 
-#: support/views/all_views.py:1214
+#: support/views/all_views.py:1893
 msgid "This filter has no mailtrain id. To use the sync function"
 msgstr ""
 "Este filtro no tiene un ID de Mailtrain. Para usar la función de "
 "sincronización"
 
-#: support/views/all_views.py:1272
+#: support/views/all_views.py:1951
 msgid "Envelope data has been saved."
 msgstr "Datos de la envoltorio han sido guardados."
 
-#: support/views/all_views.py:1292
+#: support/views/all_views.py:1971
 msgid "Payment certificate has been uploaded successfully"
 msgstr "Certificado de pago subido exitosamente"
 
-#: support/views/all_views.py:1424 support/views/contacts.py:88
+#: support/views/all_views.py:2119 support/views/contacts.py:156
 msgid "Has active subscriptions"
 msgstr "Tiene suscripciones activas"
 
-#: support/views/all_views.py:1426
+#: support/views/all_views.py:2121
 msgid "Unfinished invoicing issues"
 msgstr "Incidentes de facturación no finalizados"
 
-#: support/views/all_views.py:1427
+#: support/views/all_views.py:2122
 msgid "Finished invoicing issues"
 msgstr "Incidentes de facturación finalizados"
 
-#: support/views/all_views.py:1718
+#: support/views/all_views.py:2290
+#, fuzzy
+#| msgid "Campaign count"
+msgid "Campaign resolution"
+msgstr "Cantidad de campañas"
+
+#: support/views/all_views.py:2291
+#, fuzzy
+#| msgid "Resolution"
+msgid "Resolution reason"
+msgstr "Resolución"
+
+#: support/views/all_views.py:2293
+#, fuzzy
+#| msgid "Not assigned"
+msgid "Date assigned"
+msgstr "No asignados"
+
+#: support/views/all_views.py:2294
+#, fuzzy
+#| msgid "Next action date"
+msgid "Last action date"
+msgstr "Fecha de próxima acción"
+
+#: support/views/all_views.py:2296
+#, fuzzy
+#| msgid "Not contacted"
+msgid "Times contacted"
+msgstr "No contactado"
+
+#: support/views/all_views.py:2297
+#, fuzzy
+#| msgid "Activities count"
+msgid "Activity count"
+msgstr "Cuenta de actividades"
+
+#: support/views/all_views.py:2298
+#, fuzzy
+#| msgid "Seller console action"
+msgid "Last console action"
+msgstr "Acción de consola de ventas"
+
+#: support/views/all_views.py:2300
+#, fuzzy
+#| msgid "Products Total"
+msgid "Products sold"
+msgstr "Total de productos"
+
+#: support/views/all_views.py:2581
 msgid "Address information has been updated successfully"
 msgstr "Información de dirección actualizada exitosamente"
 
-#: support/views/all_views.py:1820
+#: support/views/all_views.py:2683
 msgid "Numbers have been uploaded successfully."
 msgstr "Números subidos exitosamente."
 
-#: support/views/all_views.py:1950
+#: support/views/all_views.py:2780 templates/components/_sidebar.html:99
+msgid "My Sales"
+msgstr "Mis Ventas"
+
+#: support/views/all_views.py:2850
 msgid "You have no sales records."
 msgstr "No tienes registros de ventas."
 
-#: support/views/all_views.py:1970 support/views/all_views.py:2042
-#: support/views/seller_console.py:78
+#: support/views/all_views.py:2878 support/views/all_views.py:2955
+#: support/views/seller_console.py:157
 msgid "You are not authorized to see this page"
 msgstr "No tienes autorización para ver esta página"
 
-#: support/views/all_views.py:1973
+#: support/views/all_views.py:2881
 msgid "There are no sales records."
 msgstr "No hay registros de ventas."
 
-#: support/views/all_views.py:1992
-msgid "Subscription start date"
-msgstr "Fecha de inicio de la suscripción"
-
-#: support/views/all_views.py:1996
+#: support/views/all_views.py:2904
 msgid "Total Commission"
 msgstr "Comisión total"
 
-#: support/views/all_views.py:2063
+#: support/views/all_views.py:2987
 msgid "The sale and subscription have been validated."
 msgstr "La venta y la suscripción han sido validadas."
 
-#: support/views/all_views.py:2079
+#: support/views/all_views.py:3003
 msgid "There was an error validating the sale and subscription."
 msgstr "Hubo un error al validar la venta y la suscripción."
 
-#: support/views/all_views.py:2093
+#: support/views/all_views.py:3017
 msgid "This subscription has no sales record."
 msgstr "Esta suscripción no tiene un registro de venta."
 
-#: support/views/all_views.py:2096
+#: support/views/all_views.py:3020
 msgid "This subscription has already been validated."
 msgstr "Esta suscripción ya ha sido validada."
 
-#: support/views/all_views.py:2120
+#: support/views/all_views.py:3044
 msgid "This subscription already has a sales record."
 msgstr "Esta suscripción ya tiene un registro de venta."
 
-#: support/views/contacts.py:89
+#: support/views/all_views.py:3151
+msgid "There are no active absence reasons. Please create one before saving."
+msgstr ""
+
+#: support/views/all_views.py:3167
+#, python-format
+msgid "%(seller)s: shift times are required."
+msgstr ""
+
+#: support/views/all_views.py:3172
+#, python-format
+msgid "%(seller)s: an absence reason is required when marking as absent."
+msgstr ""
+
+#: support/views/all_views.py:3180
+#, fuzzy, python-format
+#| msgid "Enter a valid time in HH:MM format."
+msgid "%(seller)s: invalid time format."
+msgstr "Ingrese una hora válida en formato HH:MM."
+
+#: support/views/all_views.py:3188
+#, python-format
+msgid "%(seller)s: selected absence reason is not valid."
+msgstr ""
+
+#: support/views/all_views.py:3222
+#, fuzzy
+#| msgid "Contact saved successfully"
+msgid "Attendance saved successfully."
+msgstr "Contacto guardado exitosamente"
+
+#: support/views/campaign_management.py:107
+msgid ""
+"Could not find contact_id column in CSV. Expected column names: "
+"'contact_id', 'id', 'contact id', or 'contactid'"
+msgstr ""
+
+#: support/views/campaign_management.py:114
+#, fuzzy
+#| msgid "No valid contacts found in this campaign"
+msgid "No valid contact IDs found in the CSV file."
+msgstr "No se encontraron contactos válidos en esta campaña"
+
+#: support/views/campaign_management.py:127
+#, python-brace-format
+msgid ""
+"Successfully deleted {count} ContactCampaignStatus record(s) for campaign "
+"'{campaign}' with {total} contact ID(s) from CSV."
+msgstr ""
+
+#: support/views/campaign_management.py:136
+#: templates/admin/change_form.html:100 templates/admin/change_list.html:62
+#: templates/admin/login.html:8 templates/adminlte/login.html:27
+#: templates/registration/login.html:36
+msgid "Please correct the errors below."
+msgstr "Por favor, corrija los errores abajo."
+
+#: support/views/contacts.py:157
 msgid "Active products"
 msgstr "Productos activos"
 
-#: support/views/contacts.py:91
-msgid "Overdue invoices"
-msgstr "Facturas vencidas"
+#: support/views/contacts.py:159
+#, fuzzy
+#| msgid "Latest pending activity"
+msgid "Last incoming activity"
+msgstr "Actividad pendiente más reciente"
 
-#: support/views/contacts.py:230
+#: support/views/contacts.py:160
+#, fuzzy
+#| msgid "Latest pending activity"
+msgid "Last outgoing activity"
+msgstr "Actividad pendiente más reciente"
+
+#: support/views/contacts.py:386
 msgid "Future Subscriptions"
 msgstr "Suscripciones futuras"
 
-#: support/views/contacts.py:237
+#: support/views/contacts.py:393
 msgid "Subscriptions awaiting payment"
 msgstr "Suscripciones pendientes de pago"
 
-#: support/views/contacts.py:242
+#: support/views/contacts.py:398
 msgid "Subscriptions with errors"
 msgstr "Suscripciones con errores"
 
-#: support/views/contacts.py:247
+#: support/views/contacts.py:403
 msgid "Paused Subscriptions"
 msgstr "Suscripciones pausadas"
 
-#: support/views/contacts.py:252
+#: support/views/contacts.py:408
 msgid "Inactive subscriptions"
 msgstr "Suscripciones inactivas"
 
-#: support/views/contacts.py:347
+#: support/views/contacts.py:504
 msgid "Contact saved successfully"
 msgstr "Contacto guardado exitosamente"
 
-#: support/views/contacts.py:387
-msgid "Create"
-msgstr "Crear"
+#: support/views/contacts.py:1228
+#, fuzzy
+#| msgid "You don't have permission to edit anything."
+msgid "You don't have permission to edit campaign statuses."
+msgstr "No tienes permiso para editar nada."
+
+#: support/views/contacts.py:1243
+#, fuzzy
+#| msgid "Campaign start"
+msgid "Edit campaign status"
+msgstr "Inicio de campaña"
+
+#: support/views/contacts.py:1250
+#, fuzzy
+#| msgid "Contact saved successfully"
+msgid "Campaign status updated successfully."
+msgstr "Contacto guardado exitosamente"
 
 #: support/views/scheduled_tasks.py:47 support/views/scheduled_tasks.py:184
 msgid "Scheduled task for pause"
@@ -7278,129 +11382,265 @@ msgstr "Nuevo cambio de dirección"
 msgid "New partial pause"
 msgstr "Nueva pausa parcial"
 
-#: support/views/seller_console.py:27 support/views/seller_console.py:30
+#: support/views/seller_console.py:28 support/views/seller_console.py:31
+#: support/views/seller_console.py:97
 msgid "This function is not available."
 msgstr "Esta función no está disponible."
 
-#: support/views/seller_console.py:33
+#: support/views/seller_console.py:34
 msgid "This is not a special route."
 msgstr "Esta no es una ruta especial."
 
-#: support/views/seller_console.py:41 support/views/seller_console.py:87
+#: support/views/seller_console.py:42 support/views/seller_console.py:87
+#: support/views/seller_console.py:166
 msgid "User has no seller selected. Please contact your manager."
 msgstr ""
 "El usuario no tiene un vendedor seleccionado. Por favor, contacte a su "
 "supervisor."
 
-#: support/views/seller_console.py:44 support/views/seller_console.py:90
+#: support/views/seller_console.py:45 support/views/seller_console.py:90
+#: support/views/seller_console.py:169
 msgid "This seller is set in more than one user. Please contact your manager."
 msgstr ""
 "Este vendedor está configurado en más de un usuario. Por favor, contacte a "
 "su supervisor."
 
-#: support/views/seller_console.py:56
+#: support/views/seller_console.py:57
 msgid "There are no contacts in that route for this seller."
 msgstr "No hay contactos en esa ruta para este vendedor."
 
-#: support/views/seller_console.py:169
+#: support/views/seller_console.py:61 support/views/seller_console.py:133
+#, fuzzy
+#| msgid "Seller console"
+msgid "Seller Console"
+msgstr "Consola de ventas"
+
+#: support/views/seller_console.py:62
+#, fuzzy
+#| msgid "Special route"
+msgid "Special Routes"
+msgstr "Ruta especial"
+
+#: support/views/seller_console.py:128
+#, fuzzy
+#| msgid "There are no contacts in that route for this seller."
+msgid "There are no never paid issues for this seller."
+msgstr "No hay contactos en esa ruta para este vendedor."
+
+#: support/views/seller_console.py:134
+#, fuzzy
+#| msgid "New Issue"
+msgid "Never Paid Issues"
+msgstr "Nuevo incidencia"
+
+#: support/views/seller_console.py:246
 msgid "You've reached the end of this list"
 msgstr "Ha llegado al final de esta lista"
 
-#: support/views/seller_console.py:187 support/views/seller_console.py:190
+#: support/views/seller_console.py:264 support/views/seller_console.py:267
 msgid "Invalid offset value. Using first item."
 msgstr "Valor de desplazamiento inválido. Usando el primer item."
 
-#: support/views/seller_console.py:219
+#: support/views/seller_console.py:296
 #, python-brace-format
 msgid "Invalid action: {action}"
 msgstr "Acción inválida: {action}"
 
-#: support/views/seller_console.py:222
+#: support/views/seller_console.py:299
 #, python-brace-format
 msgid "Invalid action slug: {action}"
 msgstr "Slug de acción inválido: {action}"
 
-#: support/views/seller_console.py:230
+#: support/views/seller_console.py:307
 msgid "Contact is no longer in this campaign"
 msgstr "El contacto ya no está en esta campaña"
 
-#: support/views/seller_console.py:260
+#: support/views/seller_console.py:341
 msgid "Scheduled for"
 msgstr "Programado para"
 
-#: support/views/seller_console.py:269 support/views/seller_console.py:352
+#: support/views/seller_console.py:350 support/views/seller_console.py:452
 msgid "Activity not found"
 msgstr "Actividad no encontrada"
 
-#: support/views/seller_console.py:278
+#: support/views/seller_console.py:359
 #, python-brace-format
 msgid "The contact is no longer in this campaign, instance number: {}"
 msgstr "El contacto ya no está en esta campaña, instancia número: {}"
 
-#: support/views/seller_console.py:331
+#: support/views/seller_console.py:431
 msgid "Missing console instance in POST data"
 msgstr "Instancia de consola faltante en datos POST"
 
-#: support/views/seller_console.py:335
+#: support/views/seller_console.py:435
 msgid "Contact not found"
 msgstr "Contacto no encontrado"
 
-#: support/views/seller_console.py:340
+#: support/views/seller_console.py:440
 msgid "Invalid seller ID"
 msgstr "ID de vendedor inválido"
 
-#: support/views/seller_console.py:380
-#, python-brace-format
-msgid "Contact {id} has been updated"
-msgstr "El contacto {id} ha sido actualizado"
+#: support/views/seller_console.py:488
+#, fuzzy
+#| msgid "name"
+msgid "No name"
+msgstr "nombre"
 
-#: support/views/seller_console.py:398
+#: support/views/seller_console.py:492
+#, fuzzy, python-brace-format
+#| msgid "Invalid action: {action}"
+msgid "Contact {id} - {name} - Action: {action}"
+msgstr "Acción inválida: {action}"
+
+#: support/views/seller_console.py:499
+#, fuzzy, python-brace-format
+#| msgid "Scheduled for"
+msgid " - Scheduled for: {date}"
+msgstr "Programado para"
+
+#: support/views/seller_console.py:506
+#, fuzzy
+#| msgid "New contact"
+msgid "view contact"
+msgstr "Nuevo contacto"
+
+#: support/views/seller_console.py:530
 msgid "Invalid date or time format"
 msgstr "Formato de fecha o hora inválido"
 
-#: support/views/seller_console.py:431
+#: support/views/seller_console.py:574
 msgid "No valid contacts found in this campaign"
 msgstr "No se encontraron contactos válidos en esta campaña"
 
-#: support/views/seller_console.py:541
-msgid "Activity was removed because the contact is no longer in the campaign"
-msgstr "La actividad fue eliminada porque el contacto ya no está en la campaña"
-
-#: support/views/seller_console.py:546
+#: support/views/seller_console.py:700
 #, python-brace-format
 msgid "An error has occurred with activity number {}"
 msgstr "Ocurrió un error con la actividad número {}"
 
-#: support/views/subscriptions.py:200
+#: support/views/seller_console.py:708
+msgid "Activity was removed because the contact is no longer in the campaign"
+msgstr "La actividad fue eliminada porque el contacto ya no está en la campaña"
+
+#: support/views/subscriptions.py:203
 msgid ""
 "The subscription may not have been completely saved or synchronized with the "
 "CMS"
 msgstr ""
 "Esta suscripción puede no haber sido completamente sincronizada con el CMS"
 
-#: support/views/subscriptions.py:221 support/views/subscriptions.py:341
+#: support/views/subscriptions.py:224 support/views/subscriptions.py:346
 msgid "Wrong data"
 msgstr "Datos incorrectos"
 
-#: support/views/subscriptions.py:233
+#: support/views/subscriptions.py:236
 #, python-brace-format
 msgid "Activity {} is not in campaign {}. Please report this error!"
 msgstr ""
 "La actividad {} no está en la campaña {}. Por favor, reporte este error!"
 
-#: support/views/subscriptions.py:488 support/views/subscriptions.py:536
-#: support/views/subscriptions.py:625
+#: support/views/subscriptions.py:493 support/views/subscriptions.py:812
+#: support/views/subscriptions.py:901
 msgid "WARNING: This subscription has already been closed"
 msgstr "ADVERTENCIA: Esta suscripción ya ha sido cerrada"
 
-#: support/views/subscriptions.py:508 support/views/subscriptions.py:597
-#: support/views/subscriptions.py:701 support/views/subscriptions.py:825
+#: support/views/subscriptions.py:529
+#, python-brace-format
+msgid ""
+"Complete unsubscription booked for {end_date}.\n"
+"Reason: {reason}\n"
+"Products: {products}\n"
+"Manager: {manager}"
+msgstr ""
+
+#: support/views/subscriptions.py:554 support/views/subscriptions.py:873
+#: support/views/subscriptions.py:994 support/views/subscriptions.py:1121
 msgid "WARNING: This subscription already has an end date"
 msgstr "ADVERTENCIA: Esta suscripción ya tiene una fecha final"
 
-#: support/views/subscriptions.py:836
+#: support/views/subscriptions.py:595
+#, fuzzy
+#| msgid "This subscription is not active and should not be billed."
+msgid "This subscription is not unsubscribed and cannot be reactivated"
+msgstr "Esta suscripción no está activa y no debe ser facturada."
+
+#: support/views/subscriptions.py:602
+msgid ""
+"Only complete unsubscriptions can be reactivated. Partial unsubscriptions "
+"and product changes create new subscriptions."
+msgstr ""
+
+#: support/views/subscriptions.py:615
+#, python-brace-format
+msgid ""
+"This subscription cannot be reactivated because more than 30 days have "
+"passed since the unsubscription date ({unsubscription_date}). Reactivation "
+"is only allowed within 30 days of unsubscription."
+msgstr ""
+
+#: support/views/subscriptions.py:683
+#, python-brace-format
+msgid ""
+"Unsubscription data (created during reactivation for registry):\n"
+"End date: {end_date}\n"
+"Reason: {reason}\n"
+"Products: {products}\n"
+"Manager: {manager}"
+msgstr ""
+
+#: support/views/subscriptions.py:733
+#, fuzzy, python-brace-format
+#| msgid "Subscription start date"
+msgid "Subscription reactivated by {user} on {date}"
+msgstr "Fecha de inicio de la suscripción"
+
+#: support/views/subscriptions.py:739
+msgid "Original unsubscription data stored in Activity"
+msgstr ""
+
+#: support/views/subscriptions.py:1132
 msgid "Book additional product"
 msgstr "Reservar producto adicional"
+
+#: support/views/subscriptions.py:1198
+#, python-format
+msgid "Start date must be at least tomorrow (%s)"
+msgstr ""
+
+#: support/views/subscriptions.py:1237
+msgid ""
+"Please select at least one retention discount, add new products, or mark "
+"products to remove"
+msgstr ""
+
+#: support/views/subscriptions.py:1264
+msgid ""
+"You cannot remove all subscription products without adding new ones. At "
+"least one subscription product must remain (discounts alone are not enough)."
+msgstr ""
+
+#: support/views/subscriptions.py:1435
+#, fuzzy
+#| msgid "Started promotion"
+msgid "Send promotion"
+msgstr "Promoción iniciada"
+
+#: support/views/subscriptions.py:1771
+#, fuzzy
+#| msgid "Address information has been updated successfully"
+msgid "Promotional subscription updated successfully"
+msgstr "Información de dirección actualizada exitosamente"
+
+#: support/views/subscriptions.py:2065
+#, fuzzy, python-brace-format
+#| msgid "Bill subscriptions manually for %(contact)s"
+msgid "Free subscription created successfully for {contact}"
+msgstr "Facturar suscripciones manualmente para %(contact)s"
+
+#: support/views/subscriptions.py:2143
+#, fuzzy, python-brace-format
+#| msgid "Bill subscriptions manually for %(contact)s"
+msgid "Free subscription updated successfully for {contact}"
+msgstr "Facturar suscripciones manualmente para %(contact)s"
 
 #: templates/admin/base_login.html:23
 msgid "Django administration"
@@ -7428,12 +11668,6 @@ msgstr "Ver en el sitio"
 #: templates/registration/login.html:34
 msgid "Please correct the error below."
 msgstr "Por favor, corrija el error abajo."
-
-#: templates/admin/change_form.html:100 templates/admin/change_list.html:62
-#: templates/admin/login.html:8 templates/adminlte/login.html:27
-#: templates/registration/login.html:36
-msgid "Please correct the errors below."
-msgstr "Por favor, corrija los errores abajo."
 
 #: templates/admin/change_list.html:97
 #, python-format
@@ -7538,10 +11772,6 @@ msgstr ""
 msgid "Show all"
 msgstr "Mostrar todo"
 
-#: templates/admin/submit_line.html:6
-msgid "Delete"
-msgstr "Eliminar"
-
 #: templates/admin/submit_line.html:11
 msgid "Save as new"
 msgstr "Guardar como nuevo"
@@ -7589,11 +11819,17 @@ msgstr "Contraseña"
 msgid "Login"
 msgstr "Iniciar sesión"
 
-#: templates/components/_sidebar.html:87
+#: templates/components/_sidebar.html:82
+#, fuzzy
+#| msgid "Community Complaints"
+msgid "Community manager"
+msgstr "Reclamos comunitarios"
+
+#: templates/components/_sidebar.html:107
 msgid "Admin panel"
 msgstr "Panel de administración"
 
-#: templates/components/_sidebar.html:94
+#: templates/components/_sidebar.html:114
 msgid "Logout"
 msgstr "Cerrar sesión"
 
@@ -7605,37 +11841,9 @@ msgstr "Mis anunciantes"
 msgid "Purchase Orders"
 msgstr "Pedidos de compra"
 
-#: templates/components/sidebar_items/_campaign_management.html:27
-msgid "Import Contacts"
-msgstr "Importar contactos"
-
-#: templates/components/sidebar_items/_campaign_management.html:34
-msgid "Check for existing contacts"
-msgstr "Verificar contactos existentes"
-
-#: templates/components/sidebar_items/_campaign_management.html:41
-msgid "Tag Contacts"
-msgstr "Etiquetar contactos"
-
-#: templates/components/sidebar_items/_campaign_management.html:48
-msgid "Assign contacts by tag"
-msgstr "Asignar contactos por etiqueta"
-
-#: templates/components/sidebar_items/_campaign_management.html:61
-msgid "New campaign"
-msgstr "Nueva campaña"
-
-#: templates/components/sidebar_items/_campaign_management.html:71
-msgid "Sellers performance"
-msgstr "Rendimiento de vendedores"
-
-#: templates/components/sidebar_items/_campaign_management.html:76
-msgid "Release seller contacts"
-msgstr "Liberar contactos de vendedores"
-
-#: templates/components/sidebar_items/_campaign_management.html:81
-msgid "Upload do not call list"
-msgstr "Subir lista de no contactar"
+#: templates/components/sidebar_items/_campaign_management.html:119
+msgid "Attendance Calendar"
+msgstr ""
 
 #: templates/components/sidebar_items/_logistics.html:30
 msgid "Assign subscriptions to routes"
@@ -7689,6 +11897,10 @@ msgstr "Simple"
 msgid "Detailed"
 msgstr "Detallado"
 
+#: templates/components/sidebar_items/_logistics.html:126
+msgid "Complementary information"
+msgstr "Información complementaria"
+
 #: templates/components/sidebar_items/_support.html:37
 msgid "Contact filters"
 msgstr "Filtros de contacto"
@@ -7700,11 +11912,6 @@ msgstr "Fechas de finalización de suscripción"
 #: templates/components/sidebar_items/_support.html:64
 msgid "Tag analysis"
 msgstr "Análisis de etiquetas"
-
-#: tests/test_contact.py:109
-#, python-brace-format
-msgid "Contact {name} (ID: {id}) added to campaign {campaign}"
-msgstr "Contacto {name} (ID: {id}) agregado a la campaña {campaign}"
 
 #: util/dates.py:87
 msgid "Mon"
@@ -8001,6 +12208,122 @@ msgstr "La contraseña debe contener al menos 1 letra minúscula, a-z."
 #: validators.py:45
 msgid "Your password must contain at least 1 lowercase letter, a-z."
 msgstr "Tu contraseña debe contener al menos 1 letra minúscula, a-z."
+
+#~ msgid "Upgraded"
+#~ msgstr "Actualizado"
+
+#~ msgid "Upgrade"
+#~ msgstr "Actualización"
+
+#~ msgid "Journalism direction"
+#~ msgstr "Dirección de periodismo"
+
+#, python-format
+#~ msgid "Contact %(name)s (ID: %(id)s) added to campaign %(campaign)s"
+#~ msgstr "Contacto %(name)s (ID: %(id)s) agregado a la campaña %(campaign)s"
+
+#~ msgid "Only email addresses will be used for matching existing contacts"
+#~ msgstr ""
+#~ "Solo se utilizarán las direcciones de correo electrónico para buscar "
+#~ "contactos existentes"
+
+#~ msgid "Upload and Check"
+#~ msgstr "Subir y verificar"
+
+#~ msgid "Indentifier"
+#~ msgstr "Identificador"
+
+#~ msgid "Saved without Georef"
+#~ msgstr "Guardado sin georreferenciación"
+
+#~ msgid "Last Read Articles"
+#~ msgstr "Últimos artículos leídos"
+
+#~ msgid "Total invoices paid"
+#~ msgstr "Total de facturas pagadas"
+
+#~ msgid "Payment type of last invoice"
+#~ msgstr "Tipo de pago de la última factura"
+
+#~ msgid "Subscription paused until"
+#~ msgstr "Suscripción pausada hasta"
+
+#~ msgid "Subscription awaiting payment"
+#~ msgstr "Suscripción esperando pago"
+
+#~ msgid "because of pause"
+#~ msgstr "por pausa"
+
+#~ msgid "Positive Balance (Discount)"
+#~ msgstr "Saldo positivo (Descuento)"
+
+#~ msgid "Negative Balance (Surcharge)"
+#~ msgstr "Saldo negativo (Recargo)"
+
+#~ msgid "Go to parent subscription"
+#~ msgstr "Ir a la suscripción padre"
+
+#~ msgid "because of Pause"
+#~ msgstr "por pausa"
+
+#~ msgid "Last paid invoice"
+#~ msgstr "Factura pagada más reciente"
+
+#~ msgid "Import has encountered some errors"
+#~ msgstr "La importación ha encontrado algunos errores"
+
+#~ msgid ""
+#~ "Choose file to send. It has to be a csv file with the following header "
+#~ "and columns"
+#~ msgstr ""
+#~ "Elija el archivo para enviar. Debe ser un archivo csv con el siguiente "
+#~ "encabezado y columnas"
+
+#~ msgid "All columns must be present in the header."
+#~ msgstr "Todos los campos deben estar presentes en el encabezado."
+
+#~ msgid "Add new address"
+#~ msgstr "Agregar nueva dirección"
+
+#~ msgid "Bulk Subscriptions"
+#~ msgstr "Suscripciones corporativas"
+
+#~ msgid "Bulk Subscriptions for Main Subscription"
+#~ msgstr "Suscripciones corporativas para la suscripción principal"
+
+#~ msgid "Main Subscription Details"
+#~ msgstr "Detalles de la suscripción principal"
+
+#~ msgid "Add New Bulk Subscription"
+#~ msgstr "Agregar nueva suscripción corporativa"
+
+#~ msgid "Add Bulk Subscription"
+#~ msgstr "Agregar suscripción corporativa"
+
+#~ msgid "Current Bulk Subscriptions"
+#~ msgstr "Suscripciones corporativas actuales"
+
+#~ msgid "No bulk subscriptions found."
+#~ msgstr "No se encontraron suscripciones corporativas."
+
+#~ msgid "Choose file to send. It mustn't have a header"
+#~ msgstr "Elija el archivo para subir. No debe tener encabezado"
+
+#~ msgid "Contact phone"
+#~ msgstr "Teléfono de contacto"
+
+#~ msgid "Contact mobile phone"
+#~ msgstr "Celular de contacto"
+
+#~ msgid "Activity:"
+#~ msgstr "Actividad:"
+
+#~ msgid "Contact invoices"
+#~ msgstr "Facturas del contacto"
+
+#, python-brace-format
+#~ msgid "Contact {id} has been updated"
+#~ msgstr "El contacto {id} ha sido actualizado"
 
 #~ msgid ""
 #~ "Choose a CSV file to check for existing contacts. The file should have at "

--- a/support/filters.py
+++ b/support/filters.py
@@ -474,9 +474,9 @@ class SellerAttendanceFilter(django_filters.FilterSet):
         queryset=AbsenceReason.objects.filter(active=True).order_by("name"),
         label=_("Absence reason"),
     )
-    absences_only = django_filters.BooleanFilter(
-        method="filter_absences_only",
-        label=_("Absences only"),
+    include_present = django_filters.BooleanFilter(
+        method="filter_include_present",
+        label=_("Include present"),
         widget=forms.CheckboxInput(),
     )
     justified = django_filters.ChoiceFilter(
@@ -489,8 +489,8 @@ class SellerAttendanceFilter(django_filters.FilterSet):
         model = SellerAttendance
         fields = []
 
-    def filter_absences_only(self, queryset, name, value):
-        if value:
+    def filter_include_present(self, queryset, name, value):
+        if not value:
             return queryset.filter(status="A")
         return queryset
 

--- a/support/filters.py
+++ b/support/filters.py
@@ -8,7 +8,17 @@ from django.contrib.auth.models import User
 from django.db.models import Q
 
 from core.models import Activity, ContactCampaignStatus, Subscription, Campaign, Product
-from .models import Issue, IssueSubcategory, IssueResolution, Seller, ScheduledTask, SalesRecord, SellerConsoleAction
+from .models import (
+    AbsenceReason,
+    Issue,
+    IssueSubcategory,
+    IssueResolution,
+    Seller,
+    SellerAttendance,
+    ScheduledTask,
+    SalesRecord,
+    SellerConsoleAction,
+)
 
 
 CREATION_CHOICES = (
@@ -433,4 +443,62 @@ class SubscriptionEndDateFilter(django_filters.FilterSet):
     def filter_products(self, queryset, name, value):
         if value:
             return queryset.filter(products__in=value).distinct()
+        return queryset
+
+
+JUSTIFIED_CHOICES = (
+    ("", _("All")),
+    ("true", _("Justified")),
+    ("false", _("Unjustified")),
+)
+
+
+class SellerAttendanceFilter(django_filters.FilterSet):
+    date_from = django_filters.DateFilter(
+        field_name="record__date",
+        lookup_expr="gte",
+        label=_("Date from"),
+        widget=forms.DateInput(attrs={"type": "date", "class": "form-control"}),
+    )
+    date_to = django_filters.DateFilter(
+        field_name="record__date",
+        lookup_expr="lte",
+        label=_("Date to"),
+        widget=forms.DateInput(attrs={"type": "date", "class": "form-control"}),
+    )
+    seller = django_filters.ModelMultipleChoiceFilter(
+        queryset=Seller.objects.filter(call_center=True).order_by("name"),
+        label=_("Sellers"),
+    )
+    absence_reason = django_filters.ModelMultipleChoiceFilter(
+        queryset=AbsenceReason.objects.filter(active=True).order_by("name"),
+        label=_("Absence reason"),
+    )
+    absences_only = django_filters.BooleanFilter(
+        method="filter_absences_only",
+        label=_("Absences only"),
+        widget=forms.CheckboxInput(),
+    )
+    justified = django_filters.ChoiceFilter(
+        choices=JUSTIFIED_CHOICES,
+        method="filter_by_justified",
+        label=_("Justified"),
+    )
+
+    class Meta:
+        model = SellerAttendance
+        fields = []
+
+    def filter_absences_only(self, queryset, name, value):
+        if value:
+            return queryset.filter(status="A")
+        return queryset
+
+    def filter_by_justified(self, queryset, name, value):
+        if value == "true":
+            return queryset.filter(absence_reason__justified=True)
+        elif value == "false":
+            return queryset.filter(status="A").filter(
+                Q(absence_reason__isnull=True) | Q(absence_reason__justified=False)
+            )
         return queryset

--- a/support/templates/campaign_management_menu.html
+++ b/support/templates/campaign_management_menu.html
@@ -317,6 +317,19 @@ $(function() {
                                 </div>
                             </div>
                         </div>
+                        <div class="col-lg-4 col-6 campaign-card-col">
+                            <div class="card">
+                                <div class="card-header">
+                                    <h3 class="card-title">{% trans "Seller Attendance Filter" %}</h3>
+                                </div>
+                                <div class="card-body">
+                                    <p>{% trans "Filter and export seller attendance records by date range, seller, and absence reason." %}</p>
+                                    <div class="text-right">
+                                        <a href="{% url 'seller_attendance_filter' %}" class="btn btn-default">{% trans "Go to filter" %}</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/support/templates/support/seller_attendance_filter.html
+++ b/support/templates/support/seller_attendance_filter.html
@@ -1,0 +1,147 @@
+{% extends "adminlte/base.html" %}
+{% load static i18n widget_tweaks %}
+
+{% block title %}
+  {% trans "Seller Attendance Filter" %}
+{% endblock title %}
+
+{% block stylesheets %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'css/chosen/chosen.min.css' %}" />
+{% endblock %}
+
+{% block no_heading %}
+  <h1>{% trans "Seller Attendance Filter" %}</h1>
+{% endblock no_heading %}
+
+{% block extra_js %}
+  <script src="{% static 'js/chosen.jquery.min.js' %}"></script>
+  <script>
+  $(function() {
+    $("select.form-control").chosen({
+      allow_single_deselect: true,
+      no_results_text: "{% trans 'No results match' %}",
+      placeholder_text_multiple: "{% trans 'Select...' %}",
+      placeholder_text_single: "{% trans 'Select an option' %}",
+      width: "100%"
+    });
+  });
+  </script>
+{% endblock extra_js %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-12">
+
+    {# Filter card #}
+    <div class="card">
+      <div class="card-body">
+        <form method="get" id="filter-form">
+          <div class="row">
+
+            <div class="col-md-2">
+              <div class="form-group">
+                <label for="{{ filter.form.date_from.id_for_label }}">{{ filter.form.date_from.label }}</label>
+                {% render_field filter.form.date_from class="form-control" %}
+              </div>
+            </div>
+
+            <div class="col-md-2">
+              <div class="form-group">
+                <label for="{{ filter.form.date_to.id_for_label }}">{{ filter.form.date_to.label }}</label>
+                {% render_field filter.form.date_to class="form-control" %}
+              </div>
+            </div>
+
+            <div class="col-md-3">
+              <div class="form-group">
+                <label for="{{ filter.form.seller.id_for_label }}">{{ filter.form.seller.label }}</label>
+                {% render_field filter.form.seller class="form-control" %}
+              </div>
+            </div>
+
+            <div class="col-md-3">
+              <div class="form-group">
+                <label for="{{ filter.form.absence_reason.id_for_label }}">{{ filter.form.absence_reason.label }}</label>
+                {% render_field filter.form.absence_reason class="form-control" %}
+              </div>
+            </div>
+
+            <div class="col-md-1">
+              <div class="form-group">
+                <label for="{{ filter.form.justified.id_for_label }}">{{ filter.form.justified.label }}</label>
+                {% render_field filter.form.justified class="form-control" %}
+              </div>
+            </div>
+
+            <div class="col-md-1 d-flex align-items-center">
+              <div class="form-group mt-2">
+                <div class="form-check">
+                  {% render_field filter.form.absences_only class="form-check-input" %}
+                  <label class="form-check-label" for="{{ filter.form.absences_only.id_for_label }}">
+                    {{ filter.form.absences_only.label }}
+                  </label>
+                </div>
+              </div>
+            </div>
+
+          </div>
+
+          <div class="row">
+            <div class="col-md-12 text-right">
+              <span class="mr-3 text-muted">
+                {{ paginator.count }} {% trans "records" %}
+              </span>
+              <a href="?{{ request.GET.urlencode }}&export=1" class="btn btn-secondary">
+                <i class="fas fa-file-csv"></i> {% trans "Export CSV" %}
+              </a>
+              <button type="submit" class="btn btn-primary ml-1">
+                <i class="fas fa-filter"></i> {% trans "Filter" %}
+              </button>
+              <a href="?" class="btn btn-default ml-1">
+                <i class="fas fa-times"></i> {% trans "Clear" %}
+              </a>
+            </div>
+          </div>
+
+        </form>
+      </div>
+    </div>
+
+    {# Results table card #}
+    <div class="card">
+      <div class="card-body p-0">
+        <table class="table table-bordered table-striped table-sm mb-0">
+          <thead>
+            <tr>
+              <th>{% trans "Date" %}</th>
+              <th>{% trans "Seller" %}</th>
+              <th>{% trans "Status" %}</th>
+              <th>{% trans "Absence reason" %}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for att in page_obj %}
+            <tr>
+              <td>{{ att.record.date }}</td>
+              <td>{{ att.seller.name }}</td>
+              <td>{{ att.get_status_display }}</td>
+              <td>{{ att.absence_reason.name|default:"" }}</td>
+            </tr>
+            {% empty %}
+            <tr>
+              <td colspan="4" class="text-center text-muted py-3">{% trans "No records found." %}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    {% if page_obj.has_other_pages %}
+      {% include "components/_pagination.html" %}
+    {% endif %}
+
+  </div>
+</div>
+{% endblock content %}

--- a/support/templates/support/seller_attendance_filter.html
+++ b/support/templates/support/seller_attendance_filter.html
@@ -77,9 +77,9 @@
             <div class="col-md-1 d-flex align-items-center">
               <div class="form-group mt-2">
                 <div class="form-check">
-                  {% render_field filter.form.absences_only class="form-check-input" %}
-                  <label class="form-check-label" for="{{ filter.form.absences_only.id_for_label }}">
-                    {{ filter.form.absences_only.label }}
+                  {% render_field filter.form.include_present class="form-check-input" %}
+                  <label class="form-check-label" for="{{ filter.form.include_present.id_for_label }}">
+                    {{ filter.form.include_present.label }}
                   </label>
                 </div>
               </div>

--- a/support/urls.py
+++ b/support/urls.py
@@ -59,6 +59,7 @@ from support.views.all_views import (
     CommunityManagerOverviewView,
     IssueListView,
     SellerAttendanceCalendarView,
+    SellerAttendanceFilterView,
     SellerAttendanceView,
 )
 from support.views.campaign_management import bulk_delete_campaign_status, campaign_management_menu
@@ -293,5 +294,6 @@ urlpatterns = [
     ),
     path("seller_attendance/", SellerAttendanceView.as_view(), name="seller_attendance"),
     path("seller_attendance/calendar/", SellerAttendanceCalendarView.as_view(), name="seller_attendance_calendar"),
+    path("seller_attendance/filter/", SellerAttendanceFilterView.as_view(), name="seller_attendance_filter"),
     path("campaign_management/", campaign_management_menu, name="campaign_management"),
 ]

--- a/support/views/all_views.py
+++ b/support/views/all_views.py
@@ -61,6 +61,7 @@ from support.filters import (
     IssueFilter,
     SalesRecordFilter,
     SalesRecordFilterForSeller,
+    SellerAttendanceFilter,
 )
 from support.forms import (
     AddressComplementaryInformationForm,
@@ -3377,3 +3378,67 @@ class SellerAttendanceCalendarView(LoginRequiredMixin, UserPassesTestMixin, Brea
             can_edit=request.user.is_superuser or request.user.has_perm("support.change_sellerattendance"),
         )
         return render(request, self.template_name, context)
+
+
+class SellerAttendanceFilterView(LoginRequiredMixin, UserPassesTestMixin, BreadcrumbsMixin, FilterView):
+    model = SellerAttendance
+    filterset_class = SellerAttendanceFilter
+    template_name = "support/seller_attendance_filter.html"
+    paginate_by = 100
+    page_kwarg = "p"
+    context_object_name = "attendances"
+
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def breadcrumbs(self):
+        return [
+            {"label": _("Home"), "url": reverse("home")},
+            {"label": _("Campaign Management"), "url": reverse("campaign_management")},
+            {"label": _("Seller Attendance Filter")},
+        ]
+
+    def get_queryset(self):
+        return (
+            SellerAttendance.objects.select_related("record", "seller", "absence_reason")
+            .order_by("record__date", "seller__name")
+        )
+
+    def get(self, request, *args, **kwargs):
+        if request.GET.get("export"):
+            return self.export_csv()
+        return super().get(request, *args, **kwargs)
+
+    def export_csv(self):
+        import io
+
+        def generate_rows():
+            yield "﻿"  # UTF-8 BOM para Excel
+            buffer = io.StringIO()
+            writer = csv.writer(buffer)
+            writer.writerow([
+                str(_("Date")),
+                str(_("Seller")),
+                str(_("Status")),
+                str(_("Absence reason")),
+            ])
+            yield buffer.getvalue()
+            buffer.seek(0)
+            buffer.truncate(0)
+
+            filterset = self.get_filterset(self.filterset_class)
+            qs = filterset.qs.select_related("record", "seller", "absence_reason")
+            for att in qs.iterator(chunk_size=500):
+                writer.writerow([
+                    att.record.date,
+                    att.seller.name,
+                    att.get_status_display(),
+                    att.absence_reason.name if att.absence_reason else "",
+                ])
+                yield buffer.getvalue()
+                buffer.seek(0)
+                buffer.truncate(0)
+
+        response = StreamingHttpResponse(generate_rows(), content_type="text/csv; charset=utf-8")
+        response["Content-Disposition"] = 'attachment; filename="seller_attendance_filter.csv"'
+        return response


### PR DESCRIPTION
## Summary

- Adds `SellerAttendanceFilterView` (`/seller_attendance/filter/`): filterable, paginated list of `SellerAttendance` records
- Filters: date range (from/to), multiple sellers, multiple absence reasons, absences-only toggle, justified/unjustified dropdown
- Streaming CSV export with UTF-8 BOM (Excel-compatible), same filters applied
- N+1 prevented via `select_related('record', 'seller', 'absence_reason')` propagated through FilterSet and pagination
- New card "Filtro de asistencias de vendedores" added to Campaign Management menu
- Localization: Spanish (`es`) translations for all new strings

## Files changed

- `support/filters.py` — new `SellerAttendanceFilter` FilterSet
- `support/views/all_views.py` — new `SellerAttendanceFilterView`
- `support/urls.py` — new route `seller_attendance/filter/` → `seller_attendance_filter`
- `support/templates/support/seller_attendance_filter.html` — new template
- `support/templates/campaign_management_menu.html` — new card
- `locale/es/LC_MESSAGES/django.po` — translations

## Test plan

- [x] Navigate to `/campaign_management/` — confirm new "Seller Attendance Filter" card appears
- [x] Navigate to `/seller_attendance/filter/` — page loads without errors
- [x] Apply date range filter — results update correctly
- [x] Apply multiple seller filter (Chosen.js multi-select) — results update correctly
- [x] Apply absence reason filter — results update correctly
- [x] Toggle "Solo inasistencias" — only absent records shown
- [x] Filter by justified/unjustified
- [x] Export CSV with active filters — download opens correctly in Excel with accented characters
- [x] Verify no N+1 queries via django-debug-toolbar
- [x] Verify all labels appear in Spanish