### PR TITLE
t1170: no cortar el dedupe cuando el takeover contesta not_safe

### DIFF
--- a/core/email_takeover_queue.py
+++ b/core/email_takeover_queue.py
@@ -48,6 +48,19 @@ RESOLVED, REFUSED, UNREACHABLE, FAILED = "resolved", "refused", "unreachable", "
 # afford. The on-demand view still allows it, because there somebody asked for it on purpose.
 NOTHING_TO_DECIDE = "fix_email_only"
 
+# Reasons a takeover preview can come back refused that a HUMAN has to see: no automatic path can
+# resolve them, and neither can the dedupe. Everything else must NOT stop at the takeover -- most
+# of all ``not_safe``, the CMS's answer when the address belongs to a web account that already
+# carries another ``contact_id``. That is the everyday call center case (the same person entered
+# twice in the CRM, one contact per web account), and the dedupe configured in
+# ``WEB_UPDATE_USER_VALIDATION_MODULE`` does know how to merge two web accounts that each have a
+# ``contact_id`` -- it resolved this long before the takeover existed. So on those reasons the
+# preview returns None and the conflict carries on down the path it always took.
+#
+# Codes mirror ``utopia_cms_ladiaria.email_takeover.TakeoverResult``; a CMS that does not send
+# ``reason`` at all falls through to the dedupe, which is exactly the pre-takeover behaviour.
+BLOCKING_PREVIEW_REASONS = ("is_staff", "has_subscription", "has_unmovable_data", "social_auth_conflict")
+
 
 def takeover_queue_enabled():
     """

--- a/core/models.py
+++ b/core/models.py
@@ -616,11 +616,12 @@ class Contact(models.Model):
 
         Returns the queued request, or None when the conflict is not something a takeover can fix
         and the caller should fall through to the usual dedupe/block path. Raises ValidationError
-        carrying the CMS's own readable reason (staff account, active subscription, unmovable
-        content) when it has one, because that is far more useful to the operator than the
-        generic "this email is taken".
+        carrying the CMS's own readable reason only for the reasons a human has to see
+        (BLOCKING_PREVIEW_REASONS: staff account, active subscription, unmovable content, social
+        auth conflict), because there that is far more useful to the operator than the generic
+        "this email is taken".
         """
-        from .email_takeover_queue import enqueue_takeover, preview_takeover
+        from .email_takeover_queue import BLOCKING_PREVIEW_REASONS, enqueue_takeover, preview_takeover
 
         preview = preview_takeover(self.id, email)
         if preview in ("TIMEOUT", "ERROR") or not isinstance(preview, dict):
@@ -628,9 +629,13 @@ class Contact(models.Model):
             # the contact be blocked as usual rather than filing a request on a guess.
             return None
         if preview.get("retval") != 1:
-            human_msg = preview.get("msg")
-            if human_msg and human_msg != "OK":
-                raise ValidationError({"email": human_msg})
+            # Only the reasons a human has to decide on stop here. Anything else -- above all
+            # "not_safe", the address belonging to a web account with another contact_id -- goes
+            # back to the caller as None so the conflict reaches the dedupe, which handles exactly
+            # that case and did so before this queue existed. Raising on every refusal turned the
+            # most common call center conflict into a dead end. See BLOCKING_PREVIEW_REASONS.
+            if preview.get("reason") in BLOCKING_PREVIEW_REASONS:
+                raise ValidationError({"email": preview.get("msg")})
             return None
         # Note: the CMS's "fix_email_only" (the address already belongs to this contact's own web
         # account) cannot reach this point -- email_check_api would have answered OK and there

--- a/tests/test_email_takeover_queue.py
+++ b/tests/test_email_takeover_queue.py
@@ -51,6 +51,15 @@ PREVIEW_STAFF = {
     "reason": "is_staff",
     "detail": {},
 }
+# El CMS dice que no porque la cuenta del email ya tiene OTRO contact_id: la misma persona
+# cargada dos veces en el CRM, una cuenta web por contacto. El takeover no lo cubre a proposito
+# (no puede saber si son la misma persona), pero el dedupe si: este preview NO debe cortar.
+PREVIEW_NOT_SAFE = {
+    "msg": "Ese email pertenece a otro contacto en la web. Requiere revisión manual.",
+    "retval": 0,
+    "reason": "not_safe",
+    "detail": {},
+}
 
 
 @override_settings(
@@ -116,6 +125,44 @@ class TestTakeoverQueueHook(TestCase):
             contact.custom_clean(EMAIL, debug=False)
 
         self.assertIn("STAFF", str(cm.exception))
+        self.assertFalse(EmailTakeoverRequest.objects.exists())
+
+    @mock.patch("core.models.locate")
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    @mock.patch("core.models.validateEmailOnWeb")
+    def test_not_safe_sigue_al_dedupe_y_no_encola(self, mock_validate, mock_cms, mock_locate):
+        """El caso mas comun del call center: el email lo tiene una cuenta con otro contact_id.
+
+        El takeover no lo resuelve, pero el dedupe si. El preview NO debe cortar el guardado:
+        tiene que devolver el conflicto al camino de siempre. Regresion: cuando esto cortaba,
+        el operador veia "Requiere revision manual" y no habia nada que hacer.
+        """
+        contact = self._contact()
+        mock_validate.side_effect = [CONFLICT, OK]  # conflicto, y tras el dedupe la reconsulta da OK
+        mock_cms.return_value = PREVIEW_NOT_SAFE
+        mock_locate.return_value.dedupeOnWeb.return_value = {"retval": 1}
+        contact._takeover_enqueue = True
+
+        with override_settings(WEB_UPDATE_USER_VALIDATION_MODULE="fake.dedupe.module"):
+            contact.custom_clean(EMAIL, debug=False)  # no debe lanzar
+
+        mock_locate.return_value.dedupeOnWeb.assert_called_once_with(contact.id, CONFLICT["retval"], EMAIL)
+        self.assertFalse(EmailTakeoverRequest.objects.exists())
+
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    @mock.patch("core.models.validateEmailOnWeb")
+    def test_not_safe_sin_dedupe_bloquea_con_el_mensaje_de_siempre(self, mock_validate, mock_cms):
+        """Sin modulo de dedupe configurado, not_safe bloquea con el mensaje generico de siempre
+        (no con el del takeover) y tampoco encola: no hay nada que un revisor pueda aprobar."""
+        contact = self._contact()
+        mock_validate.return_value = CONFLICT
+        mock_cms.return_value = PREVIEW_NOT_SAFE
+        contact._takeover_enqueue = True
+
+        with self.assertRaises(ValidationError) as cm:
+            contact.custom_clean(EMAIL, debug=False)
+
+        self.assertIn("Ya existe", str(cm.exception))
         self.assertFalse(EmailTakeoverRequest.objects.exists())
 
     @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")


### PR DESCRIPTION
enqueue_email_takeover lanzaba ValidationError ante cualquier respuesta del preview con mensaje legible, contra lo que dice su propio docstring: ahi se enumeran los tres motivos que un humano tiene que ver (staff, suscripcion activa, contenido no movible), no todos.

El efecto es que "not_safe" -- la respuesta del CMS cuando el email pertenece a una cuenta web que ya tiene otro contact_id -- cortaba el guardado. Ese es el caso mas comun del call center: la misma persona cargada dos veces en el CRM, una cuenta web por contacto. El dedupe de WEB_UPDATE_USER_VALIDATION_MODULE sabe resolverlo (fusiona dos cuentas web con contact_id cada una) y lo venia resolviendo desde antes de que existiera el takeover, pero desde este raise no se lo llamaba nunca y el operador quedaba con "Requiere revision manual" sin nada que hacer.

Ahora solo cortan los motivos de BLOCKING_PREVIEW_REASONS; el resto devuelve None y el conflicto sigue al dedupe, como siempre. Un CMS que no mande "reason" cae tambien al dedupe, que es el comportamiento previo al takeover.

No toca la tajada MercadoPago (_takeover_autoexec), donde no caer al dedupe fue una decision explicita.

Claude-Session: https://claude.ai/code/session_01DtrNHYNbWV1axsr2To7Hkd