### PR TITLE
t1157: no archivar pedidos que no tienen nada que decidir

### DIFF
--- a/core/email_takeover_queue.py
+++ b/core/email_takeover_queue.py
@@ -41,6 +41,13 @@ logger = logging.getLogger(__name__)
 # answer": the first is a decision, the second is an outage and the request must stay pending.
 RESOLVED, REFUSED, UNREACHABLE, FAILED = "resolved", "refused", "unreachable", "failed"
 
+# The CMS answers this when the account holding the address is ALREADY the contact's own one, so a
+# takeover would do nothing but normalize the address. There is no decision in it: the automatic
+# paths skip it rather than put it in front of a reviewer. A queue full of requests that change
+# nothing teaches people to approve without reading, which is the one habit this queue cannot
+# afford. The on-demand view still allows it, because there somebody asked for it on purpose.
+NOTHING_TO_DECIDE = "fix_email_only"
+
 
 def takeover_queue_enabled():
     """
@@ -254,6 +261,9 @@ def queue_takeover_after_create(contact, user=None):
         if not isinstance(preview, dict) or preview.get("retval") != 1:
             # Either the web is down or a takeover cannot fix this one. Nothing is filed: an
             # unresolvable request would sit in the queue with no action a reviewer could take.
+            return None
+        if (preview.get("detail") or {}).get("mode") == NOTHING_TO_DECIDE:
+            # The regular CRM->CMS push already linked the account between the save and this check.
             return None
         return enqueue_takeover(
             contact,

--- a/core/models.py
+++ b/core/models.py
@@ -632,6 +632,10 @@ class Contact(models.Model):
             if human_msg and human_msg != "OK":
                 raise ValidationError({"email": human_msg})
             return None
+        # Note: the CMS's "fix_email_only" (the address already belongs to this contact's own web
+        # account) cannot reach this point -- email_check_api would have answered OK and there
+        # would be no conflict to resolve. It is filtered where it does happen, right after a
+        # contact is created (see queue_takeover_after_create).
         return enqueue_takeover(self, email, preview.get("detail"))
 
     def save(self, *args, **kwargs):

--- a/tests/test_email_takeover_queue.py
+++ b/tests/test_email_takeover_queue.py
@@ -345,6 +345,19 @@ class TestTakeoverAfterCreate(TestCase):
         self.assertFalse(EmailTakeoverRequest.objects.exists())
 
     @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    def test_no_archiva_lo_que_no_tiene_nada_que_decidir(self, mock_cms):
+        """
+        fix_email_only = la cuenta que tiene la direccion YA es la del contacto, porque el push
+        normal del CRM al CMS la vinculo entre el guardado y este chequeo. Aprobar eso no vincula
+        ni borra nada. Un pedido que no cambia nada le enseña al revisor a aprobar sin leer.
+        """
+        contact = self._contacto_nuevo()
+        mock_cms.return_value = {"msg": "OK", "retval": 1, "detail": {"mode": "fix_email_only"}}
+
+        self.assertIsNone(queue_takeover_after_create(contact))
+        self.assertFalse(EmailTakeoverRequest.objects.exists())
+
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
     def test_nunca_revienta_un_alta(self, mock_cms):
         """Un contacto que se creo se queda creado, pase lo que pase con el CMS."""
         contact = self._contacto_nuevo()


### PR DESCRIPTION
En la prueba aparecio un pedido con badge "Solo normaliza la direccion" (fix_email_only): el CMS lo contesta cuando la cuenta que tiene esa direccion YA es la del contacto, porque el push normal del CRM al CMS la vinculo entre el guardado y el chequeo posterior. Aprobarlo no vincula ni borra nada.

Un pedido sin decision adentro es peor que inutil: le hace perder tiempo al revisor y lo entrena a aprobar sin leer, que es el unico habito que esta cola no se puede permitir. El alta deja de archivarlos. El takeover a demanda los sigue permitiendo, porque ahi alguien lo pidio a proposito.

En la edicion no hace falta filtrarlo y no se filtra: si la direccion ya fuera de la cuenta del contacto, email_check_api habria contestado OK y no habria conflicto que resolver. Queda anotado en el codigo para que nadie agregue esa guarda creyendo que falta.

Asistencia tecnica: Claude Opus 5.