### PR TITLE
t1157: el alta de contacto le pregunta al takeover, no al email_check

### DIFF
--- a/core/email_takeover_queue.py
+++ b/core/email_takeover_queue.py
@@ -32,7 +32,7 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from .models import EmailTakeoverRequest
-from .utils import emailTakeoverOnWeb, validateEmailOnWeb
+from .utils import emailTakeoverOnWeb
 
 
 logger = logging.getLogger(__name__)
@@ -244,14 +244,12 @@ def queue_takeover_after_create(contact, user=None):
             return None
         if not getattr(settings, "WEB_UPDATE_USER_ENABLED", False):
             return None
-        resp = validateEmailOnWeb(contact.id, contact.email)
-        if resp in ("TIMEOUT", "ERROR") or not isinstance(resp, dict):
-            return None
-        if resp.get("msg") == "OK":
-            return None
-        retval = resp.get("retval")
-        if not (retval and retval > 0):
-            return None
+        # Asking validateEmailOnWeb first would be useless here: it answers OK without looking at
+        # the email whenever the contact has no web account of its own, and a contact that was just
+        # created never has one. So the takeover preview is asked directly -- it is the one that
+        # knows this shape (no account for the contact + an orphan holding the address) and answers
+        # `attach_only`. It is also stricter than the check: with no orphan it returns NO_ORPHAN, so
+        # nothing is filed for an address that is simply free.
         preview = preview_takeover(contact.id, contact.email)
         if not isinstance(preview, dict) or preview.get("retval") != 1:
             # Either the web is down or a takeover cannot fix this one. Nothing is filed: an

--- a/tests/test_email_takeover_queue.py
+++ b/tests/test_email_takeover_queue.py
@@ -23,6 +23,7 @@ from core.email_takeover_queue import (
     RESOLVED,
     UNREACHABLE,
     approve_takeover,
+    queue_takeover_after_create,
     reject_takeover,
 )
 from core.models import EmailTakeoverRequest
@@ -271,4 +272,82 @@ class TestTakeoverResolution(TestCase):
         outcome, _msg = approve_takeover(self.request, user=self.reviewer)
 
         self.assertEqual(outcome, FAILED)
+        mock_cms.assert_not_called()
+
+
+@override_settings(
+    WEB_UPDATE_USER_ENABLED=True,
+    WEB_EMAIL_TAKEOVER_ENABLED=True,
+    WEB_EMAIL_TAKEOVER_URI="http://cms.local/api/email_takeover/",
+    WEB_UPDATE_USER_VALIDATION_MODULE=None,
+)
+class TestTakeoverAfterCreate(TestCase):
+    """
+    Crear un contacto es el unico camino donde el CRM nunca le pregunta al CMS: Contact.clean()
+    solo consulta `if ... and self.id`, y en una creacion todavia no hay id. El contacto se crea
+    igual --es la entidad comercial-- pero el conflicto tiene que quedar archivado en vez de pasar
+    en silencio.
+    """
+
+    def _contacto_nuevo(self, email=EMAIL):
+        with override_settings(WEB_UPDATE_USER_ENABLED=False, WEB_CREATE_USER_ENABLED=False):
+            return create_contact(name="Alta Test", phone="099333444", email=email)
+
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    def test_le_pregunta_al_takeover_no_al_email_check(self, mock_cms):
+        """
+        Preguntarle a validateEmailOnWeb aca no sirve: contesta OK sin mirar el email cuando el
+        contacto no tiene cuenta web propia, y un contacto recien creado nunca la tiene. Por eso
+        se consulta el preview del takeover, que es el que conoce esta forma y contesta
+        attach_only.
+        """
+        contact = self._contacto_nuevo()
+        mock_cms.return_value = PREVIEW_ATTACH
+
+        queued = queue_takeover_after_create(contact)
+
+        self.assertIsNotNone(queued)
+        mock_cms.assert_called_once_with(contact.id, EMAIL, confirm=False)  # preview, no ejecucion
+        self.assertEqual(queued.origin, EmailTakeoverRequest.ORIGIN_CREATE_CONTACT)
+        self.assertEqual(queued.takeover_mode, "attach_only")
+        self.assertFalse(queued.deletes_an_account)
+
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    def test_el_email_queda_en_el_contacto(self, mock_cms):
+        """A diferencia de una edicion, aca no se descarta nada: no hay nada en disputa del lado
+        del CRM."""
+        contact = self._contacto_nuevo()
+        mock_cms.return_value = PREVIEW_ATTACH
+
+        queue_takeover_after_create(contact)
+
+        contact.refresh_from_db()
+        self.assertEqual(contact.email, EMAIL)
+
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    def test_email_libre_no_archiva_nada(self, mock_cms):
+        """Sin cuenta huerfana que reclamar, el CMS contesta NO_ORPHAN y no hay pedido que hacer."""
+        contact = self._contacto_nuevo()
+        mock_cms.return_value = {"msg": "No hay cuenta web con ese email", "retval": 0, "reason": "no_orphan"}
+
+        self.assertIsNone(queue_takeover_after_create(contact))
+        self.assertFalse(EmailTakeoverRequest.objects.exists())
+
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    def test_nunca_revienta_un_alta(self, mock_cms):
+        """Un contacto que se creo se queda creado, pase lo que pase con el CMS."""
+        contact = self._contacto_nuevo()
+        mock_cms.side_effect = Exception("boom")
+
+        self.assertIsNone(queue_takeover_after_create(contact))
+        contact.refresh_from_db()
+        self.assertEqual(contact.email, EMAIL)
+
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    def test_kill_switch_apagado_no_consulta(self, mock_cms):
+        contact = self._contacto_nuevo()
+
+        with override_settings(WEB_EMAIL_TAKEOVER_ENABLED=False):
+            self.assertIsNone(queue_takeover_after_create(contact))
+
         mock_cms.assert_not_called()


### PR DESCRIPTION
queue_takeover_after_create no archivaba nunca. Consultaba validateEmailOnWeb primero, y esa vista contesta OK sin mirar el email cuando el contacto no tiene cuenta web propia (thedaily/views.py, la rama `else: msg = 'OK'`, que es el agujero 2 anotado en plan-acotado-mercadopago.md seccion 10). Un contacto recien creado NUNCA tiene cuenta propia, asi que siempre recibia OK y salia sin hacer nada.

Ahora consulta directo el preview del takeover, que es el que conoce esta forma --contacto sin cuenta + huerfana con la direccion-- y contesta attach_only. Ademas es mas estricto que el check: sin huerfana devuelve NO_ORPHAN, asi que no archiva nada por una direccion que simplemente esta libre.

5 tests. El que fija la razon del cambio falla con la version anterior.

Aparecio armando el guion de prueba de CRMTEST, antes de probar: el caso E no podia funcionar. El caso D (editar un contacto que no tiene cuenta web) sigue sin detectarse por la misma rama de email_check_api, y ese no se arregla desde el CRM.

Asistencia tecnica: Claude Opus 5.