### PR TITLE
docs: changelog + devnotes del desmapeo de newsletters (branch completa)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## v0.5.1
 
+## 2026-06-29 — desmapeo-newsletters (t1158) El CMS pasa a ser la fuente de verdad de las newsletters
+
+- El CRM dejó de mantener su espejo de newsletters como verdad: ahora las lee y edita a demanda contra el CMS. En la ficha de contacto, en el formulario de edición y en la consola de vendedores las newsletters se cargan por AJAX desde el CMS, y los cambios se guardan uno por uno (alta/baja puntual) directo en el CMS, sin pisar el resto
+- Se apagó el envío destructivo de newsletters del CRM al CMS (el que en cada guardado de contacto reemplazaba la lista completa). Queda detrás de una opción de configuración para poder prenderlo/apagarlo
+- Se eliminó el diálogo de "newsletters por defecto" al crear suscripciones: ahora las aplica el CMS al crear la cuenta. Se retiraron además los mapeos de newsletters que ya no se usan
+- El filtro de contactos por newsletter queda temporalmente sin datos nuevos (sigue leyendo el espejo viejo) hasta un proceso futuro de repoblado; el espejo no se borró
+- Deployment: no se requieren migraciones. Hay que desplegar en la misma ventana los cambios del CMS y poner `WEB_UPDATE_USER_NEWSLETTERS_ENABLED = False` en producción (ver el pre-deploy checklist del frente)
+- **Author:** Tanya Tree + Claude Opus 4.8
+
 ## 2026-06-19 — feature/export-all-campaigns-status Exportación CSV de estado de contactos en todas las campañas
 
 - Se agregó una nueva herramienta en el menú de Gestión de Campañas para descargar por CSV el estado de los contactos (ContactCampaignStatus) de todas las campañas a la vez, con los mismos filtros que la vista de estadísticas por campaña. Cada fila es un estado de contacto, así que un mismo contacto puede aparecer varias veces si pertenece a más de una campaña

--- a/docs/en/devnotes/2026-06-29-t1158-newsletters-cms-source-of-truth.md
+++ b/docs/en/devnotes/2026-06-29-t1158-newsletters-cms-source-of-truth.md
@@ -1,0 +1,156 @@
+# Newsletters Unmapping: CMS Becomes the Source of Truth
+
+- **Date:** 2026-06-29
+- **Author:** Tanya Tree + Claude Opus 4.8
+- **Ticket:** t1158 (branch `desmapeo-newsletters`)
+- **Type:** Refactor
+- **Component:** Core, Support, Invoicing, Settings, Contact templates
+- **Impact:** Data Integrity, User Experience, CRM↔CMS sync
+
+## 🎯 Summary
+
+The CRM used to keep a local mirror of each contact's newsletters (`SubscriptionNewsletter`) and treat it as the truth: on every `Contact` save it pushed the full photo to the CMS with a destructive `.set()`, which overwrote newsletters the CRM didn't know about. This work flips the model so the **CMS is the source of truth**. The CRM no longer trusts its mirror: it **reads and edits newsletters on demand** against the CMS over htmx (contact detail, edit-contact form, and the seller console), edits are applied as **non-destructive deltas** (add/remove a single newsletter), the destructive CRM→CMS push is turned off behind a flag, the rudimentary "default newsletters" dialog is removed (the CMS now applies its own defaults on account creation), and the now-unused newsletter maps are retired. The local mirror is intentionally left in place but frozen; the newsletter filter keeps reading it until a future repopulation command exists.
+
+This is the base-app (`utopia-crm`) half of the change; it pairs with new read/delta REST endpoints in the CMS (`utopia-cms`) and must be deployed alongside them.
+
+## ✨ Changes
+
+### 1. On-demand newsletter read/edit via an htmx proxy
+
+**Files:** `support/views/newsletters.py` (new), `support/urls.py`, `support/views/__init__.py`,
+`support/templates/contact_detail/tabs/_overview.html`,
+`support/templates/contact_detail/htmx/_newsletters_htmx.html` (new),
+`support/templates/create_contact/tabs/_newsletters.html`,
+`support/templates/create_contact/htmx/_newsletters_form_htmx.html` (new),
+`support/templates/create_contact/htmx/_newsletter_item.html` (new),
+`support/templates/create_contact/create_contact.html`, `support/views/contacts.py`
+
+Three staff-only proxy views were added. The browser talks to the CRM (htmx); the CRM talks to the CMS with the API key it already holds server-side, via `cms_rest_api_request`:
+
+- `contact_newsletters_overview` — read-only partial for the contact overview card.
+- `contact_newsletters_form` — editable partial (checkboxes by type) for the edit-contact Newsletters tab.
+- `contact_newsletter_toggle` — persists a single newsletter change straight to the CMS as a **delta**, independent of the contact form submit (so it never goes through `Contact.save()` nor the local mirror).
+
+The contact overview card and the edit-contact Newsletters tab now load by AJAX (`hx-trigger`), splitting **Newsletters** (publication) from **Áreas** (category). The overview no longer precomputes the mirror (`get_all_querysets_and_lists`), and `ContactAdminFormWithNewsletters` was reduced to a plain form (its `newsletters` field and save were removed).
+
+Two bugs were found and fixed while building the widget:
+
+1. The htmx newsletter item must **not** inject submittable fields into the contact `<form>`: its hidden `name=...` inputs collided with the Contact's own `name` field, so saving the contact replaced the contact's name with a newsletter's. The item now carries no submittable inputs; the data travels only with the htmx request via `hx-vals` (namespaced `nl_*` keys).
+2. `hx-vals='js:{...}'` does not bind `this` to the element in htmx 1.9.2, so `this.dataset` threw and **aborted the request** (the toggle never fired). The checkbox is now referenced by `id`.
+
+### 2. Newsletters card in the seller console
+
+**File:** `support/templates/seller_console.html`
+
+A collapsible **Newsletters** card was added to the right sidebar, below the "Web Reading" card. It reuses the same `contact_newsletters_overview` proxy and read-only partial, loading by htmx — no new backend.
+
+### 3. Destructive CRM→CMS push turned off behind a flag
+
+**Files:** `core/models.py`, `settings.py`
+
+`update_web_user_newsletters` now early-returns when `WEB_UPDATE_USER_NEWSLETTERS_ENABLED` is `False`. A single guard covers both signal callers. The setting defaults to `True` (backwards-compatible); production must set it to `False` so a `Contact` save no longer `.set()`s the CMS to the local mirror and wipes newsletters the CRM doesn't mirror.
+
+```python
+if not getattr(settings, "WEB_UPDATE_USER_NEWSLETTERS_ENABLED", True):
+    return
+```
+
+### 4. The "default newsletters" dialog was removed
+
+**Files:** `support/views/all_views.py`, `support/templates/default_newsletters_dialog.html` (deleted),
+`core/models.py`, `core/admin.py`, `invoicing/api.py`, `settings.py`
+
+The rudimentary dialog that asked whether to add the default newsletters on subscription creation was removed end to end: the view and template, the `Contact.offer_default_newsletters_condition` / `add_default_newsletters` methods (and the `import_module` they used), the four redirects in `core/admin.py` (plus the `response_add_or_change_next_url` helper), the call in `invoicing/api.py`, and the `CORE_DEFAULT_NEWSLETTERS` setting. The CMS now applies its own default newsletters when it creates the account.
+
+### 5. Newsletter maps retired and the inbound `update_customer` branch neutralized
+
+**Files:** `settings.py`, `migration_settings.py`, `core/models.py`
+
+`WEB_UPDATE_NEWSLETTER_MAP` and `WEB_UPDATE_AREA_NEWSLETTER_MAP` were removed (they were only used by the CSV producer and by `update_customer`). Because `update_customer` (the CMS→CRM receiver) read those maps dynamically, that branch was neutralized so it ignores the inbound `newsletters` / `area_newsletters[_remove]` fields.
+
+### 6. Read/delta endpoint settings
+
+**File:** `settings.py`
+
+`WEB_NEWSLETTERS_READ_URI` and `WEB_NEWSLETTERS_UPDATE_URI` were added (default `None`, auto-derived from `LDSOCIAL_URL`). They are POSTs that must work regardless of `WEB_CREATE_USER_ENABLED` (they never create web users), so they are added to `WEB_CREATE_USER_POST_WHITELIST`.
+
+### 7. Tests
+
+**Files:** `tests/test_newsletters_proxy.py` (new), `tests/test_contact.py`
+
+`test_newsletters_proxy.py` covers the three proxy views with the CMS mocked (8 tests). `test_contact.py` was adjusted to the removed default-newsletter behaviour.
+
+## 📁 Files Modified
+
+- **`core/models.py`** — guard on `update_web_user_newsletters`; removed `offer_default_newsletters_condition` / `add_default_newsletters`; neutralized the `update_customer` newsletter branch
+- **`core/admin.py`** — removed the four default-newsletter dialog redirects and the `response_add_or_change_next_url` helper
+- **`invoicing/api.py`** — removed the default-newsletter dialog call
+- **`settings.py`** — added `WEB_NEWSLETTERS_READ_URI` / `WEB_NEWSLETTERS_UPDATE_URI` / `WEB_UPDATE_USER_NEWSLETTERS_ENABLED` + whitelist; removed `CORE_DEFAULT_NEWSLETTERS`, `WEB_UPDATE_NEWSLETTER_MAP`, `WEB_UPDATE_AREA_NEWSLETTER_MAP`
+- **`migration_settings.py`** — dropped the removed map settings
+- **`support/views/newsletters.py`** — new proxy views (overview / form / toggle)
+- **`support/views/__init__.py`** — export the new views
+- **`support/urls.py`** — routes for the proxy views
+- **`support/views/contacts.py`** — `ContactAdminFormWithNewsletters` reduced to a plain form
+- **`support/views/all_views.py`** — removed `default_newsletters_dialog`
+- **`support/templates/contact_detail/tabs/_overview.html`** — Newsletters card loads by htmx; mirror precompute removed
+- **`support/templates/create_contact/tabs/_newsletters.html`** — tab loads by htmx
+- **`support/templates/create_contact/create_contact.html`** — added the htmx `<script>`
+- **`support/templates/seller_console.html`** — new Newsletters card
+- **`tests/test_contact.py`** — adjusted to the new behaviour
+
+## 📁 Files Created
+
+- **`support/templates/contact_detail/htmx/_newsletters_htmx.html`** — read-only overview partial
+- **`support/templates/create_contact/htmx/_newsletters_form_htmx.html`** — editable form partial
+- **`support/templates/create_contact/htmx/_newsletter_item.html`** — single newsletter toggle item
+- **`tests/test_newsletters_proxy.py`** — proxy view tests (CMS mocked)
+
+## 🧪 Manual Testing
+
+1. **Read and edit on demand (happy path):**
+   - Open a contact detail whose person exists in the CMS → the Newsletters card loads its active newsletters from the CMS.
+   - Open the edit-contact Newsletters tab → toggle one newsletter → confirm in the CMS `Subscriber` that **only that one** changed.
+   - Save the contact → the CMS newsletters do **not** change (no destructive push).
+   - **Verify:** reads reflect the CMS live; edits are single-newsletter deltas; saving the contact never overwrites the CMS.
+
+2. **Seller console:**
+   - Open the seller console on a contact linked to a CMS subscriber.
+   - **Verify:** the Newsletters card (below "Web Reading") lists the active newsletters; it can be collapsed.
+
+3. **CMS unreachable (edge case):**
+   - Point the CMS URIs at an unreachable host (or stop the CMS) and open a contact detail / seller console.
+   - **Verify:** the page renders normally; only the Newsletters card shows the "could not load newsletters from the CMS" alert; saving the contact still works.
+
+4. **Person not in the CMS yet (edge case):**
+   - Open a contact whose person has no web account.
+   - **Verify:** the card shows "this contact does not exist on the web yet" instead of an error.
+
+## 📝 Deployment Notes
+
+- **No database migrations.** The `SubscriptionNewsletter` mirror is intentionally **left in place and frozen** (not removed in this change).
+- **Deploy in the same window as the CMS branch** (`utopia-cms` / `utopia_cms_ladiaria`): the proxy calls new CMS endpoints (`usuarios/api/newsletters/`, `usuarios/api/newsletter_update/`).
+- **Production config (critical):** set `WEB_UPDATE_USER_NEWSLETTERS_ENABLED = False` in the CRM config (`ss_conf`). If left `True`, every `Contact` save keeps pushing a destructive `.set()` to the CMS.
+- On the CMS side, set `CRM_UPDATE_NEWSLETTERS_ENABLED = False` (turns off the now-unnecessary CMS→CRM push).
+- The new URIs auto-derive from `LDSOCIAL_URL`; verify `LDSOCIAL_API_KEY` is a valid CMS key.
+- Removed settings (`CORE_DEFAULT_NEWSLETTERS`, `WEB_UPDATE_NEWSLETTER_MAP`, `WEB_UPDATE_AREA_NEWSLETTER_MAP`) can be deleted from prod config (optional; they sit inert otherwise).
+- Full sequence and the rsync timing rule: see `plans/desync-crm-cms/desmapeo-newsletters/PRE_DEPLOY_CHECKLIST.md`.
+
+## 🎓 Design Decisions
+
+- **Proxy in the CRM, not browser→CMS directly:** keeps the CMS API key server-side and gives the CRM front a single origin.
+- **Delta (add/remove), never `.set()`:** edits from the CRM can no longer wipe newsletters the CRM doesn't know about — that was the root bug.
+- **Mirror left frozen, not deleted:** the newsletter filter still depends on it; removing it (and the dead push machinery) is a later cleanup phase, after the filter repopulation command exists.
+
+## 🚀 Future Improvements
+
+- Repopulation/reconciliation command (CMS→CRM by email) to restore the newsletter filter.
+- Cleanup phase: remove the dead push (`update_web_user_newsletters`), its flag, and the signal callers after a prod bake.
+- Extend the same htmx read pattern to any other views that show newsletters.
+
+---
+
+- **Date:** 2026-06-29
+- **Author:** Tanya Tree + Claude Opus 4.8
+- **Branch:** desmapeo-newsletters (t1158)
+- **Type:** Refactor
+- **Modules affected:** Core, Support, Invoicing, Settings

--- a/docs/es/devnotes/2026-06-29-t1158-desmapeo-newsletters-cms-fuente-de-verdad.md
+++ b/docs/es/devnotes/2026-06-29-t1158-desmapeo-newsletters-cms-fuente-de-verdad.md
@@ -1,0 +1,156 @@
+# Desmapeo de Newsletters: el CMS pasa a ser la Fuente de Verdad
+
+- **Fecha:** 2026-06-29
+- **Autor:** Tanya Tree + Claude Opus 4.8
+- **Ticket:** t1158 (branch `desmapeo-newsletters`)
+- **Tipo:** Refactorización
+- **Componente:** Core, Support, Invoicing, Settings, templates de contacto
+- **Impacto:** Integridad de Datos, Experiencia de Usuario, sync CRM↔CMS
+
+## 🎯 Resumen
+
+El CRM mantenía un espejo local de las newsletters de cada contacto (`SubscriptionNewsletter`) y lo trataba como la verdad: en cada guardado de `Contact` empujaba la foto completa al CMS con un `.set()` destructivo, que pisaba newsletters que el CRM no conocía. Este trabajo invierte el modelo para que el **CMS sea la fuente de verdad**. El CRM deja de confiar en su espejo: **lee y edita las newsletters a demanda** contra el CMS por htmx (ficha de contacto, formulario de edición y consola de vendedores), las ediciones se aplican como **deltas no destructivos** (alta/baja de una sola newsletter), se apaga el push destructivo CRM→CMS detrás de una opción de configuración, se elimina el rudimentario diálogo de "newsletters por defecto" (ahora el CMS aplica sus propias defaults al crear la cuenta) y se retiran los mapeos de newsletters que ya no se usan. El espejo local se deja a propósito en su lugar pero congelado; el filtro por newsletter lo sigue leyendo hasta que exista un comando futuro de repoblado.
+
+Esta es la mitad de la app base (`utopia-crm`); se complementa con endpoints REST nuevos de lectura/delta en el CMS (`utopia-cms`) y debe desplegarse junto con ellos.
+
+## ✨ Cambios
+
+### 1. Lectura/edición de newsletters a demanda por un proxy htmx
+
+**Archivos:** `support/views/newsletters.py` (nuevo), `support/urls.py`, `support/views/__init__.py`,
+`support/templates/contact_detail/tabs/_overview.html`,
+`support/templates/contact_detail/htmx/_newsletters_htmx.html` (nuevo),
+`support/templates/create_contact/tabs/_newsletters.html`,
+`support/templates/create_contact/htmx/_newsletters_form_htmx.html` (nuevo),
+`support/templates/create_contact/htmx/_newsletter_item.html` (nuevo),
+`support/templates/create_contact/create_contact.html`, `support/views/contacts.py`
+
+Se agregaron tres vistas proxy solo-staff. El navegador habla con el CRM (htmx); el CRM habla con el CMS con la API key que ya tiene del lado del servidor, vía `cms_rest_api_request`:
+
+- `contact_newsletters_overview` — parcial de solo lectura para el card de la ficha de contacto.
+- `contact_newsletters_form` — parcial editable (checkboxes por tipo) para el tab de Newsletters de la edición de contacto.
+- `contact_newsletter_toggle` — persiste un cambio de una sola newsletter directo al CMS como **delta**, independiente del submit del formulario de contacto (así nunca pasa por `Contact.save()` ni por el espejo local).
+
+El card de la ficha y el tab de Newsletters de la edición ahora cargan por AJAX (`hx-trigger`), separando **Newsletters** (publicación) de **Áreas** (categoría). El overview ya no precalcula el espejo (`get_all_querysets_and_lists`), y `ContactAdminFormWithNewsletters` quedó reducido a un formulario pelado (se le sacó el campo `newsletters` y su save).
+
+Se encontraron y corrigieron dos bugs al construir el widget:
+
+1. El item htmx de newsletter **no** debe inyectar campos enviables en el `<form>` de contacto: sus inputs ocultos `name=...` colisionaban con el campo `name` del propio Contact, así que al guardar el contacto se reemplazaba el nombre del contacto por el de una newsletter. El item ahora no lleva inputs enviables; los datos viajan solo con el request htmx vía `hx-vals` (claves `nl_*` con namespace).
+2. `hx-vals='js:{...}'` no liga `this` al elemento en htmx 1.9.2, así que `this.dataset` tiraba error y **abortaba el request** (el toggle nunca se disparaba). Ahora el checkbox se referencia por `id`.
+
+### 2. Card de Newsletters en la consola de vendedores
+
+**Archivo:** `support/templates/seller_console.html`
+
+Se agregó un card **Newsletters** colapsable en la columna lateral derecha, debajo del card de "Web Reading". Reusa el mismo proxy `contact_newsletters_overview` y el parcial de solo lectura, cargando por htmx — sin backend nuevo.
+
+### 3. Apagado del push destructivo CRM→CMS detrás de una opción de configuración
+
+**Archivos:** `core/models.py`, `settings.py`
+
+`update_web_user_newsletters` ahora retorna temprano cuando `WEB_UPDATE_USER_NEWSLETTERS_ENABLED` es `False`. Un solo guard cubre los dos callers de signals. La opción default a `True` (compatible hacia atrás); en producción hay que ponerla en `False` para que un guardado de `Contact` no le haga `.set()` al CMS con el espejo local y borre newsletters que el CRM no espeja.
+
+```python
+if not getattr(settings, "WEB_UPDATE_USER_NEWSLETTERS_ENABLED", True):
+    return
+```
+
+### 4. Se eliminó el diálogo de "newsletters por defecto"
+
+**Archivos:** `support/views/all_views.py`, `support/templates/default_newsletters_dialog.html` (eliminado),
+`core/models.py`, `core/admin.py`, `invoicing/api.py`, `settings.py`
+
+El diálogo rudimentario que preguntaba si agregar las newsletters por defecto al crear una suscripción se eliminó de punta a punta: la vista y el template, los métodos `Contact.offer_default_newsletters_condition` / `add_default_newsletters` (y el `import_module` que usaban), los cuatro redirects en `core/admin.py` (más el helper `response_add_or_change_next_url`), la llamada en `invoicing/api.py` y la opción `CORE_DEFAULT_NEWSLETTERS`. Ahora el CMS aplica sus propias newsletters por defecto cuando crea la cuenta.
+
+### 5. Se retiraron los mapeos de newsletters y se neutralizó la rama de `update_customer`
+
+**Archivos:** `settings.py`, `migration_settings.py`, `core/models.py`
+
+Se removieron `WEB_UPDATE_NEWSLETTER_MAP` y `WEB_UPDATE_AREA_NEWSLETTER_MAP` (solo los usaban el productor del CSV y `update_customer`). Como `update_customer` (el receptor CMS→CRM) leía esos mapeos dinámicamente, esa rama se neutralizó para que ignore los campos entrantes `newsletters` / `area_newsletters[_remove]`.
+
+### 6. Settings de los endpoints de lectura/delta
+
+**Archivo:** `settings.py`
+
+Se agregaron `WEB_NEWSLETTERS_READ_URI` y `WEB_NEWSLETTERS_UPDATE_URI` (default `None`, derivados de `LDSOCIAL_URL`). Son POSTs que deben funcionar sin importar `WEB_CREATE_USER_ENABLED` (nunca crean usuarios web), así que se agregan a `WEB_CREATE_USER_POST_WHITELIST`.
+
+### 7. Tests
+
+**Archivos:** `tests/test_newsletters_proxy.py` (nuevo), `tests/test_contact.py`
+
+`test_newsletters_proxy.py` cubre las tres vistas proxy con el CMS mockeado (8 tests). `test_contact.py` se ajustó al comportamiento sin las newsletters por defecto.
+
+## 📁 Archivos Modificados
+
+- **`core/models.py`** — guard en `update_web_user_newsletters`; se quitaron `offer_default_newsletters_condition` / `add_default_newsletters`; se neutralizó la rama de newsletters de `update_customer`
+- **`core/admin.py`** — se quitaron los cuatro redirects del diálogo de newsletters por defecto y el helper `response_add_or_change_next_url`
+- **`invoicing/api.py`** — se quitó la llamada al diálogo de newsletters por defecto
+- **`settings.py`** — se agregaron `WEB_NEWSLETTERS_READ_URI` / `WEB_NEWSLETTERS_UPDATE_URI` / `WEB_UPDATE_USER_NEWSLETTERS_ENABLED` + whitelist; se quitaron `CORE_DEFAULT_NEWSLETTERS`, `WEB_UPDATE_NEWSLETTER_MAP`, `WEB_UPDATE_AREA_NEWSLETTER_MAP`
+- **`migration_settings.py`** — se quitaron los settings de mapeos removidos
+- **`support/views/newsletters.py`** — nuevas vistas proxy (overview / form / toggle)
+- **`support/views/__init__.py`** — exporta las vistas nuevas
+- **`support/urls.py`** — rutas de las vistas proxy
+- **`support/views/contacts.py`** — `ContactAdminFormWithNewsletters` reducido a formulario pelado
+- **`support/views/all_views.py`** — se quitó `default_newsletters_dialog`
+- **`support/templates/contact_detail/tabs/_overview.html`** — el card de Newsletters carga por htmx; se quitó el precálculo del espejo
+- **`support/templates/create_contact/tabs/_newsletters.html`** — el tab carga por htmx
+- **`support/templates/create_contact/create_contact.html`** — se agregó el `<script>` de htmx
+- **`support/templates/seller_console.html`** — nuevo card de Newsletters
+- **`tests/test_contact.py`** — ajustado al nuevo comportamiento
+
+## 📁 Archivos Creados
+
+- **`support/templates/contact_detail/htmx/_newsletters_htmx.html`** — parcial de overview de solo lectura
+- **`support/templates/create_contact/htmx/_newsletters_form_htmx.html`** — parcial de formulario editable
+- **`support/templates/create_contact/htmx/_newsletter_item.html`** — item de toggle de una newsletter
+- **`tests/test_newsletters_proxy.py`** — tests de las vistas proxy (CMS mockeado)
+
+## 🧪 Pruebas Manuales
+
+1. **Lectura y edición a demanda (caso exitoso):**
+   - Abrir una ficha de contacto cuya persona exista en el CMS → el card de Newsletters carga sus newsletters activas desde el CMS.
+   - Abrir el tab de Newsletters de la edición de contacto → marcar/desmarcar una newsletter → confirmar en el `Subscriber` del CMS que **solo esa** cambió.
+   - Guardar el contacto → las newsletters del CMS **no** cambian (sin push destructivo).
+   - **Verificar:** las lecturas reflejan el CMS en vivo; las ediciones son deltas de una sola newsletter; guardar el contacto nunca pisa el CMS.
+
+2. **Consola de vendedores:**
+   - Abrir la consola de vendedores en un contacto asociado a un subscriber del CMS.
+   - **Verificar:** el card de Newsletters (debajo de "Web Reading") lista las newsletters activas; se puede colapsar.
+
+3. **CMS inaccesible (caso borde):**
+   - Apuntar las URIs del CMS a un host inaccesible (o frenar el CMS) y abrir una ficha de contacto / consola.
+   - **Verificar:** la página renderiza normal; solo el card de Newsletters muestra el alert de "no se pudieron cargar las newsletters desde el CMS"; guardar el contacto sigue funcionando.
+
+4. **Persona todavía no existe en el CMS (caso borde):**
+   - Abrir un contacto cuya persona no tiene cuenta web.
+   - **Verificar:** el card muestra "este contacto todavía no existe en la web" en vez de un error.
+
+## 📝 Notas de Despliegue
+
+- **No se requieren migraciones de base de datos.** El espejo `SubscriptionNewsletter` se deja a propósito **en su lugar y congelado** (no se elimina en este cambio).
+- **Desplegar en la misma ventana que la branch del CMS** (`utopia-cms` / `utopia_cms_ladiaria`): el proxy llama a endpoints nuevos del CMS (`usuarios/api/newsletters/`, `usuarios/api/newsletter_update/`).
+- **Config de producción (crítico):** poner `WEB_UPDATE_USER_NEWSLETTERS_ENABLED = False` en la config del CRM (`ss_conf`). Si queda en `True`, cada guardado de `Contact` sigue empujando un `.set()` destructivo al CMS.
+- Del lado del CMS, poner `CRM_UPDATE_NEWSLETTERS_ENABLED = False` (apaga el push CMS→CRM ya innecesario).
+- Las URIs nuevas se derivan de `LDSOCIAL_URL`; verificar que `LDSOCIAL_API_KEY` sea una key válida del CMS.
+- Los settings removidos (`CORE_DEFAULT_NEWSLETTERS`, `WEB_UPDATE_NEWSLETTER_MAP`, `WEB_UPDATE_AREA_NEWSLETTER_MAP`) se pueden borrar de la config de prod (opcional; quedan inertes si no).
+- Secuencia completa y la regla de horarios del rsync: ver `plans/desync-crm-cms/desmapeo-newsletters/PRE_DEPLOY_CHECKLIST.md`.
+
+## 🎓 Decisiones de Diseño
+
+- **Proxy en el CRM, no navegador→CMS directo:** mantiene la API key del CMS del lado del servidor y le da al front del CRM un único origen.
+- **Delta (add/remove), nunca `.set()`:** las ediciones desde el CRM ya no pueden borrar newsletters que el CRM no conoce — ese era el bug de fondo.
+- **El espejo se deja congelado, no se borra:** el filtro por newsletter todavía depende de él; eliminarlo (y la maquinaria muerta del push) es una fase de limpieza posterior, una vez que exista el comando de repoblado del filtro.
+
+## 🚀 Mejoras Futuras
+
+- Comando de repoblado/reconciliación (CMS→CRM por email) para restaurar el filtro por newsletter.
+- Fase de limpieza: eliminar el push muerto (`update_web_user_newsletters`), su flag y los callers de signals tras un período de prueba en prod.
+- Extender el mismo patrón de lectura por htmx a otras vistas que muestren newsletters.
+
+---
+
+- **Fecha:** 2026-06-29
+- **Autor:** Tanya Tree + Claude Opus 4.8
+- **Branch:** desmapeo-newsletters (t1158)
+- **Tipo de cambio:** Refactorización
+- **Módulos afectados:** Core, Support, Invoicing, Settings


### PR DESCRIPTION
CHANGELOG.md + devnotes EN/ES que documentan todo lo hecho en la branch desmapeo-newsletters: CMS como fuente de verdad de NL, lectura/edicion por htmx, apagado del push destructivo, eliminacion del dialogo de NL por defecto y retiro de los mapeos.