### PR TITLE
t1156: infraestructura de reporte de errores (logging + soporte Sentry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v0.5.1
 
+## 2026-06-16 — t1156 Infraestructura de reporte de errores: logging y soporte de Sentry
+
+- Se agregó configuración de logging que mantiene el comportamiento por defecto de Django: los errores no atrapados se mandan por email a los `ADMINS` y todo se escribe en la salida estándar para que el log de uWSGI lo capture. No se crean archivos de log en disco
+- Se incorporó `sentry-sdk` como dependencia y se documentó en el `local_settings_sample.py` cómo inicializar Sentry (solo en producción) para que los errores del CRM lleguen al panel de Sentry
+- Se documentaron las nuevas variables de configuración: `ADMINS`/`MANAGERS`, las de Sentry y la lista de destinatarios de errores de alta de suscripción por MercadoPago (la lógica que las usa vive en utopia-crm-ladiaria)
+- Deployment: requiere instalar la nueva dependencia (`pip install -r requirements.txt`); no se requieren migraciones. Sentry y los destinatarios se configuran en `local_settings.py` de cada ambiente
+- **Author:** Tanya Tree + Claude Opus 4.8
+
 ## 2026-06-15 — t1154 Reasignación masiva de estado de incidencias
 
 - Desde el listado de incidencias ahora se puede cambiar el estado de varias incidencias a la vez: se seleccionan con casillas por fila y una casilla que marca todas las visibles de la página

--- a/docs/en/devnotes/2026-06-16-t1156-error-reporting-infrastructure.md
+++ b/docs/en/devnotes/2026-06-16-t1156-error-reporting-infrastructure.md
@@ -1,0 +1,91 @@
+# Error Reporting Infrastructure: Logging and Sentry Support
+
+- **Date:** 2026-06-16
+- **Author:** Tanya Tree + Claude Opus 4.8
+- **Ticket:** t1156
+- **Type:** Enhancement
+- **Component:** Settings, Logging, Error Reporting
+- **Impact:** Observability, Operability
+
+## 🎯 Summary
+
+When a MercadoPago subscription failed from the web, the real cause of the exception was lost in production (`DEBUG=False`), forcing the team to guess what went wrong. This ticket builds the base-app infrastructure to stop flying blind: a Django `LOGGING` configuration that preserves Django's default behaviour (email uncaught errors to `ADMINS`, plus stderr output captured by uWSGI), the `sentry-sdk` dependency, and documentation for initializing Sentry in production only. The MercadoPago-specific capture logic lives in `utopia-crm-ladiaria`; this base-app change provides the plumbing those reports rely on (`ADMINS`, the Sentry SDK, and the recipients setting default).
+
+## ✨ Changes
+
+### 1. Logging configuration in base settings
+
+**File:** `settings.py`
+
+A `LOGGING` dict was added that keeps Django's default behaviour and adds explicit console output:
+
+- A `mail_admins` handler (Django's `AdminEmailHandler`) filtered by `require_debug_false`, so uncaught errors email the `ADMINS` only in production.
+- A `console` (stderr) handler attached to the root and `django` loggers, so uWSGI captures everything in its log.
+- No file handlers, by design.
+
+`ADMINS` and `MANAGERS` were also given empty defaults so they can be populated per environment in `local_settings.py`.
+
+### 2. Sentry SDK dependency
+
+**File:** `requirements.txt`
+
+`sentry-sdk` was added to the requirements. The actual initialization is **not** in base settings: it is done in `local_settings.py` so that only the environments that need it (production) enable Sentry.
+
+### 3. Documentation of new settings
+
+**File:** `local_settings_sample.py`
+
+A commented reference block was added documenting:
+
+- `ADMINS` / `MANAGERS`.
+- `SENTRY_ENABLED`, `SENTRY_DSN`, `SENTRY_ENVIRONMENT` and a full `sentry_sdk.init(...)` example guarded by `SENTRY_ENVIRONMENT == "production"`, with a `before_send` hook that filters sensitive MercadoPago / auth keys.
+- `MERCADOPAGO_ERRORS_RECIPIENTS` (already used by debit errors) and the new `MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS`.
+
+The `MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS` default (empty list) was also added to base settings next to the MercadoPago config.
+
+## 📁 Files Modified
+
+- **`settings.py`** — Added `LOGGING`, `ADMINS`/`MANAGERS` defaults, and `MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS` default
+- **`requirements.txt`** — Added `sentry-sdk`
+- **`local_settings_sample.py`** — Documented Sentry init, `ADMINS`, and the MercadoPago error recipients
+
+## 📚 Technical Details
+
+Sentry is initialized in `local_settings.py` rather than base settings on purpose: the base CRM app must stay deployable without a Sentry account, and only production should report. The init reads `SENTRY_ENABLED`, `SENTRY_DSN`, and `SENTRY_ENVIRONMENT`, and only calls `sentry_sdk.init` when the environment is `"production"`. The `before_send` hook strips sensitive keys (`token`, `security_code`, `mp_card_id`, `card_number`, etc.) from the request data before events are sent.
+
+## 🧪 Manual Testing
+
+1. **Uncaught error emails ADMINS in production:**
+   - Set `DEBUG = False` and populate `ADMINS` in `local_settings.py`.
+   - Trigger a 500 error on any view.
+   - **Verify:** an error email is sent to the configured `ADMINS`, and the traceback appears in the uWSGI log.
+
+2. **Edge case — no ADMINS configured:**
+   - Leave `ADMINS = []` (base default).
+   - Trigger a 500 error.
+   - **Verify:** no email is attempted and no exception is raised by the logging handler; the error still appears on stderr / uWSGI log.
+
+3. **Edge case — Sentry disabled in non-production:**
+   - Set `SENTRY_ENVIRONMENT = "test"` (or leave `SENTRY_ENABLED` unset).
+   - Start the app.
+   - **Verify:** `sentry_sdk.init` is not called and the app boots normally.
+
+## 📝 Deployment Notes
+
+- Install the new dependency: `pip install -r requirements.txt` (adds `sentry-sdk`).
+- No database migrations required.
+- Per environment, configure in `local_settings.py`: `ADMINS`, and (production only) the Sentry block plus `MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS`.
+- A dedicated Sentry project/DSN for the CRM should be created; the DSN goes in production `local_settings.py`.
+
+## 🚀 Future Improvements
+
+- Consider a `LOGGING` review to add named loggers for the billing and MercadoPago flows specifically.
+- Optionally wire `release` tracking in Sentry via a `GIT_COMMIT` environment variable, as the CMS does.
+
+---
+
+- **Date:** 2026-06-16
+- **Author:** Tanya Tree + Claude Opus 4.8
+- **Branch:** t1156
+- **Type:** Enhancement
+- **Modules affected:** Settings, Logging, Error Reporting

--- a/docs/es/devnotes/2026-06-16-t1156-infraestructura-reporte-errores.md
+++ b/docs/es/devnotes/2026-06-16-t1156-infraestructura-reporte-errores.md
@@ -1,0 +1,91 @@
+# Infraestructura de Reporte de Errores: Logging y Soporte de Sentry
+
+- **Fecha:** 2026-06-16
+- **Autor:** Tanya Tree + Claude Opus 4.8
+- **Ticket:** t1156
+- **Tipo:** Mejora
+- **Componente:** Settings, Logging, Reporte de Errores
+- **Impacto:** Observabilidad, Operabilidad
+
+## 🎯 Resumen
+
+Cuando una suscripción por MercadoPago fallaba desde la web, la causa real de la excepción se perdía en producción (`DEBUG=False`), obligando al equipo a adivinar qué había salido mal. Este ticket construye la infraestructura en la app base para dejar de andar a ciegas: una configuración de `LOGGING` de Django que conserva el comportamiento por defecto (mail de errores no atrapados a los `ADMINS`, más salida a stderr capturada por uWSGI), la dependencia `sentry-sdk`, y la documentación para inicializar Sentry solo en producción. La lógica específica de captura de MercadoPago vive en `utopia-crm-ladiaria`; este cambio en la app base provee la plomería de la que dependen esos reportes (`ADMINS`, el SDK de Sentry y el default de la setting de destinatarios).
+
+## ✨ Cambios
+
+### 1. Configuración de logging en settings base
+
+**Archivo:** `settings.py`
+
+Se agregó un diccionario `LOGGING` que mantiene el comportamiento por defecto de Django y agrega salida explícita a consola:
+
+- Un handler `mail_admins` (el `AdminEmailHandler` de Django) filtrado por `require_debug_false`, de modo que los errores no atrapados envíen mail a los `ADMINS` solo en producción.
+- Un handler `console` (stderr) asociado al logger raíz y a `django`, para que uWSGI capture todo en su log.
+- Sin handlers de archivo, por decisión de diseño.
+
+A `ADMINS` y `MANAGERS` también se les dio un default vacío para poder poblarlos por ambiente en `local_settings.py`.
+
+### 2. Dependencia del SDK de Sentry
+
+**Archivo:** `requirements.txt`
+
+Se agregó `sentry-sdk` a los requirements. La inicialización en sí **no** está en settings base: se hace en `local_settings.py` para que solo los ambientes que lo necesitan (producción) activen Sentry.
+
+### 3. Documentación de las nuevas settings
+
+**Archivo:** `local_settings_sample.py`
+
+Se agregó un bloque de referencia comentado que documenta:
+
+- `ADMINS` / `MANAGERS`.
+- `SENTRY_ENABLED`, `SENTRY_DSN`, `SENTRY_ENVIRONMENT` y un ejemplo completo de `sentry_sdk.init(...)` condicionado a `SENTRY_ENVIRONMENT == "production"`, con un hook `before_send` que filtra claves sensibles de MercadoPago / autenticación.
+- `MERCADOPAGO_ERRORS_RECIPIENTS` (ya usada por los errores de débito) y la nueva `MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS`.
+
+El default de `MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS` (lista vacía) también se agregó a settings base junto a la configuración de MercadoPago.
+
+## 📁 Archivos Modificados
+
+- **`settings.py`** — Se agregó `LOGGING`, los defaults de `ADMINS`/`MANAGERS` y el default de `MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS`
+- **`requirements.txt`** — Se agregó `sentry-sdk`
+- **`local_settings_sample.py`** — Se documentó la inicialización de Sentry, `ADMINS` y los destinatarios de errores de MercadoPago
+
+## 📚 Detalles Técnicos
+
+Sentry se inicializa en `local_settings.py` en lugar de en settings base de forma intencional: la app base del CRM debe poder desplegarse sin una cuenta de Sentry, y solo producción debe reportar. La inicialización lee `SENTRY_ENABLED`, `SENTRY_DSN` y `SENTRY_ENVIRONMENT`, y solo llama a `sentry_sdk.init` cuando el ambiente es `"production"`. El hook `before_send` elimina claves sensibles (`token`, `security_code`, `mp_card_id`, `card_number`, etc.) de los datos del request antes de enviar los eventos.
+
+## 🧪 Pruebas Manuales
+
+1. **Error no atrapado envía mail a ADMINS en producción:**
+   - Poner `DEBUG = False` y poblar `ADMINS` en `local_settings.py`.
+   - Disparar un error 500 en cualquier vista.
+   - **Verificar:** se envía un mail de error a los `ADMINS` configurados, y el traceback aparece en el log de uWSGI.
+
+2. **Caso borde — sin ADMINS configurados:**
+   - Dejar `ADMINS = []` (default base).
+   - Disparar un error 500.
+   - **Verificar:** no se intenta enviar mail ni el handler de logging levanta excepción; el error igual aparece en stderr / log de uWSGI.
+
+3. **Caso borde — Sentry deshabilitado fuera de producción:**
+   - Poner `SENTRY_ENVIRONMENT = "test"` (o dejar `SENTRY_ENABLED` sin definir).
+   - Arrancar la app.
+   - **Verificar:** `sentry_sdk.init` no se llama y la app arranca normalmente.
+
+## 📝 Notas de Despliegue
+
+- Instalar la nueva dependencia: `pip install -r requirements.txt` (agrega `sentry-sdk`).
+- No se requieren migraciones de base de datos.
+- Por ambiente, configurar en `local_settings.py`: `ADMINS`, y (solo producción) el bloque de Sentry más `MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS`.
+- Se debe crear un proyecto/DSN de Sentry dedicado para el CRM; el DSN va en el `local_settings.py` de producción.
+
+## 🚀 Mejoras Futuras
+
+- Considerar una revisión de `LOGGING` para agregar loggers con nombre específicos para los flujos de facturación y MercadoPago.
+- Opcionalmente, cablear el seguimiento de `release` en Sentry mediante una variable de entorno `GIT_COMMIT`, como hace el CMS.
+
+---
+
+- **Fecha:** 2026-06-16
+- **Autor:** Tanya Tree + Claude Opus 4.8
+- **Branch:** t1156
+- **Tipo de cambio:** Mejora
+- **Módulos afectados:** Settings, Logging, Reporte de Errores

--- a/local_settings_sample.py
+++ b/local_settings_sample.py
@@ -86,3 +86,50 @@ MERCADOPAGO_ENABLED = False  # Override to True to enable Mercado Pago
 # MERCADOPAGO_ACCESS_TOKEN = ""  # Override to your Mercado Pago access token in local_settings.py
 # MERCADOPAGO_API_MAX_ATTEMPTS = 10  # Override to the maximum number of attempts to get a successful payment
 # MERCADOPAGO_FORCE_FAIL_PAYMENT = False  # Override to True to make the payment fail
+
+# Recipients for MercadoPago debit errors (already used by mercadopago_debit)
+# MERCADOPAGO_ERRORS_RECIPIENTS = ["comercial@example.com"]
+# Recipients for MercadoPago new-subscription errors (t1156): full exception + traceback + MP data
+# MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS = ["soporte@example.com"]
+
+# =============================================================================
+# Error reporting: ADMINS + Sentry
+# =============================================================================
+# ADMINS receive emails on uncaught server errors (Django default behaviour). Each entry is
+# a (name, email) tuple. MANAGERS defaults to ADMINS in settings.py.
+# ADMINS = [("Nami", "tu-email@example.com")]
+
+# Sentry error tracking. The SDK is initialized here (not in the base settings) so only the
+# environments that need it (production) enable it. Only production should report, per t1156.
+# SENTRY_ENABLED = True
+# SENTRY_DSN = "https://YOUR_KEY@YOUR_SENTRY_INSTANCE.ingest.sentry.io/YOUR_PROJECT_ID"
+# SENTRY_ENVIRONMENT = "production"  # only production sends data to Sentry
+#
+# if locals().get("SENTRY_ENABLED") and locals().get("SENTRY_DSN") and SENTRY_ENVIRONMENT == "production":
+#     import sentry_sdk
+#     from sentry_sdk.integrations.django import DjangoIntegration
+#
+#     def before_send(event, hint):
+#         """Filter sensitive MercadoPago / auth data before sending to Sentry."""
+#         request = event.get("request", {})
+#         data = request.get("data")
+#         if isinstance(data, dict):
+#             sensitive_keys = [
+#                 "password", "token", "secret", "api_key", "security_code",
+#                 "mp_card_id", "card_number", "credit_card",
+#             ]
+#             for key in sensitive_keys:
+#                 if key in data:
+#                     data[key] = "[Filtered]"
+#         return event
+#
+#     sentry_sdk.init(
+#         dsn=SENTRY_DSN,
+#         integrations=[DjangoIntegration()],
+#         before_send=before_send,
+#         environment=SENTRY_ENVIRONMENT,
+#         traces_sample_rate=0.0,
+#         # CRM has no end-user web traffic; keep PII off by default.
+#         send_default_pii=False,
+#     )
+# =============================================================================

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ PyPDF2
 python-dateutil
 reportlab
 requests
+sentry-sdk
 setuptools
 tqdm
 unidecode

--- a/settings.py
+++ b/settings.py
@@ -244,6 +244,9 @@ ALLOW_QUEUE_SUBSCRIPTIONS = False
 # MercadoPago integration (override this to True in your local_settings.py to enable)
 MERCADOPAGO_ENABLED = False
 
+# Recipients for MercadoPago new-subscription error reports (t1156). Set in local_settings.py.
+MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS = []
+
 # phonenumbers default region
 PHONENUMBER_DEFAULT_REGION = "UY"
 
@@ -255,6 +258,53 @@ WEB_CREATE_USER_ENABLED = None
 WEB_CREATE_USER_POST_WHITELIST = []
 
 GEOREF_SERVICES = False
+
+# Error reporting recipients. ADMINS receive uncaught-exception emails (Django default
+# behaviour via the mail_admins logging handler). Populate these in local_settings.py.
+ADMINS = []
+MANAGERS = ADMINS
+
+# Logging: keep Django's default behaviour (mail uncaught exceptions to ADMINS when not in
+# DEBUG) and additionally send everything to stderr/console so uWSGI captures it in its log.
+# No file handlers on purpose.
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
+    },
+    "formatters": {
+        "verbose": {"format": "[%(asctime)s] %(levelname)s %(name)s: %(message)s"},
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+        "mail_admins": {
+            "level": "ERROR",
+            "filters": ["require_debug_false"],
+            "class": "django.utils.log.AdminEmailHandler",
+            "include_html": True,
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "INFO",
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console", "mail_admins"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "django.request": {
+            "handlers": ["console", "mail_admins"],
+            "level": "ERROR",
+            "propagate": False,
+        },
+    },
+}
 
 # Import local settings if they exist
 # TODO: - improve hardcoded load of community settings (which are this community settings?)


### PR DESCRIPTION
- LOGGING explícito que conserva el comportamiento por defecto de Django (mail a ADMINS en 500) y agrega salida a stderr para uWSGI; sin archivos
- sentry-sdk como dependencia; init documentado en local_settings_sample (solo producción) para que los errores del CRM lleguen a Sentry
- defaults de ADMINS/MANAGERS y MERCADOPAGO_SUBSCRIPTION_ERRORS_RECIPIENTS
- changelog + devnotes (EN/ES)