### PR TITLE
t1144: ranking de productos, gráfico de conversión y fix N+1 en campaign statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## v0.5.1
 
+## 2026-05-11 — t1144 Ranking de productos y métricas de conversión en estadísticas de campaña
+
+- La vista de estadísticas de campaña ahora muestra los productos vendidos ordenados de mayor a menor, filtrando los que no tienen ventas; la antigua tabla plana sin orden fue reemplazada
+- La tarjeta "Producto más vendido" fue expandida a un ranking con podio visual (trofeo dorado, medalla plateada, medalla bronce para los primeros tres) y lista simple para el resto
+- Se agregaron dos nuevas tarjetas en la columna lateral: total de productos vendidos y promedio de productos por suscriptor con éxito (resolución S2)
+- La tarjeta "Conversión de la base" ahora muestra un gráfico de dona (doughnut) junto al texto usando Chart.js, ya incluido en AdminLTE
+- Se corrigió un N+1: el conteo de ventas por producto pasó de N queries individuales a una sola query con GROUP BY
+- No se requieren migraciones
+- **Author:** Tanya Tree + Claude Sonnet 4.6
+
 ## 2026-05-08 — t1143 Fix seller takeover in ValidateSalesRecord and SalesRecordCreate
 
 - Validating a sale with "can be commissioned" no longer overwrites the seller of every type-S product on the subscription — the update now applies only to products explicitly listed in that specific SalesRecord

--- a/support/templates/campaign_statistics_detail.html
+++ b/support/templates/campaign_statistics_detail.html
@@ -1,9 +1,33 @@
 {% extends "adminlte/base.html" %}
 {% load i18n static widget_tweaks %}
+{% block stylesheets %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'admin-lte/plugins/chart.js/Chart.min.css' %}">
+{% endblock %}
 {% block extra_js %}
+  <script src="{% static 'admin-lte/plugins/chart.js/Chart.bundle.min.js' %}"></script>
   <script type="text/javascript">
 $( function() {
   $('[data-toggle="tooltip"]').tooltip();
+
+  var pct = parseFloat("{{ success_rate_pct|floatformat:2 }}".replace(",", "."));
+  var ctx = document.getElementById('conversionChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      datasets: [{
+        data: [pct, Math.max(0, 100 - pct)],
+        backgroundColor: ['#007bff', '#e9ecef'],
+        borderWidth: 0,
+      }]
+    },
+    options: {
+      cutoutPercentage: 70,
+      legend: { display: false },
+      tooltips: { enabled: false },
+      animation: { animateRotate: true },
+    }
+  });
 });
   </script>
 {% endblock %}
@@ -268,10 +292,14 @@ $( function() {
               </tr>
             </thead>
             <tbody>
-              {% for product, amount in subs_dict.items %}
+              {% for product, amount in sorted_products %}
                 <tr>
                   <td>{{ product }}</td>
                   <td>{{ amount }}</td>
+                </tr>
+              {% empty %}
+                <tr>
+                  <td colspan="2">Sin ventas registradas</td>
                 </tr>
               {% endfor %}
             </tbody>
@@ -284,17 +312,73 @@ $( function() {
         <div class="card-header">
           <h4 class="card-title">Conversión de la base</h4>
         </div>
-        <div class="card-body">
-          <p class="h2">{{ success_rate_count }} suscriptores ({{ success_rate_pct|floatformat:2 }}% de contactados)</p>
+        <div class="card-body d-flex align-items-center">
+          <div style="width:90px;min-width:90px;">
+            <canvas id="conversionChart" width="90" height="90"></canvas>
+          </div>
+          <div class="ml-3">
+            <p class="h2 mb-1">{{ success_rate_count }} suscriptores</p>
+            <p class="h5 text-muted mb-0">{{ success_rate_pct|floatformat:2 }}% de contactados</p>
+          </div>
         </div>
       </div>
-      {% if most_sold_count %}
+      {% if sorted_products %}
         <div class="card">
           <div class="card-header">
-            <h4 class="card-title">Producto más vendido</h4>
+            <h4 class="card-title">Ranking de productos vendidos</h4>
           </div>
           <div class="card-body">
-            <p class="h2">{{ most_sold }} ({{ most_sold_count }})</p>
+            {% for product, amount in sorted_products %}
+              {% if forloop.counter == 1 %}
+                <div class="d-flex justify-content-between align-items-center h6 text-warning mb-2">
+                  <span><i class="fas fa-trophy"></i> {{ product }}</span>
+                  <span class="badge badge-warning">{{ amount }}</span>
+                </div>
+              {% elif forloop.counter == 2 %}
+                <div class="d-flex justify-content-between align-items-center h6 text-secondary mb-2">
+                  <span><i class="fas fa-medal"></i> {{ product }}</span>
+                  <span class="badge badge-secondary">{{ amount }}</span>
+                </div>
+              {% elif forloop.counter == 3 %}
+                <div class="d-flex justify-content-between align-items-center h6 mb-2" style="color:#cd7f32;">
+                  <span><i class="fas fa-medal"></i> {{ product }}</span>
+                  <span class="badge" style="background-color:#cd7f32;color:#fff;">{{ amount }}</span>
+                </div>
+              {% else %}
+                {% if forloop.counter == 4 %}
+                  <hr>
+                  <ul class="list-unstyled mb-0">
+                {% endif %}
+                    <li class="d-flex justify-content-between">
+                      <span>{{ product }}</span>
+                      <span class="text-muted">{{ amount }}</span>
+                    </li>
+                {% if forloop.last %}
+                  </ul>
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+      {% if sorted_products %}
+        <div class="card">
+          <div class="card-header">
+            <h4 class="card-title">Total de productos vendidos</h4>
+          </div>
+          <div class="card-body">
+            <p class="h2 mb-0">{{ total_products_sold }}</p>
+          </div>
+        </div>
+      {% endif %}
+      {% if success_rate_count %}
+        <div class="card">
+          <div class="card-header">
+            <h4 class="card-title">Promedio de productos por suscriptor</h4>
+          </div>
+          <div class="card-body">
+            <p class="h2 mb-1">{{ avg_products_per_success|floatformat:2 }} productos</p>
+            <p class="h6 text-muted">sobre {{ success_rate_count }} suscriptores con éxito</p>
           </div>
         </div>
       {% endif %}

--- a/support/views/all_views.py
+++ b/support/views/all_views.py
@@ -2439,8 +2439,14 @@ class CampaignStatisticsDetailView(BreadcrumbsMixin, UserPassesTestMixin, Filter
         if context['seller']:
             sales_records = sales_records.filter(seller=context['seller'])
 
-        for product in Product.objects.filter(offerable=True, type="S"):
-            subs_dict[product.name] = sales_records.filter(products=product).count()
+        product_counts = (
+            sales_records.filter(products__offerable=True, products__type="S")
+            .values("products__name")
+            .annotate(total=Count("products"))
+        )
+        counts_by_name = {row["products__name"]: row["total"] for row in product_counts}
+        for product in Product.objects.filter(offerable=True, type="S").values_list("name", flat=True):
+            subs_dict[product] = counts_by_name.get(product, 0)
 
         try:
             most_sold = max(subs_dict, key=subs_dict.get)
@@ -2451,6 +2457,21 @@ class CampaignStatisticsDetailView(BreadcrumbsMixin, UserPassesTestMixin, Filter
         context['subs_dict'] = subs_dict
         context['most_sold'] = most_sold
         context['most_sold_count'] = most_sold_count
+
+        # Sorted ranking (descending), exclude zero-count products
+        sorted_products = sorted(
+            [(name, count) for name, count in subs_dict.items() if count > 0],
+            key=lambda x: x[1],
+            reverse=True,
+        )
+        context['sorted_products'] = sorted_products
+
+        # Avg products per successful contact (S2 resolutions)
+        total_products_sold = sum(count for _, count in sorted_products)
+        context['total_products_sold'] = total_products_sold
+        context['avg_products_per_success'] = (
+            total_products_sold / success_rate_count if success_rate_count else 0
+        )
 
         return context
 


### PR DESCRIPTION
## Resumen

- Productos vendidos en estadísticas de campaña ahora se muestran ordenados de mayor a menor, sin filas con cero ventas
- Ranking con podio visual (trofeo/medalla) para los primeros 3 productos en la columna lateral
- Gráfico de dona (Chart.js, ya bundleado en AdminLTE) en la tarjeta "Conversión de la base"
- Nuevas tarjetas: total de productos vendidos y promedio de productos por suscriptor con éxito
- Fix N+1: el conteo por producto pasó de N queries individuales a una sola query con GROUP BY

## Plan de prueba

- [ ] Navegar a `/support/campaign_statistics/<id>/` con una campaña que tenga SalesRecords
- [ ] Verificar que la tabla de productos está ordenada de mayor a menor y no muestra filas con 0
- [ ] Verificar que el podio del ranking muestra los colores correctos (dorado, plateado, bronce)
- [ ] Verificar que el gráfico de dona aparece junto al texto de conversión
- [ ] Aplicar filtro por seller y confirmar que las métricas se recalculan
- [ ] Verificar con campaña sin ventas: tarjetas de ranking y promedio no aparecen