### PR TITLE
t1170: pedir la politica del call center e informar el contacto dupli…

### DIFF
--- a/core/email_takeover_queue.py
+++ b/core/email_takeover_queue.py
@@ -59,7 +59,15 @@ NOTHING_TO_DECIDE = "fix_email_only"
 #
 # Codes mirror ``utopia_cms_ladiaria.email_takeover.TakeoverResult``; a CMS that does not send
 # ``reason`` at all falls through to the dedupe, which is exactly the pre-takeover behaviour.
-BLOCKING_PREVIEW_REASONS = ("is_staff", "has_subscription", "has_unmovable_data", "social_auth_conflict")
+BLOCKING_PREVIEW_REASONS = (
+    "is_staff",
+    "has_subscription",
+    "has_unmovable_data",
+    "social_auth_conflict",
+    # el duplicado que tendría que absorberse tiene suscripción activa: hay un contacto vivo
+    # detrás de ese contact_id, y con una suscripción de por medio decide una persona.
+    "orphan_has_subscription",
+)
 
 
 def takeover_queue_enabled():
@@ -77,8 +85,14 @@ def preview_takeover(contact_id, email):
     """
     Ask the CMS what a takeover of ``email`` for ``contact_id`` would do, without touching
     anything. Returns the CMS response dict, or "TIMEOUT"/"ERROR".
+
+    Always with the call center policy (``keep_subscription``), because this queue IS the call
+    center channel: keep the account that holds the subscription, and accept that the account
+    holding the address may carry a ``contact_id`` of its own -- the same person entered twice in
+    the CRM. The preview and the approval must ask for the same policy or the reviewer would be
+    approving something different from what they were shown.
     """
-    return emailTakeoverOnWeb(contact_id, email, confirm=False)
+    return emailTakeoverOnWeb(contact_id, email, confirm=False, keep_subscription=True)
 
 
 def enqueue_takeover(contact, email, preview_detail=None, origin=None, requested_by=None):
@@ -134,7 +148,7 @@ def approve_takeover(takeover_request, user=None, note=""):
         return FAILED, _("Email takeovers are disabled.")
 
     contact, email = takeover_request.contact, takeover_request.requested_email
-    run = emailTakeoverOnWeb(contact.id, email, confirm=True)
+    run = emailTakeoverOnWeb(contact.id, email, confirm=True, keep_subscription=True)  # ver preview_takeover
 
     if run in ("TIMEOUT", "ERROR") or not isinstance(run, dict):
         logger.warning("Takeover approval could not reach the CMS for request %s (%s)", takeover_request.id, run)

--- a/core/models.py
+++ b/core/models.py
@@ -3740,6 +3740,24 @@ class EmailTakeoverRequest(models.Model):
         """True when approving this request would delete a web account."""
         return self.takeover_mode == "merge"
 
+    @property
+    def released_contact_id(self):
+        """The CRM contact left WITHOUT a web account by this takeover, when there is one.
+
+        It appears in the everyday call center case: the same person entered twice in the CRM, one
+        web account per contact. The account that survives is the one holding the subscription --
+        the contact's own -- and the duplicate's account is absorbed, so the duplicate contact ends
+        up with no web account at all. That contact is almost certainly the one to merge or drop in
+        the CRM, and the reviewer has no way of guessing its id: this is where they read it.
+        """
+        return (self.preview_detail or {}).get("released_contact_id")
+
+    @property
+    def orphan_contact_id(self):
+        """Which contact owns the web account holding the requested address, when the CMS knows.
+        Present on refusals too, where it is the only handle the reviewer has to act on."""
+        return (self.preview_detail or {}).get("orphan_contact_id")
+
     # What the CMS's move_data() carries over to the surviving account before deleting the old one
     # (thedaily/utils.py). The cascade inventory in the preview is Django's Collector answering
     # "what would deleting this account destroy", and it is computed BEFORE the move -- so without
@@ -3761,12 +3779,18 @@ class EmailTakeoverRequest(models.Model):
         """(moved, gone) from the stored cascade inventory. `User` and `Subscriber` are the account
         rows themselves, so they are neither: they are what the takeover deletes on purpose."""
         cascade = (self.preview_detail or {}).get("cascade_would_delete") or {}
+        # When the surviving account is the contact's own (the call center case, the one that
+        # leaves a contact without a web account), the CMS moves over the Google login of the
+        # claimed address: that account ends up carrying exactly that email, so the binding stays
+        # consistent and the person keeps signing in with Google. Listing it as lost there would
+        # tell the reviewer the opposite of what happens.
+        moved_models = self.MOVED_ON_TAKEOVER + (("usersocialauth",) if self.released_contact_id else ())
         moved, gone = {}, {}
         for model, amount in cascade.items():
             key = model.lower()
             if key in ("user", "subscriber"):
                 continue
-            (moved if key in self.MOVED_ON_TAKEOVER else gone)[model] = amount
+            (moved if key in moved_models else gone)[model] = amount
         return moved, gone
 
     @property

--- a/core/utils.py
+++ b/core/utils.py
@@ -680,18 +680,29 @@ def validateEmailOnWeb(contact_id, email):
     )
 
 
-def emailTakeoverOnWeb(contact_id, email, confirm=False):
+def emailTakeoverOnWeb(contact_id, email, confirm=False, keep_subscription=False):
     """
     Pide al CMS el takeover de email huerfano para el contacto (desduplicacion CRM<->CMS).
     confirm=False -> preview (el CMS solo evalua las guardas, no toca nada).
-    confirm=True  -> ejecuta el takeover (conserva la cuenta del email nuevo, le transfiere
-                     el contact_id de la vieja, le mueve los datos y borra la vieja).
+    confirm=True  -> ejecuta el takeover.
+    keep_subscription=False -> politica MercadoPago: conserva la cuenta del email nuevo, le
+                     transfiere el contact_id de la vieja, le mueve los datos y borra la vieja.
+    keep_subscription=True  -> politica call center: conserva la cuenta CON SUSCRIPCION ACTIVA
+                     (que suele ser la del contacto, no la del email nuevo), le pone el email
+                     nuevo y absorbe la otra, que puede ser un duplicado del mismo humano con
+                     contact_id propio. Ese contact_id queda sin cuenta web y vuelve en el
+                     detalle como "released_contact_id".
     Devuelve el dict de respuesta del CMS o "TIMEOUT"/"ERROR".
     """
     return cms_rest_api_request(
         "emailTakeoverOnWeb",
         getattr(settings, "WEB_EMAIL_TAKEOVER_URI", None),
-        {"contact_id": contact_id, "email": email, "confirm": "1" if confirm else "0"},
+        {
+            "contact_id": contact_id,
+            "email": email,
+            "confirm": "1" if confirm else "0",
+            "keep_subscription": "1" if keep_subscription else "0",
+        },
     )
 
 

--- a/support/templates/email_takeovers/queue.html
+++ b/support/templates/email_takeovers/queue.html
@@ -87,6 +87,18 @@
                         <dd class="col-sm-9">{{ req.preview_detail.newsletters_drop|join:", " }}</dd>
                     {% endif %}
 
+                    {% if req.released_contact_id %}
+                        <dt class="col-sm-3 text-warning">{% trans "Duplicate contact in the CRM" %}</dt>
+                        <dd class="col-sm-9">
+                            <a href="{% url 'contact_detail' req.released_contact_id %}">
+                                {{ req.released_contact_id }}
+                            </a>
+                            <small class="text-muted d-block">
+                                {% blocktrans %}The web account being absorbed belongs to this contact, which will be left with no web account. Check whether it should be merged into this one or dropped.{% endblocktrans %}
+                            </small>
+                        </dd>
+                    {% endif %}
+
                     {% if req.cascade_moved %}
                         <dt class="col-sm-3 text-success">{% trans "Moves to the account that stays" %}</dt>
                         <dd class="col-sm-9">

--- a/tests/test_email_takeover_queue.py
+++ b/tests/test_email_takeover_queue.py
@@ -87,7 +87,7 @@ class TestTakeoverQueueHook(TestCase):
         contact.custom_clean(EMAIL, debug=False)  # no debe lanzar
 
         # El CMS fue consultado en modo preview: NO se ejecuto nada.
-        mock_cms.assert_called_once_with(contact.id, EMAIL, confirm=False)
+        mock_cms.assert_called_once_with(contact.id, EMAIL, confirm=False, keep_subscription=True)
         # El cambio de email se descarto y quedo la marca para que la vista avise.
         self.assertEqual(contact.email, OLD_EMAIL)
         self.assertEqual(contact.takeover_queued, EMAIL)
@@ -126,6 +126,73 @@ class TestTakeoverQueueHook(TestCase):
 
         self.assertIn("STAFF", str(cm.exception))
         self.assertFalse(EmailTakeoverRequest.objects.exists())
+
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    @mock.patch("core.models.validateEmailOnWeb")
+    def test_pide_la_politica_del_call_center(self, mock_validate, mock_cms):
+        """La cola siempre pide keep_subscription: conservar la cuenta con la suscripcion y
+        aceptar que la del email nuevo traiga contact_id propio (el duplicado del CRM)."""
+        contact = self._contact()
+        mock_validate.return_value = CONFLICT
+        mock_cms.return_value = PREVIEW_MERGE
+        contact._takeover_enqueue = True
+
+        contact.custom_clean(EMAIL, debug=False)
+
+        mock_cms.assert_called_once_with(contact.id, EMAIL, confirm=False, keep_subscription=True)
+
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    @mock.patch("core.models.validateEmailOnWeb")
+    def test_duplicado_con_suscripcion_muestra_el_motivo_y_no_encola(self, mock_validate, mock_cms):
+        """El duplicado que habria que absorber tiene suscripcion activa: decide una persona,
+        no la cola. El operador ve el motivo, con el contacto duenio del email."""
+        contact = self._contact()
+        mock_validate.return_value = CONFLICT
+        mock_cms.return_value = {
+            "msg": (
+                "La cuenta web que tiene ese email pertenece a otro contacto CON suscripción activa. "
+                "Ese email lo tiene la cuenta web del contacto 694270."
+            ),
+            "retval": 0,
+            "reason": "orphan_has_subscription",
+            "detail": {"orphan_contact_id": 694270},
+        }
+        contact._takeover_enqueue = True
+
+        with self.assertRaises(ValidationError) as cm:
+            contact.custom_clean(EMAIL, debug=False)
+
+        self.assertIn("694270", str(cm.exception))
+        self.assertFalse(EmailTakeoverRequest.objects.exists())
+
+    @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
+    @mock.patch("core.models.validateEmailOnWeb")
+    def test_el_pedido_expone_el_contacto_duplicado(self, mock_validate, mock_cms):
+        """Cuando el takeover deja un contacto del CRM sin cuenta web, el revisor tiene que poder
+        verlo en la cola: es el que hay que fusionar o dar de baja despues."""
+        contact = self._contact()
+        mock_validate.return_value = CONFLICT
+        mock_cms.return_value = {
+            "msg": "OK",
+            "retval": 1,
+            "reason": "ok",
+            "detail": {
+                "mode": "merge",
+                "drop_email": EMAIL,
+                "keep_subscriber_id": 23895,
+                "released_contact_id": 694270,
+                "cascade_would_delete": {"User": 1, "Subscriber": 1, "UserSocialAuth": 1},
+            },
+        }
+        contact._takeover_enqueue = True
+
+        contact.custom_clean(EMAIL, debug=False)
+
+        request = EmailTakeoverRequest.objects.get(contact=contact, requested_email=EMAIL)
+        self.assertEqual(request.released_contact_id, 694270)
+        # el login de Google viaja a la cuenta que queda: no se muestra como perdido
+        self.assertIn("UserSocialAuth", request.cascade_moved)
+        self.assertNotIn("UserSocialAuth", request.cascade_lost)
 
     @mock.patch("core.models.locate")
     @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")
@@ -279,7 +346,7 @@ class TestTakeoverResolution(TestCase):
         outcome, _msg = approve_takeover(self.request, user=self.reviewer)
 
         self.assertEqual(outcome, RESOLVED)
-        mock_cms.assert_called_once_with(self.contact.id, EMAIL, confirm=True)
+        mock_cms.assert_called_once_with(self.contact.id, EMAIL, confirm=True, keep_subscription=True)
         self.request.refresh_from_db()
         self.contact.refresh_from_db()
         self.assertEqual(self.request.status, EmailTakeoverRequest.APPROVED)
@@ -365,7 +432,8 @@ class TestTakeoverAfterCreate(TestCase):
         queued = queue_takeover_after_create(contact)
 
         self.assertIsNotNone(queued)
-        mock_cms.assert_called_once_with(contact.id, EMAIL, confirm=False)  # preview, no ejecucion
+        # preview, no ejecucion
+        mock_cms.assert_called_once_with(contact.id, EMAIL, confirm=False, keep_subscription=True)
         self.assertEqual(queued.origin, EmailTakeoverRequest.ORIGIN_CREATE_CONTACT)
         self.assertEqual(queued.takeover_mode, "attach_only")
         self.assertFalse(queued.deletes_an_account)

--- a/tests/test_email_takeover_views.py
+++ b/tests/test_email_takeover_views.py
@@ -123,7 +123,8 @@ class TestEmailTakeoverViews(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, OLD_EMAIL)  # que se borraria
-        mock_cms.assert_called_once_with(self.contact.id, EMAIL, confirm=False)  # solo preview
+        # solo preview, y con la politica del call center (ver preview_takeover)
+        mock_cms.assert_called_once_with(self.contact.id, EMAIL, confirm=False, keep_subscription=True)
 
     @mock.patch("core.models.validateEmailOnWeb")
     @mock.patch("core.email_takeover_queue.emailTakeoverOnWeb")


### PR DESCRIPTION
…cado

La cola ES el canal del call center, asi que preview y aprobacion piden el takeover con keep_subscription=True: conservar la cuenta que tiene la suscripcion y aceptar que la del email nuevo traiga contact_id propio (el mismo humano cargado dos veces en el CRM). Las dos llamadas piden la misma politica, o el revisor aprobaria algo distinto de lo que se le mostro.

`orphan_has_subscription` entra en BLOCKING_PREVIEW_REASONS: cuando el duplicado a absorber tiene suscripcion activa hay un contacto vivo detras y decide una persona, no la cola.

Para que el revisor pueda cerrar el caso: `released_contact_id` y `orphan_contact_id` se exponen como properties del pedido, y la cola muestra el contacto del CRM que queda sin cuenta web, con link, para fusionarlo o darlo de baja. En ese modo el login de Google se mueve a la cuenta que queda, asi que se lista entre lo que viaja y no entre lo que se pierde.

Claude-Session: https://claude.ai/code/session_01DtrNHYNbWV1axsr2To7Hkd