### PR TITLE
t1141: fix default absences-only, add justified column

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: django\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-06 16:44-0300\n"
+"POT-Creation-Date: 2026-05-06 17:07-0300\n"
 "PO-Revision-Date: 2026-04-30 17:18-0300\n"
 "Last-Translator: tanyatree\n"
 "Language-Team: \n"
@@ -65,7 +65,7 @@ msgstr "Anunciante"
 #: support/templates/validate_subscription_sales_record.html:334
 #: support/templates/validate_subscription_sales_record.html:380
 #: support/views/all_views.py:2292 support/views/all_views.py:2899
-#: support/views/all_views.py:3421
+#: support/views/all_views.py:3423
 msgid "Seller"
 msgstr "Vendedor"
 
@@ -101,7 +101,7 @@ msgstr "Facturar a"
 #: support/templates/support/seller_attendance.html:19
 #: support/templates/support/seller_attendance_filter.html:117
 #: support/templates/unsubscription_statistics.html:47
-#: support/views/all_views.py:2898 support/views/all_views.py:3420
+#: support/views/all_views.py:2898 support/views/all_views.py:3422
 msgid "Date"
 msgstr "Fecha"
 
@@ -802,7 +802,7 @@ msgstr "Dirección"
 #: support/templates/validate_subscription_sales_record.html:225
 #: support/templates/view_issue.html:189 support/views/all_views.py:694
 #: support/views/all_views.py:2024 support/views/all_views.py:2289
-#: support/views/all_views.py:3422
+#: support/views/all_views.py:3424
 msgid "Status"
 msgstr "Estado"
 
@@ -5795,10 +5795,15 @@ msgstr "Fecha de inicio de la suscripción (máxima)"
 
 #: support/filters.py:451 support/filters.py:485 support/models.py:681
 #: support/models.py:685
+#: support/templates/support/seller_attendance_filter.html:120
+#: support/templates/support/seller_attendance_filter.html:132
+#: support/views/all_views.py:3425 support/views/all_views.py:3436
 msgid "Justified"
 msgstr "Justificada"
 
 #: support/filters.py:452 support/models.py:685
+#: support/templates/support/seller_attendance_filter.html:132
+#: support/views/all_views.py:3436
 msgid "Unjustified"
 msgstr "Injustificada"
 
@@ -5816,12 +5821,12 @@ msgstr "Vendedores"
 
 #: support/filters.py:475 support/models.py:723
 #: support/templates/support/seller_attendance.html:51
-#: support/templates/support/seller_attendance_filter.html:120
-#: support/views/all_views.py:3423
+#: support/templates/support/seller_attendance_filter.html:121
+#: support/views/all_views.py:3426
 msgid "Absence reason"
 msgstr "Razón de inasistencia"
 
-#: support/filters.py:479
+#: support/filters.py:478
 msgid "Include present"
 msgstr "Incluir asistencias"
 
@@ -10220,7 +10225,7 @@ msgstr ""
 msgid "records"
 msgstr "registros"
 
-#: support/templates/support/seller_attendance_filter.html:133
+#: support/templates/support/seller_attendance_filter.html:139
 msgid "No records found."
 msgstr "No se encontraron registros."
 

--- a/support/filters.py
+++ b/support/filters.py
@@ -475,9 +475,9 @@ class SellerAttendanceFilter(django_filters.FilterSet):
         label=_("Absence reason"),
     )
     include_present = django_filters.BooleanFilter(
-        method="filter_include_present",
         label=_("Include present"),
         widget=forms.CheckboxInput(),
+        method="filter_include_present",
     )
     justified = django_filters.ChoiceFilter(
         choices=JUSTIFIED_CHOICES,
@@ -490,8 +490,7 @@ class SellerAttendanceFilter(django_filters.FilterSet):
         fields = []
 
     def filter_include_present(self, queryset, name, value):
-        if not value:
-            return queryset.filter(status="A")
+        # Filtering handled in SellerAttendanceFilterView.get_queryset() via GET param
         return queryset
 
     def filter_by_justified(self, queryset, name, value):

--- a/support/templates/support/seller_attendance_filter.html
+++ b/support/templates/support/seller_attendance_filter.html
@@ -117,6 +117,7 @@
               <th>{% trans "Date" %}</th>
               <th>{% trans "Seller" %}</th>
               <th>{% trans "Status" %}</th>
+              <th>{% trans "Justified" %}</th>
               <th>{% trans "Absence reason" %}</th>
             </tr>
           </thead>
@@ -126,11 +127,16 @@
               <td>{{ att.record.date }}</td>
               <td>{{ att.seller.name }}</td>
               <td>{{ att.get_status_display }}</td>
+              <td>
+                {% if att.absence_reason %}
+                  {% if att.absence_reason.justified %}{% trans "Justified" %}{% else %}{% trans "Unjustified" %}{% endif %}
+                {% endif %}
+              </td>
               <td>{{ att.absence_reason.name|default:"" }}</td>
             </tr>
             {% empty %}
             <tr>
-              <td colspan="4" class="text-center text-muted py-3">{% trans "No records found." %}</td>
+              <td colspan="5" class="text-center text-muted py-3">{% trans "No records found." %}</td>
             </tr>
             {% endfor %}
           </tbody>

--- a/support/views/all_views.py
+++ b/support/views/all_views.py
@@ -3399,10 +3399,12 @@ class SellerAttendanceFilterView(LoginRequiredMixin, UserPassesTestMixin, Breadc
         ]
 
     def get_queryset(self):
-        return (
-            SellerAttendance.objects.select_related("record", "seller", "absence_reason")
-            .order_by("record__date", "seller__name")
+        qs = SellerAttendance.objects.select_related("record", "seller", "absence_reason").order_by(
+            "record__date", "seller__name"
         )
+        if not self.request.GET.get("include_present"):
+            qs = qs.filter(status="A")
+        return qs
 
     def get(self, request, *args, **kwargs):
         if request.GET.get("export"):
@@ -3420,6 +3422,7 @@ class SellerAttendanceFilterView(LoginRequiredMixin, UserPassesTestMixin, Breadc
                 str(_("Date")),
                 str(_("Seller")),
                 str(_("Status")),
+                str(_("Justified")),
                 str(_("Absence reason")),
             ])
             yield buffer.getvalue()
@@ -3429,10 +3432,15 @@ class SellerAttendanceFilterView(LoginRequiredMixin, UserPassesTestMixin, Breadc
             filterset = self.get_filterset(self.filterset_class)
             qs = filterset.qs.select_related("record", "seller", "absence_reason")
             for att in qs.iterator(chunk_size=500):
+                if att.absence_reason:
+                    justified_str = str(_("Justified") if att.absence_reason.justified else _("Unjustified"))
+                else:
+                    justified_str = ""
                 writer.writerow([
                     att.record.date,
                     att.seller.name,
                     att.get_status_display(),
+                    justified_str,
                     att.absence_reason.name if att.absence_reason else "",
                 ])
                 yield buffer.getvalue()


### PR DESCRIPTION
Default view now shows only absences regardless of filter state by checking include_present GET param in get_queryset(). Adds Justified column (Justificada/Injustificada) to both table and CSV export.