### PR TITLE
t1164: robustecer run_scheduled_tasks y corregir bugs de ScheduledTask

### DIFF
--- a/support/management/commands/run_scheduled_tasks.py
+++ b/support/management/commands/run_scheduled_tasks.py
@@ -3,6 +3,11 @@ from datetime import date, timedelta
 from django.core.management import BaseCommand
 from support.models import ScheduledTask
 
+try:
+    import sentry_sdk
+except ImportError:  # pragma: no cover - sentry_sdk debería estar instalado en producción
+    sentry_sdk = None
+
 
 class Command(BaseCommand):
     help = u"Executes pending scheduled tasks"
@@ -15,6 +20,26 @@ class Command(BaseCommand):
             self.stdout.write(f"Found {tasks.count()} tasks to execute")
 
         for task in tasks:
-            response = task.execute(verbose=verbosity >= 2)
+            try:
+                response = task.execute(verbose=verbosity >= 2)
+            except Exception as exc:
+                self.stderr.write(
+                    f"Error executing ScheduledTask {task.id} "
+                    f"(category={task.category}, contact_id={task.contact_id}): {exc!r}"
+                )
+                if sentry_sdk is not None:
+                    with sentry_sdk.push_scope() as scope:
+                        scope.set_context(
+                            "scheduled_task",
+                            {
+                                "id": task.id,
+                                "category": task.category,
+                                "contact_id": task.contact_id,
+                                "subscription_id": task.subscription_id,
+                                "execution_date": str(task.execution_date),
+                            },
+                        )
+                        sentry_sdk.capture_exception(exc)
+                continue
             if response and verbosity >= 1:
                 self.stdout.write(response)

--- a/support/models.py
+++ b/support/models.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 from django.db import models
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.utils.safestring import mark_safe
@@ -329,6 +330,19 @@ class ScheduledTask(models.Model):
     def get_category(self):
         categories = dict(SCHEDULED_TASK_CATEGORIES)
         return categories.get(self.category, "N/A")
+
+    def clean(self):
+        errors = {}
+        if self.category in ('PD', 'PA') and not self.subscription_id:
+            errors['subscription'] = _("A subscription is required for this category.")
+        if self.category == 'AC' and not self.address_id:
+            errors['address'] = _("An address is required for this category.")
+        if errors:
+            raise ValidationError(errors)
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)
 
     def execute(self, debug=False, verbose=False):
         """Execute the scheduled task based on its category"""

--- a/support/templates/new_scheduled_task_partial_pause.html
+++ b/support/templates/new_scheduled_task_partial_pause.html
@@ -20,7 +20,7 @@ $(function(){
 
   $('.pause-product').click(function(){
     var parent_card = $(this).parent('div').parent('div').parent('div')
-    $(this).parent('div').parent('div').parent('div').siblings().hide()
+    parent_card.siblings('.subscription-card').hide()
   });
 });
 </script>

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -128,10 +128,16 @@ def create_address(address_1, contact, address_type='physical'):
     return Address.objects.get(pk=address.id)
 
 
-def create_scheduled_task(contact, category, execution_date):
+def create_scheduled_task(contact, category, execution_date, address=None, subscription=None):
     from support.models import ScheduledTask
 
-    scheduled_task = ScheduledTask.objects.create(contact=contact, category=category, execution_date=execution_date)
+    scheduled_task = ScheduledTask.objects.create(
+        contact=contact,
+        category=category,
+        execution_date=execution_date,
+        address=address,
+        subscription=subscription,
+    )
 
     return ScheduledTask.objects.get(pk=scheduled_task.id)
 


### PR DESCRIPTION
Una ScheduledTask sin subscription en categoria PD/PA rompia el comando completo (AttributeError no manejado), dejando sin ejecutar el resto de las tareas pendientes de esa corrida. Ahora cada tarea corre en su propio try/except: el error se loguea con contexto y se reporta a Sentry, pero las demas tareas se siguen ejecutando.

Se agrega validacion en el modelo (clean/save) para que una ScheduledTask no pueda guardarse sin subscription si es PD/PA, ni sin address si es AC, sin importar el camino de creacion (admin incluido).

De paso, se corrige el JS de pausa parcial: al tildar un producto se ocultaba tambien el titulo "Seleccionar productos" por estar al mismo nivel que las tarjetas de suscripcion en el DOM.