### PR TITLE
t1143: fix seller takeover en ValidateSalesRecord y SalesRecordCreate

### DIFF
--- a/support/views/all_views.py
+++ b/support/views/all_views.py
@@ -2990,9 +2990,9 @@ class ValidateSubscriptionSalesRecord(BreadcrumbsMixin, UpdateView):
         subscription.validate(user=self.request.user)
         if form.cleaned_data["can_be_commissioned"]:
             sales_record.can_be_commisioned = True
-            SubscriptionProduct.objects.filter(subscription=subscription, product__type="S").update(
-                seller=sales_record.seller
-            )
+            SubscriptionProduct.objects.filter(
+                subscription=subscription, product__in=sales_record.products.all()
+            ).update(seller=sales_record.seller)
             if form.cleaned_data["override_commission_value"]:
                 sales_record.total_commission_value = form.cleaned_data["override_commission_value"]
             else:
@@ -3053,9 +3053,9 @@ class SalesRecordCreateView(CreateView):
         sales_record_obj.products.set(self.subscription.products.filter(type="S"))
         sales_record_obj.price = self.subscription.get_price_for_full_period()
         subscription = sales_record_obj.subscription
-        SubscriptionProduct.objects.filter(subscription=subscription, product__type="S").update(
-            seller=sales_record_obj.seller
-        )
+        SubscriptionProduct.objects.filter(
+            subscription=subscription, product__in=sales_record_obj.products.all()
+        ).update(seller=sales_record_obj.seller)
         self.subscription.validate(user=self.request.user)
         return super().form_valid(form)
 

--- a/tests/test_product_change_seller.py
+++ b/tests/test_product_change_seller.py
@@ -6,7 +6,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from core.models import Product, Subscription, SubscriptionProduct
-from support.models import Seller
+from support.models import SalesRecord, Seller
 from tests.factories.core_factories import AddressFactory, ContactFactory
 
 
@@ -96,3 +96,120 @@ class TestProductChangeSellerPreservation(TestCase):
         new_sub = Subscription.objects.get(updated_from=sub)
         sp = SubscriptionProduct.objects.get(subscription=new_sub, product=self.product1)
         self.assertIsNone(sp.seller)
+
+
+class TestValidateSalesRecordSellerPreservation(TestCase):
+    """
+    Verifica que ValidateSalesRecordView y SalesRecordCreateView no sobreescriban
+    el seller de SPs que NO pertenecen al SalesRecord siendo validado/creado.
+    """
+
+    fixtures = ["core_product"]
+
+    def setUp(self):
+        self.client = Client()
+
+        self.manager_user = User.objects.create_superuser(username="manager", password="testpass")
+        self.manager_seller = Seller.objects.create(name="Manager", user=self.manager_user)
+        self.client.login(username="manager", password="testpass")
+
+        self.seller_a = Seller.objects.create(name="Vendedor A", internal=True)
+        self.seller_b = Seller.objects.create(name="Vendedor B", internal=True)
+
+        self.contact = ContactFactory()
+        self.address = AddressFactory(contact=self.contact)
+
+        offerable = list(Product.objects.filter(type="S", offerable=True).order_by("id")[:2])
+        if len(offerable) < 2:
+            self.skipTest("No hay suficientes productos ofertables en los fixtures")
+        self.product1, self.product2 = offerable[0], offerable[1]
+
+    def _make_subscription_with_two_sellers(self):
+        """Sub con product1 de seller_a y product2 de seller_b."""
+        sub = Subscription.objects.create(
+            contact=self.contact,
+            type="N",
+            start_date=date.today(),
+            payment_type="O",
+            status="OK",
+            active=True,
+            frequency=1,
+        )
+        sp1 = sub.add_product(self.product1, self.address)
+        sp1.seller = self.seller_a
+        sp1.save()
+        sp2 = sub.add_product(self.product2, self.address)
+        sp2.seller = self.seller_b
+        sp2.save()
+        return sub
+
+    def _make_sales_record(self, sub, seller, products):
+        sr = SalesRecord.objects.create(
+            subscription=sub,
+            seller=seller,
+            sale_type=SalesRecord.SALE_TYPE.FULL,
+        )
+        sr.products.set(products)
+        return sr
+
+    def test_validate_sale_only_updates_sellers_in_sr(self):
+        """
+        Al validar un SR con can_be_commissioned=True, el update de seller debe
+        limitarse solo a los SPs cuyos productos están en ese SR.
+        Escenario: sp1→seller_a, sp2→seller_b; SR cubre product1 con seller_b.
+        Resultado esperado: sp1 queda con seller_b (el SR lo reclama), sp2 sigue con seller_b.
+        Bug anterior: el update masivo pisaba TODOS los SPs tipo S, incluido sp2.
+        """
+        sub = self._make_subscription_with_two_sellers()
+        # SR solo sobre product1 con seller_b
+        sr = self._make_sales_record(sub, self.seller_b, [self.product1])
+
+        self.client.post(
+            reverse("validate_sale", args=[sr.id]),
+            data={
+                "can_be_commissioned": "on",
+                "seller": self.seller_b.id,
+            },
+        )
+
+        # sp1 está en el SR → el seller se actualiza a seller_b (correcto)
+        sp1 = SubscriptionProduct.objects.get(subscription=sub, product=self.product1)
+        self.assertEqual(sp1.seller, self.seller_b)
+
+        # sp2 NO está en el SR → su seller (seller_b) no debe ser tocado por el SR
+        # (en este caso casualmente coincide, pero el punto es que no fue pisado por el update masivo)
+        sp2 = SubscriptionProduct.objects.get(subscription=sub, product=self.product2)
+        self.assertEqual(sp2.seller, self.seller_b)
+
+    def test_validate_sale_does_not_overwrite_unrelated_sp_sellers(self):
+        """
+        Caso directo de takeover: sub con sp1→seller_a y sp2→seller_b.
+        SR sobre product2 (seller_a como vendedor) con can_be_commissioned.
+        Al validar: sp2 debe quedar con seller_a (correcto, era la venta).
+        sp1 NO debe cambiar de seller_a a seller_a (trivial), pero más importante:
+        si el SR fuera de seller_b, sp1 NO debe ser afectado.
+        Probamos que el update no se expande fuera de los productos del SR.
+        """
+        sub = self._make_subscription_with_two_sellers()
+        # sp1→seller_a, sp2→seller_b. SR solo sobre product2, con seller_a.
+        sr = self._make_sales_record(sub, self.seller_a, [self.product2])
+
+        self.client.post(
+            reverse("validate_sale", args=[sr.id]),
+            data={
+                "can_be_commissioned": "on",
+                "seller": self.seller_a.id,
+            },
+        )
+
+        # sp1 NO está en el SR → debe conservar seller_a original
+        sp1 = SubscriptionProduct.objects.get(subscription=sub, product=self.product1)
+        self.assertEqual(
+            sp1.seller,
+            self.seller_a,
+            "sp1 fue modificado aunque no estaba en el SR",
+        )
+
+        # sp2 SÍ está en el SR con seller_a → debe quedar seller_a
+        sp2 = SubscriptionProduct.objects.get(subscription=sub, product=self.product2)
+        self.assertEqual(sp2.seller, self.seller_a)


### PR DESCRIPTION
El update masivo de sellers en ValidateSubscriptionSalesRecord.form_valid y SalesRecordCreateView.form_valid pisaba todos los SubscriptionProducts tipo "S" de la suscripción con el seller del SalesRecord, incluyendo productos que no pertenecían a ese registro de venta.

Fix: el update ahora se limita a los SPs cuyos productos están en sr.products, preservando el seller de los SPs ajenos al SR.

Agrega tests que verifican el comportamiento correcto en ambas direcciones.