### PR TITLE
t1159: bloque de extensión vacío en billing_info para paquetes derivados

### DIFF
--- a/support/templates/new_subscription.html
+++ b/support/templates/new_subscription.html
@@ -310,6 +310,7 @@
                     {{ form.billing_email }}
                   </div>
                 </div>
+                {% block billing_info_extra %}{% endblock billing_info_extra %}
               </div>
             {% endblock billing_info %}
 


### PR DESCRIPTION
Agrega billing_info_extra dentro del panel colapsable de datos de facturación en new_subscription.html, para que paquetes como utopia-crm-ladiaria puedan agregar campos ahí sin duplicar el template.