### PR TITLE
fix: ContactUpdateForm no aceptaba el kwarg request

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -227,6 +227,10 @@ class ContactUpdateForm(EmailValidationForm, forms.ModelForm):
             "birthdate": forms.TextInput(attrs={"class": "form-control datepicker"}),
         }
 
+    def __init__(self, *args, request=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.request = request
+
     def clean(self):
         cleaned_data = super().clean()
         email = cleaned_data.get("email")


### PR DESCRIPTION
ContactUpdateView.get_form_kwargs inyecta request para el form, pero ContactUpdateForm (base de ContactAdminFormWithNewsletters desde 68b194b) nunca definió un __init__ que lo acepte. Mientras existió el __init__ propio de ContactAdminFormWithNewsletters para las newsletters, absorbía el kwarg sin reenviarlo; al sacarlo en el desmapeo de NL (c335c7e), el kwarg quedó viajando hasta BaseModelForm.__init__ y explotaba con TypeError al editar cualquier contacto.