### PR TITLE
Add CSV export of contact campaign status across all campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v0.5.1
 
+## 2026-06-19 — feature/export-all-campaigns-status Exportación CSV de estado de contactos en todas las campañas
+
+- Se agregó una nueva herramienta en el menú de Gestión de Campañas para descargar por CSV el estado de los contactos (ContactCampaignStatus) de todas las campañas a la vez, con los mismos filtros que la vista de estadísticas por campaña. Cada fila es un estado de contacto, así que un mismo contacto puede aparecer varias veces si pertenece a más de una campaña
+- Por defecto la vista no devuelve nada: hay que elegir una "fecha de asignado (desde)" para que filtre y exporte, evitando descargar todo el histórico. El resto de los filtros (campaña, vendedor, estado) son opcionales y si no se elige campaña se incluyen todas
+- Se corrigió el cálculo de "Veces contactado", que venía mostrando 0 casi siempre porque leía un campo del modelo que nunca se persiste. Ahora se calcula contando las llamadas completadas registradas para ese contacto en esa campaña, tanto en la vista nueva como en la vista de estadísticas por campaña existente
+- Deployment: no se requieren migraciones
+- **Author:** Tanya Tree + Claude Opus 4.8
+
 ## 2026-06-16 — t1156 Infraestructura de reporte de errores: logging y soporte de Sentry
 
 - Se agregó configuración de logging que mantiene el comportamiento por defecto de Django: los errores no atrapados se mandan por email a los `ADMINS` y todo se escribe en la salida estándar para que el log de uWSGI lo capture. No se crean archivos de log en disco

--- a/docs/en/devnotes/2026-06-19-export-all-campaigns-status-csv.md
+++ b/docs/en/devnotes/2026-06-19-export-all-campaigns-status-csv.md
@@ -1,0 +1,154 @@
+# Feature: Export Contact Campaign Status Across All Campaigns to CSV
+
+- **Date:** 2026-06-19
+- **Author:** Tanya Tree + Claude Opus 4.8
+- **Ticket:** feature/export-all-campaigns-status
+- **Type:** Feature (+ Bug Fix)
+- **Component:** Support — Campaign Management, Core Models (ContactCampaignStatus, Activity)
+- **Impact:** Campaign Reporting, Data Export, Data Integrity
+
+## 🎯 Summary
+
+The existing per-campaign statistics view (`/support/campaign_statistics/<pk>/`) can export the `ContactCampaignStatus` records of a single campaign, but there was no way to export them across **all** campaigns at once. This change adds a new view, `AllCampaignsStatusExportView`, that streams a CSV of contact campaign statuses spanning every campaign, using the same filters as the per-campaign view. Because that dataset would be enormous, the view returns nothing by default: a `date_assigned` (from) filter is required before any data is shown or exported. While building it we confirmed a long-standing bug the user suspected: the "Times contacted" column was almost always `0` because it read the persisted `ContactCampaignStatus.times_contacted` field, which is never incremented anywhere in the code. It is now computed on the fly by counting completed calls for that exact contact and campaign — both in the new view and in the existing per-campaign export.
+
+## ✨ Changes
+
+### 1. New global export view
+
+**File:** `support/views/all_views.py`
+
+`AllCampaignsStatusExportView` is a `FilterView` over `ContactCampaignStatus` (not scoped to one campaign). It mirrors the per-campaign view's permissions (`Managers` group or superuser, `staff_member_required`). Nothing is returned until a date is selected:
+
+```python
+def has_date_filter(self):
+    return bool(self.request.GET.get("date_assigned_min"))
+
+def get_queryset(self):
+    if not self.has_date_filter():
+        return ContactCampaignStatus.objects.none()
+    return ContactCampaignStatus.objects.all()
+```
+
+The page shows a filter form plus a paginated preview; `?export=csv` triggers a `StreamingHttpResponse` (UTF-8 BOM for Excel, `io.StringIO` buffer flushed per row, `iterator(chunk_size=1000)`), matching the seller-attendance export pattern already in the codebase.
+
+### 2. Correct "Times contacted" calculation (correlated per campaign)
+
+**File:** `support/views/all_views.py`
+
+Because the global query spans many campaigns, the completed-call count must correlate the `Activity.campaign` with each row's `ContactCampaignStatus.campaign`. A correlated `Subquery` is used (not a `Count` with `F('campaign')`, which is unreliable across a multi-campaign `GROUP BY`):
+
+```python
+times_contacted_sq = (
+    Activity.objects.filter(
+        contact=OuterRef("contact"),
+        campaign=OuterRef("campaign"),
+        activity_type="C",
+        status="C",
+    )
+    .order_by()
+    .values("contact")
+    .annotate(c=Count("id"))
+    .values("c")
+)
+filtered_qs = filtered_qs.annotate(
+    times_contacted_real=Coalesce(Subquery(times_contacted_sq, output_field=IntegerField()), 0),
+    activity_count=Coalesce(Subquery(activity_count_sq, output_field=IntegerField()), 0),
+)
+```
+
+`activity_count` uses the same correlation (without the type/status filter) so the count belongs to that specific contact-campaign pair and not to another campaign of the same contact. Products sold are mapped per `(contact_id, campaign_id)` from `SalesRecord.products`, built once before streaming and bounded by the filtered contacts/campaigns.
+
+### 3. Fix the same bug in the existing per-campaign export
+
+**File:** `support/views/all_views.py`
+
+`CampaignStatisticsDetailView.export_csv` exported the raw `ccs.times_contacted` field (always `0`). Since that view is single-campaign, a plain `Count` with a constant campaign filter is enough (no Subquery needed):
+
+```python
+times_contacted_real=Count(
+    "contact__activity",
+    filter=Q(
+        contact__activity__campaign=self.campaign,
+        contact__activity__activity_type="C",
+        contact__activity__status="C",
+    ),
+)
+```
+
+The CSV row now uses `ccs.times_contacted_real`. The model field is left untouched (no persistence logic added); the on-the-fly count matches what the seller console already computes.
+
+### 4. New filter, URL, menu card, and sidebar item
+
+**Files:** `support/filters.py`, `support/urls.py`, `support/templates/campaign_management_menu.html`, `templates/components/sidebar_items/_campaign_management.html`
+
+`AllCampaignsContactStatusFilter` reuses the same fields as `ContactCampaignStatusFilter` (seller, status, `date_assigned_min/max`, `last_action_date_min/max`) plus an optional `campaign` filter to narrow a subset. The "empty by default" behaviour is enforced in the view, not the filter, so the filter stays reusable. A new URL (`all_campaigns_status_export`), a card in the "Tracking and reports" section of the campaign management menu, and a sidebar item were added.
+
+### 5. Template with usage hint
+
+**File:** `support/templates/all_campaigns_status_export.html` (new)
+
+The page clarifies that **only** the assigned-date is required and that the other filters are optional — leaving the campaign empty includes every campaign — so operators do not mistake the non-required fields for required ones.
+
+## 📁 Files Modified
+
+- **`support/views/all_views.py`** — Added `AllCampaignsStatusExportView`; added imports (`io`, `Subquery`, `IntegerField`, `Coalesce`); fixed `times_contacted` in `CampaignStatisticsDetailView.export_csv`
+- **`support/filters.py`** — Added `AllCampaignsContactStatusFilter`
+- **`support/urls.py`** — Added the `all_campaigns_status_export` route
+- **`support/templates/campaign_management_menu.html`** — Added the "Export all campaigns status" card
+- **`templates/components/sidebar_items/_campaign_management.html`** — Added the sidebar item
+
+## 📁 Files Created
+
+- **`support/templates/all_campaigns_status_export.html`** — Filter form, usage hint, paginated preview, and CSV download button
+
+## 📚 Technical Details
+
+**Why the field was always 0:** `ContactCampaignStatus.times_contacted` is a `SmallIntegerField(default=0)` that is never incremented or saved anywhere in the codebase. The seller console computes the real value on the fly (`contact.activity_set.filter(activity_type="C", status="C", campaign=campaign).count()`) but does not persist it, so any reader of the raw field saw `0`. The fix computes the same value at query time instead of touching the model.
+
+**Why Subquery instead of `F('campaign')` in the global view:** a `Count('contact__activity', filter=Q(... campaign=F('campaign')))` joins `Activity` by contact and can inflate or mis-correlate counts under a multi-campaign `GROUP BY`. A correlated `Subquery` with `OuterRef("campaign")` returns one scalar per row, correctly matched to that row's campaign, without inflating rows.
+
+## 🧪 Manual Testing
+
+1. **Happy path — export with a date:**
+   - Open Campaign Management → "Export all campaigns status".
+   - Select an "assigned date (from)" within a period that has data and click "Download CSV".
+   - **Verify:** A CSV downloads with one row per contact campaign status across all campaigns; the header is translated and the "Times contacted" column shows real counts (not all zeros).
+
+2. **Times contacted matches the seller console:**
+   - Pick a contact with several completed calls in a campaign.
+   - **Verify:** The CSV's "Times contacted" for that contact-campaign equals the count shown by the seller console (e.g. 6 calls → 6).
+
+3. **Edge case — no date returns nothing:**
+   - Open the view without selecting a date; also try `?export=csv` with no date.
+   - **Verify:** The preview is empty with a hint to select a date; the CSV contains only the header (0 data rows).
+
+4. **Edge case — campaign left empty includes all campaigns:**
+   - Filter only by date, leaving the campaign select empty.
+   - **Verify:** The export includes statuses from multiple campaigns.
+
+5. **Permissions:**
+   - Access the view as a non-Manager, non-superuser user.
+   - **Verify:** Access is denied (403/redirect).
+
+## 📝 Deployment Notes
+
+- No database migrations required.
+- No configuration changes required.
+- Historical `times_contacted` values are not backfilled; the column is computed at export time, so no data migration is needed.
+
+## 🎓 Design Decisions
+
+The "empty by default" rule is enforced in the view (`get_queryset` returns `.none()` without a date) rather than in the filter, so `AllCampaignsContactStatusFilter` stays a plain, reusable, testable FilterSet. The persisted `times_contacted` field is intentionally left in place and unused for reads rather than removed or backfilled, keeping the change low-risk and consistent with the seller console's existing on-the-fly calculation.
+
+## 🚀 Future Improvements
+
+- Consider persisting `times_contacted` (or removing the dead field) so it does not mislead future readers.
+- Add an index on `Activity(contact, campaign)` if the correlated subqueries become a bottleneck on very large date ranges.
+
+---
+
+**Date:** 2026-06-19
+**Author:** Tanya Tree + Claude Opus 4.8
+**Branch:** feature/export-all-campaigns-status
+**Type:** Feature (+ Bug Fix)
+**Modules affected:** Support, Core (ContactCampaignStatus, Activity)

--- a/docs/es/devnotes/2026-06-19-exportacion-estado-todas-las-campanas-csv.md
+++ b/docs/es/devnotes/2026-06-19-exportacion-estado-todas-las-campanas-csv.md
@@ -1,0 +1,154 @@
+# Funcionalidad: Exportar a CSV el estado de contactos de todas las campañas
+
+- **Fecha:** 2026-06-19
+- **Autor:** Tanya Tree + Claude Opus 4.8
+- **Ticket:** feature/export-all-campaigns-status
+- **Tipo:** Funcionalidad (+ Corrección)
+- **Componente:** Support — Gestión de Campañas, Modelos Core (ContactCampaignStatus, Activity)
+- **Impacto:** Reportes de Campaña, Exportación de Datos, Integridad de Datos
+
+## 🎯 Resumen
+
+La vista de estadísticas por campaña existente (`/support/campaign_statistics/<pk>/`) permite exportar los registros de `ContactCampaignStatus` de una sola campaña, pero no había forma de exportarlos de **todas** las campañas a la vez. Este cambio agrega una nueva vista, `AllCampaignsStatusExportView`, que genera por streaming un CSV con el estado de los contactos a través de todas las campañas, usando los mismos filtros que la vista por campaña. Como ese conjunto de datos sería enorme, la vista no devuelve nada por defecto: requiere un filtro de fecha de asignado (desde) antes de mostrar o exportar datos. Al construirla confirmamos un bug que la usuaria sospechaba: la columna "Veces contactado" mostraba casi siempre `0` porque leía el campo persistido `ContactCampaignStatus.times_contacted`, que nunca se incrementa en ninguna parte del código. Ahora se calcula al vuelo contando las llamadas completadas de ese contacto en esa campaña, tanto en la vista nueva como en la exportación por campaña existente.
+
+## ✨ Cambios
+
+### 1. Nueva vista de exportación global
+
+**Archivo:** `support/views/all_views.py`
+
+`AllCampaignsStatusExportView` es un `FilterView` sobre `ContactCampaignStatus` (no acotado a una campaña). Replica los permisos de la vista por campaña (grupo `Managers` o superuser, `staff_member_required`). No devuelve nada hasta que se selecciona una fecha:
+
+```python
+def has_date_filter(self):
+    return bool(self.request.GET.get("date_assigned_min"))
+
+def get_queryset(self):
+    if not self.has_date_filter():
+        return ContactCampaignStatus.objects.none()
+    return ContactCampaignStatus.objects.all()
+```
+
+La página muestra un formulario de filtros y una vista previa paginada; `?export=csv` dispara un `StreamingHttpResponse` (BOM UTF-8 para Excel, buffer `io.StringIO` vaciado por fila, `iterator(chunk_size=1000)`), siguiendo el patrón de exportación de asistencia de vendedores que ya existe en el código.
+
+### 2. Cálculo correcto de "Veces contactado" (correlacionado por campaña)
+
+**Archivo:** `support/views/all_views.py`
+
+Como la consulta global abarca muchas campañas, el conteo de llamadas completadas debe correlacionar el `Activity.campaign` con la `ContactCampaignStatus.campaign` de cada fila. Se usa un `Subquery` correlacionado (no un `Count` con `F('campaign')`, poco confiable bajo un `GROUP BY` multi-campaña):
+
+```python
+times_contacted_sq = (
+    Activity.objects.filter(
+        contact=OuterRef("contact"),
+        campaign=OuterRef("campaign"),
+        activity_type="C",
+        status="C",
+    )
+    .order_by()
+    .values("contact")
+    .annotate(c=Count("id"))
+    .values("c")
+)
+filtered_qs = filtered_qs.annotate(
+    times_contacted_real=Coalesce(Subquery(times_contacted_sq, output_field=IntegerField()), 0),
+    activity_count=Coalesce(Subquery(activity_count_sq, output_field=IntegerField()), 0),
+)
+```
+
+`activity_count` usa la misma correlación (sin el filtro de tipo/estado) para que el conteo corresponda a ese par contacto-campaña y no a otra campaña del mismo contacto. Los productos vendidos se mapean por `(contact_id, campaign_id)` desde `SalesRecord.products`, construidos una sola vez antes del streaming y acotados por los contactos/campañas filtrados.
+
+### 3. Corrección del mismo bug en la exportación por campaña existente
+
+**Archivo:** `support/views/all_views.py`
+
+`CampaignStatisticsDetailView.export_csv` exportaba el campo `ccs.times_contacted` crudo (siempre `0`). Como esa vista es de una sola campaña, alcanza con un `Count` simple con filtro de campaña constante (sin Subquery):
+
+```python
+times_contacted_real=Count(
+    "contact__activity",
+    filter=Q(
+        contact__activity__campaign=self.campaign,
+        contact__activity__activity_type="C",
+        contact__activity__status="C",
+    ),
+)
+```
+
+La fila del CSV ahora usa `ccs.times_contacted_real`. No se toca el campo del modelo (no se agrega lógica de persistencia); el conteo al vuelo coincide con lo que ya calcula la consola de vendedores.
+
+### 4. Nuevo filtro, URL, card del menú e ítem del sidebar
+
+**Archivos:** `support/filters.py`, `support/urls.py`, `support/templates/campaign_management_menu.html`, `templates/components/sidebar_items/_campaign_management.html`
+
+`AllCampaignsContactStatusFilter` reutiliza los mismos campos que `ContactCampaignStatusFilter` (vendedor, estado, `date_assigned_min/max`, `last_action_date_min/max`) más un filtro opcional `campaign` para acotar a un subconjunto. El comportamiento de "vacío por defecto" se aplica en la vista, no en el filtro, para que el filtro siga siendo reutilizable. Se agregaron una nueva URL (`all_campaigns_status_export`), una card en la sección "Tracking and reports" del menú de gestión de campañas y un ítem en el sidebar.
+
+### 5. Template con nota de uso
+
+**Archivo:** `support/templates/all_campaigns_status_export.html` (nuevo)
+
+La página aclara que **solo** la fecha de asignado es obligatoria y que los demás filtros son opcionales — si se deja la campaña vacía se incluyen todas — para que los operadores no confundan los campos no obligatorios con obligatorios.
+
+## 📁 Archivos Modificados
+
+- **`support/views/all_views.py`** — Se agregó `AllCampaignsStatusExportView`; se agregaron imports (`io`, `Subquery`, `IntegerField`, `Coalesce`); se corrigió `times_contacted` en `CampaignStatisticsDetailView.export_csv`
+- **`support/filters.py`** — Se agregó `AllCampaignsContactStatusFilter`
+- **`support/urls.py`** — Se agregó la ruta `all_campaigns_status_export`
+- **`support/templates/campaign_management_menu.html`** — Se agregó la card "Export all campaigns status"
+- **`templates/components/sidebar_items/_campaign_management.html`** — Se agregó el ítem del sidebar
+
+## 📁 Archivos Creados
+
+- **`support/templates/all_campaigns_status_export.html`** — Formulario de filtros, nota de uso, vista previa paginada y botón de descarga del CSV
+
+## 📚 Detalles Técnicos
+
+**Por qué el campo daba siempre 0:** `ContactCampaignStatus.times_contacted` es un `SmallIntegerField(default=0)` que nunca se incrementa ni se guarda en ninguna parte del código. La consola de vendedores calcula el valor real al vuelo (`contact.activity_set.filter(activity_type="C", status="C", campaign=campaign).count()`) pero no lo persiste, así que cualquier lectura del campo crudo veía `0`. La corrección calcula el mismo valor en tiempo de consulta en lugar de tocar el modelo.
+
+**Por qué Subquery y no `F('campaign')` en la vista global:** un `Count('contact__activity', filter=Q(... campaign=F('campaign')))` une `Activity` por contacto y puede inflar o correlacionar mal los conteos bajo un `GROUP BY` multi-campaña. Un `Subquery` correlacionado con `OuterRef("campaign")` devuelve un escalar por fila, correctamente asociado a la campaña de esa fila, sin inflar filas.
+
+## 🧪 Pruebas Manuales
+
+1. **Caso exitoso — exportar con una fecha:**
+   - Abrir Gestión de Campañas → "Export all campaigns status".
+   - Seleccionar una "fecha de asignado (desde)" dentro de un período con datos y hacer clic en "Descargar CSV".
+   - **Verificar:** Se descarga un CSV con una fila por estado de contacto a través de todas las campañas; el encabezado está traducido y la columna "Veces contactado" muestra conteos reales (no todos ceros).
+
+2. **Veces contactado coincide con la consola de vendedores:**
+   - Elegir un contacto con varias llamadas completadas en una campaña.
+   - **Verificar:** El "Veces contactado" del CSV para ese par contacto-campaña es igual al conteo que muestra la consola de vendedores (ej. 6 llamadas → 6).
+
+3. **Caso borde — sin fecha no devuelve nada:**
+   - Abrir la vista sin seleccionar fecha; probar también `?export=csv` sin fecha.
+   - **Verificar:** La vista previa está vacía con una nota para seleccionar una fecha; el CSV contiene solo el encabezado (0 filas de datos).
+
+4. **Caso borde — campaña vacía incluye todas las campañas:**
+   - Filtrar solo por fecha, dejando el selector de campaña vacío.
+   - **Verificar:** La exportación incluye estados de varias campañas.
+
+5. **Permisos:**
+   - Acceder a la vista como usuario sin grupo Managers ni superuser.
+   - **Verificar:** Se deniega el acceso (403/redirección).
+
+## 📝 Notas de Despliegue
+
+- No se requieren migraciones de base de datos.
+- No se requieren cambios de configuración.
+- No se rellenan valores históricos de `times_contacted`; la columna se calcula en el momento de la exportación, así que no se necesita migración de datos.
+
+## 🎓 Decisiones de Diseño
+
+La regla de "vacío por defecto" se aplica en la vista (`get_queryset` devuelve `.none()` sin fecha) y no en el filtro, para que `AllCampaignsContactStatusFilter` siga siendo un FilterSet simple, reutilizable y testeable. El campo persistido `times_contacted` se deja en su lugar, sin usar para lecturas, en vez de eliminarlo o rellenarlo, manteniendo el cambio de bajo riesgo y consistente con el cálculo al vuelo que ya hace la consola de vendedores.
+
+## 🚀 Mejoras Futuras
+
+- Considerar persistir `times_contacted` (o eliminar el campo muerto) para que no confunda a futuros lectores.
+- Agregar un índice en `Activity(contact, campaign)` si los subqueries correlacionados se vuelven un cuello de botella en rangos de fecha muy amplios.
+
+---
+
+**Fecha:** 2026-06-19
+**Autor:** Tanya Tree + Claude Opus 4.8
+**Branch:** feature/export-all-campaigns-status
+**Tipo de cambio:** Funcionalidad (+ Corrección)
+**Módulos afectados:** Support, Core (ContactCampaignStatus, Activity)

--- a/support/filters.py
+++ b/support/filters.py
@@ -271,6 +271,41 @@ class ContactCampaignStatusFilter(django_filters.FilterSet):
         fields = ["seller", "status"]
 
 
+class AllCampaignsContactStatusFilter(django_filters.FilterSet):
+    """
+    Same filters as ContactCampaignStatusFilter but across all campaigns, with an optional campaign
+    filter to narrow down a subset. The "empty by default" behaviour (requiring a date) is enforced
+    in the view, not here, so the filter stays reusable.
+    """
+
+    campaign = django_filters.ModelChoiceFilter(queryset=Campaign.objects.all().order_by('-id'))
+    seller = django_filters.ModelChoiceFilter(queryset=Seller.objects.filter(internal=True).order_by('name'))
+    date_assigned_min = django_filters.DateFilter(
+        field_name='date_assigned',
+        lookup_expr='gte',
+        widget=forms.DateInput(attrs={'type': 'date', 'class': 'form-control'}),
+    )
+    date_assigned_max = django_filters.DateFilter(
+        field_name='date_assigned',
+        lookup_expr='lte',
+        widget=forms.DateInput(attrs={'type': 'date', 'class': 'form-control'}),
+    )
+    last_action_date_min = django_filters.DateFilter(
+        field_name='last_action_date',
+        lookup_expr='gte',
+        widget=forms.DateInput(attrs={'type': 'date', 'class': 'form-control'}),
+    )
+    last_action_date_max = django_filters.DateFilter(
+        field_name='last_action_date',
+        lookup_expr='lte',
+        widget=forms.DateInput(attrs={'type': 'date', 'class': 'form-control'}),
+    )
+
+    class Meta:
+        model = ContactCampaignStatus
+        fields = ["campaign", "seller", "status"]
+
+
 class UnsubscribedSubscriptionsByEndDateFilter(django_filters.FilterSet):
     date = django_filters.ChoiceFilter(choices=CREATION_CHOICES, method='filter_by_date')
     date_gte = django_filters.DateFilter(

--- a/support/templates/all_campaigns_status_export.html
+++ b/support/templates/all_campaigns_status_export.html
@@ -1,0 +1,148 @@
+{% extends "adminlte/base.html" %}
+{% load i18n static widget_tweaks url_replace %}
+
+{% block no_heading %}
+  <h1>{% trans "Export all campaigns status" %}</h1>
+{% endblock %}
+
+{% block title %}
+  {% trans "Export all campaigns status" %}
+{% endblock title %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-12">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="card-title">{% trans "Filters" %}</h3>
+        </div>
+        <div class="card-body">
+          <p class="text-muted">
+            {% trans "Download a CSV of contact campaign statuses across all campaigns. A contact may appear more than once because it can belong to several campaigns." %}
+          </p>
+          <p class="text-muted">
+            <i class="fas fa-lightbulb"></i>
+            {% trans "Only the 'assigned date (from)' is required. All other filters (campaign, seller, status) are optional: if you leave the campaign empty, the export includes every campaign." %}
+          </p>
+          {% if not has_date_filter %}
+            <div class="alert alert-info">
+              <i class="fas fa-info-circle"></i>
+              {% trans "Select an 'assigned date (from)' to filter and export. Without a date nothing is returned." %}
+            </div>
+          {% endif %}
+          <form method="get" id="filter-form">
+            <div class="row">
+              <div class="form-group col-md-4">
+                <label>{% trans "Campaign" %}</label>
+                {% render_field filter.form.campaign class="form-control" %}
+              </div>
+              <div class="form-group col-md-4">
+                <label>{% trans "Filter by seller" %}</label>
+                {% render_field filter.form.seller class="form-control" %}
+              </div>
+              <div class="form-group col-md-4">
+                <label>{% trans "Filter by status" %}</label>
+                {% render_field filter.form.status class="form-control" %}
+              </div>
+            </div>
+            <div class="row">
+              <div class="form-group col-md-6">
+                <label>{% trans "Date assigned (from)" %} <span class="text-danger">*</span></label>
+                {% render_field filter.form.date_assigned_min class="form-control" %}
+              </div>
+              <div class="form-group col-md-6">
+                <label>{% trans "Date assigned (to)" %}</label>
+                {% render_field filter.form.date_assigned_max class="form-control" %}
+              </div>
+            </div>
+            <div class="row">
+              <div class="form-group col-md-6">
+                <label>{% trans "Last action date (from)" %}</label>
+                {% render_field filter.form.last_action_date_min class="form-control" %}
+              </div>
+              <div class="form-group col-md-6">
+                <label>{% trans "Last action date (to)" %}</label>
+                {% render_field filter.form.last_action_date_max class="form-control" %}
+              </div>
+            </div>
+            <div class="text-right">
+              <button type="submit" class="btn btn-primary">
+                <i class="fas fa-filter"></i> {% trans "Filter" %}
+              </button>
+              {% if has_date_filter %}
+                <button type="submit" name="export" value="csv" class="btn btn-success">
+                  <i class="fas fa-file-csv"></i> {% trans "Download CSV" %}
+                </button>
+              {% endif %}
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {% if has_date_filter %}
+    <div class="row">
+      <div class="col-12">
+        <div class="card">
+          <div class="card-header">
+            <h3 class="card-title">{% trans "Preview" %} ({{ paginator.count }})</h3>
+          </div>
+          <div class="card-body table-responsive p-0">
+            <table class="table table-hover text-nowrap">
+              <thead>
+                <tr>
+                  <th>{% trans "Contact" %}</th>
+                  <th>{% trans "Campaign" %}</th>
+                  <th>{% trans "Status" %}</th>
+                  <th>{% trans "Seller" %}</th>
+                  <th>{% trans "Date assigned" %}</th>
+                  <th>{% trans "Last action date" %}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for ccs in contact_campaign_statuses %}
+                  <tr>
+                    <td>{{ ccs.contact.get_full_name }}</td>
+                    <td>{{ ccs.campaign.name }}</td>
+                    <td>{{ ccs.get_status }}</td>
+                    <td>{{ ccs.seller.name|default:"" }}</td>
+                    <td>{{ ccs.date_assigned|default:"" }}</td>
+                    <td>{{ ccs.last_action_date|default:"" }}</td>
+                  </tr>
+                {% empty %}
+                  <tr>
+                    <td colspan="6" class="text-center text-muted">{% trans "No records found." %}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% if is_paginated %}
+            <div class="card-footer clearfix">
+              <ul class="pagination pagination-sm m-0 float-right">
+                {% if page_obj.has_previous %}
+                  <li class="page-item">
+                    <a class="page-link" href="?{% url_replace request 'page' page_obj.previous_page_number %}">
+                      <i class="fas fa-angle-left"></i>
+                    </a>
+                  </li>
+                {% endif %}
+                <li class="page-item disabled">
+                  <span class="page-link">{{ page_obj.number }} / {{ paginator.num_pages }}</span>
+                </li>
+                {% if page_obj.has_next %}
+                  <li class="page-item">
+                    <a class="page-link" href="?{% url_replace request 'page' page_obj.next_page_number %}">
+                      <i class="fas fa-angle-right"></i>
+                    </a>
+                  </li>
+                {% endif %}
+              </ul>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/support/templates/campaign_management_menu.html
+++ b/support/templates/campaign_management_menu.html
@@ -239,6 +239,19 @@ $(function() {
                         <div class="col-lg-4 col-6 campaign-card-col">
                             <div class="card">
                                 <div class="card-header">
+                                    <h3 class="card-title">{% trans "Export all campaigns status" %}</h3>
+                                </div>
+                                <div class="card-body">
+                                    <p>{% trans "Download a CSV of contact campaign statuses across all campaigns. Requires a date filter." %}</p>
+                                    <div class="text-right">
+                                        <a href="{% url 'all_campaigns_status_export' %}" class="btn btn-default">{% trans "Go to export" %}</a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-lg-4 col-6 campaign-card-col">
+                            <div class="card">
+                                <div class="card-header">
                                     <h3 class="card-title">{% trans "Sellers performance" %}</h3>
                                 </div>
                                 <div class="card-body">

--- a/support/urls.py
+++ b/support/urls.py
@@ -39,6 +39,7 @@ from support.views import (
     upload_payment_certificate,
     campaign_statistics_list,
     CampaignStatisticsDetailView,
+    AllCampaignsStatusExportView,
     campaign_statistics_per_seller,
     seller_performance_by_time,
     unsubscription_statistics,
@@ -180,6 +181,11 @@ urlpatterns = [
         name="edit_address_complementary_information",
     ),
     path("campaign_statistics/", campaign_statistics_list, name="campaign_statistics_list"),
+    path(
+        "campaign_statistics/export_all/",
+        AllCampaignsStatusExportView.as_view(),
+        name="all_campaigns_status_export",
+    ),
     re_path(
         r"^campaign_statistics/(?P<campaign_id>\d+)/$",
         CampaignStatisticsDetailView.as_view(),

--- a/support/views/all_views.py
+++ b/support/views/all_views.py
@@ -1,5 +1,6 @@
 import calendar
 import csv
+import io
 import json
 from datetime import date, datetime, timedelta
 
@@ -12,7 +13,20 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import PermissionRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.models import User
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.db.models import Count, Exists, Min, OuterRef, Q, Sum, Case, When, Prefetch
+from django.db.models import (
+    Count,
+    Exists,
+    IntegerField,
+    Min,
+    OuterRef,
+    Q,
+    Subquery,
+    Sum,
+    Case,
+    When,
+    Prefetch,
+)
+from django.db.models.functions import Coalesce
 from django.http import (
     HttpResponse,
     HttpResponseNotFound,
@@ -55,6 +69,7 @@ from core.utils import (
 from invoicing.models import Invoice
 from support.choices import ISSUE_ANSWERS, get_issue_categories
 from support.filters import (
+    AllCampaignsContactStatusFilter,
     CampaignFilter,
     ContactCampaignStatusFilter,
     InvoicingIssueFilter,
@@ -2252,12 +2267,23 @@ class CampaignStatisticsDetailView(BreadcrumbsMixin, UserPassesTestMixin, Filter
         filterset = self.filterset_class(self.request.GET, queryset=self.get_queryset())
         filtered_qs = filterset.qs
 
-        # Annotate activity count per contact-campaign
+        # Annotate activity count and real "times contacted" per contact-campaign.
+        # times_contacted_real counts completed calls (activity_type="C", status="C") for this
+        # campaign, mirroring the seller console calculation. The model field
+        # ContactCampaignStatus.times_contacted is never persisted, so we compute it on the fly.
         filtered_qs = filtered_qs.select_related('contact', 'seller', 'last_console_action').annotate(
             activity_count=Count(
                 'contact__activity',
                 filter=Q(contact__activity__campaign=self.campaign),
-            )
+            ),
+            times_contacted_real=Count(
+                'contact__activity',
+                filter=Q(
+                    contact__activity__campaign=self.campaign,
+                    contact__activity__activity_type="C",
+                    contact__activity__status="C",
+                ),
+            ),
         )
 
         # Build a dict of contact_id -> subscription data for this campaign.
@@ -2333,7 +2359,7 @@ class CampaignStatisticsDetailView(BreadcrumbsMixin, UserPassesTestMixin, Filter
                     ccs.date_assigned or "",
                     ccs.last_action_date or "",
                     ccs.date_created or "",
-                    ccs.times_contacted,
+                    ccs.times_contacted_real,
                     ccs.activity_count,
                     ccs.last_console_action.name if ccs.last_console_action else "",
                     sub_data.get("start_date", ""),
@@ -2492,6 +2518,188 @@ class CampaignStatisticsDetailView(BreadcrumbsMixin, UserPassesTestMixin, Filter
 
 # Backward compatibility
 campaign_statistics_detail = CampaignStatisticsDetailView.as_view()
+
+
+class AllCampaignsStatusExportView(BreadcrumbsMixin, UserPassesTestMixin, FilterView):
+    """
+    Export ContactCampaignStatus records across ALL campaigns to CSV, with the same filters as the
+    per-campaign statistics view.
+
+    By default nothing is returned: a date_assigned filter is required, otherwise the dataset would
+    span every campaign in history. Each row is a ContactCampaignStatus; contacts may repeat because
+    a contact can belong to several campaigns.
+    """
+
+    model = ContactCampaignStatus
+    filterset_class = AllCampaignsContactStatusFilter
+    template_name = "all_campaigns_status_export.html"
+    context_object_name = "contact_campaign_statuses"
+    paginate_by = 50
+
+    def breadcrumbs(self):
+        return [
+            {"label": _("Home"), "url": reverse("home")},
+            {"label": _("Campaign Management"), "url": reverse("campaign_management")},
+            {"label": _("Export all campaigns status"), "url": ""},
+        ]
+
+    def test_func(self):
+        """Only users in the Managers group or superusers can access this view."""
+        return self.request.user.groups.filter(name='Managers').exists() or self.request.user.is_superuser
+
+    @method_decorator(staff_member_required)
+    def dispatch(self, *args, **kwargs):
+        return super().dispatch(*args, **kwargs)
+
+    def has_date_filter(self):
+        """A date_assigned_min value is required before any data is shown or exported."""
+        return bool(self.request.GET.get("date_assigned_min"))
+
+    def get_queryset(self):
+        """Return all ContactCampaignStatus, but nothing until a date_assigned filter is set."""
+        if not self.has_date_filter():
+            return ContactCampaignStatus.objects.none()
+        return ContactCampaignStatus.objects.all()
+
+    def get(self, request, *args, **kwargs):
+        if request.GET.get("export") == "csv":
+            return self.export_csv()
+        return super().get(request, *args, **kwargs)
+
+    def export_csv(self):
+        """Stream the filtered ContactCampaignStatus records to CSV."""
+        filterset = self.filterset_class(self.request.GET, queryset=self.get_queryset())
+        filtered_qs = filterset.qs.select_related("contact", "seller", "last_console_action", "campaign")
+
+        # times_contacted_real: completed calls (activity_type="C", status="C") for this exact
+        # contact+campaign, mirroring the seller console. The model field times_contacted is never
+        # persisted, so we compute it on the fly. We use a correlated Subquery (not a Count with
+        # F('campaign')) so the campaign of each row is matched correctly across all campaigns.
+        times_contacted_sq = (
+            Activity.objects.filter(
+                contact=OuterRef("contact"),
+                campaign=OuterRef("campaign"),
+                activity_type="C",
+                status="C",
+            )
+            .order_by()
+            .values("contact")
+            .annotate(c=Count("id"))
+            .values("c")
+        )
+        # activity_count: every activity for this exact contact+campaign (no type/status filter),
+        # so the count belongs to this specific CCS and not to another campaign of the same contact.
+        activity_count_sq = (
+            Activity.objects.filter(
+                contact=OuterRef("contact"),
+                campaign=OuterRef("campaign"),
+            )
+            .order_by()
+            .values("contact")
+            .annotate(c=Count("id"))
+            .values("c")
+        )
+        filtered_qs = filtered_qs.annotate(
+            times_contacted_real=Coalesce(Subquery(times_contacted_sq, output_field=IntegerField()), 0),
+            activity_count=Coalesce(Subquery(activity_count_sq, output_field=IntegerField()), 0),
+        )
+
+        # Map (contact_id, campaign_id) -> {start_date, products} from SalesRecord.products (M2M),
+        # so we only count products actually sold in that campaign action. Built once before
+        # streaming, bounded by the contacts/campaigns of the filtered queryset.
+        pairs = list(filtered_qs.values_list("contact_id", "campaign_id"))
+        sales_records = (
+            SalesRecord.objects.filter(
+                subscription__contact_id__in=[c for c, _campaign in pairs],
+                campaign_id__in=[ca for _contact, ca in pairs],
+            )
+            .select_related("subscription")
+            .prefetch_related("products")
+            .order_by("date_time")
+        )
+        subscription_data = {}
+        for sr in sales_records:
+            key = (sr.subscription.contact_id, sr.campaign_id)
+            sold_products = [p.name for p in sr.products.all()]
+            if key in subscription_data:
+                subscription_data[key]["products_list"].extend(sold_products)
+            else:
+                subscription_data[key] = {
+                    "start_date": sr.subscription.start_date,
+                    "products_list": sold_products,
+                }
+        for data in subscription_data.values():
+            data["products"] = ", ".join(data["products_list"])
+
+        def generate_rows():
+            yield "﻿"  # UTF-8 BOM para Excel
+            buffer = io.StringIO()
+            writer = csv.writer(buffer)
+            writer.writerow(
+                [
+                    str(_("Contact ID")),
+                    str(_("Contact name")),
+                    str(_("Email")),
+                    str(_("Phone")),
+                    str(_("Mobile")),
+                    str(_("Campaign")),
+                    str(_("Status")),
+                    str(_("Campaign resolution")),
+                    str(_("Resolution reason")),
+                    str(_("Seller")),
+                    str(_("Date assigned")),
+                    str(_("Last action date")),
+                    str(_("Date created")),
+                    str(_("Times contacted")),
+                    str(_("Activity count")),
+                    str(_("Last console action")),
+                    str(_("Subscription start date")),
+                    str(_("Products sold")),
+                ]
+            )
+            yield buffer.getvalue()
+            buffer.seek(0)
+            buffer.truncate(0)
+
+            for ccs in filtered_qs.iterator(chunk_size=1000):
+                contact = ccs.contact
+                sub_data = subscription_data.get((ccs.contact_id, ccs.campaign_id), {})
+                writer.writerow(
+                    [
+                        contact.id,
+                        contact.get_full_name(),
+                        contact.email or "",
+                        str(contact.phone) if contact.phone else "",
+                        str(contact.mobile) if contact.mobile else "",
+                        ccs.campaign.name,
+                        ccs.get_status(),
+                        ccs.get_campaign_resolution(),
+                        ccs.get_resolution_reason(),
+                        ccs.seller.name if ccs.seller else "",
+                        ccs.date_assigned or "",
+                        ccs.last_action_date or "",
+                        ccs.date_created or "",
+                        ccs.times_contacted_real,
+                        ccs.activity_count,
+                        ccs.last_console_action.name if ccs.last_console_action else "",
+                        sub_data.get("start_date", ""),
+                        sub_data.get("products", ""),
+                    ]
+                )
+                yield buffer.getvalue()
+                buffer.seek(0)
+                buffer.truncate(0)
+
+        response = StreamingHttpResponse(generate_rows(), content_type="text/csv; charset=utf-8")
+        response["Content-Disposition"] = 'attachment; filename="all_campaigns_status_{}.csv"'.format(
+            date.today().strftime("%Y%m%d")
+        )
+        return response
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["has_date_filter"] = self.has_date_filter()
+        return context
 
 
 @staff_member_required

--- a/templates/components/sidebar_items/_campaign_management.html
+++ b/templates/components/sidebar_items/_campaign_management.html
@@ -5,6 +5,7 @@
 {% url 'assign_to_seller' as assign_to_seller %}
 {% url 'core_campaign_add' as core_campaign_add %}
 {% url 'campaign_statistics_list' as campaign_statistics_list %}
+{% url 'all_campaigns_status_export' as all_campaigns_status_export %}
 {% url 'seller_performance_by_time' as seller_performance_by_time %}
 {% url 'release_seller_contacts' as release_seller_contacts %}
 {% url 'upload_do_not_call_numbers' as upload_do_not_call_numbers %}
@@ -68,6 +69,13 @@
          class="nav-link {% if request.path == campaign_statistics_list %}active{% endif %}">
         <i class="nav-icon fas fa-chart-bar"></i>
         <p>{% trans "Campaign statistics" %}</p>
+      </a>
+    </li>
+    <li class="nav-item">
+      <a href="{{ all_campaigns_status_export }}"
+         class="nav-link {% if request.path == all_campaigns_status_export %}active{% endif %}">
+        <i class="nav-icon fas fa-file-csv"></i>
+        <p>{% trans "Export all campaigns status" %}</p>
       </a>
     </li>
     <li class="nav-item">


### PR DESCRIPTION
New AllCampaignsStatusExportView streams a CSV of ContactCampaignStatus across every campaign, using the same filters as the per-campaign statistics view. The view returns nothing until a date_assigned (from) filter is set, to avoid exporting the whole history.

Also fixes the 'Times contacted' column, which was almost always 0 because it read the never-persisted ContactCampaignStatus.times_contacted field. It is now computed on the fly by counting completed calls for the exact contact and campaign, both in the new view (correlated Subquery) and in the existing per-campaign export.

Adds a filter, URL, menu card and sidebar item, plus EN/ES devnotes and a CHANGELOG entry. No migrations required.