### PR TITLE
t1145: fix block title en new_subscription.html para modo edición

### DIFF
--- a/support/templates/new_subscription.html
+++ b/support/templates/new_subscription.html
@@ -1,7 +1,7 @@
 {% extends "adminlte/base.html" %}
 {% load i18n static core_tags %}
 {% block title %}
-  {% trans "New subscription" %}
+  {% if edit_subscription %}{% trans "Edit subscription" %}{% else %}{% trans "New subscription" %}{% endif %}
 {% endblock %}
 
 {% block extra_head %}


### PR DESCRIPTION
El block title siempre mostraba "New subscription" incluso al editar, a diferencia del block no_heading que ya tenía la condición correcta.