### PR TITLE
Chore: actualizar test con lo de main (t1176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v0.5.1
 
+## 2026-09-08 — t1176 Sacar a un contacto de una campaña ya no deja agendas colgando
+
+- Cuando se sacaba a un contacto de una campaña (el borrado masivo por CSV), se borraba su estado de campaña pero **no sus agendas**: la llamada pendiente seguía apareciendo en la cola del vendedor para una campaña de la que el contacto ya no formaba parte. Peor: al resolverla, la consola marcaba la actividad como hecha **antes** de verificar el estado de campaña, así que el vendedor veía el error "el contacto ya no está en esta campaña" y la agenda quedaba cerrada igual, sin haber quedado registrada en ningún lado. Ahora el borrado masivo limpia también esas agendas, y la consola verifica primero y no toca nada si el contacto ya salió
+- La cola de agendas del vendedor deja fuera las actividades de contactos que ya no están en la campaña, así que las que quedaron de antes no se ofrecen más para trabajar
+- Se corrigió el error 500 al abrir una venta desde un link viejo de la consola (una pestaña abierta, el botón "atrás"): el link lleva el número del estado de campaña y, si ese estado ya fue borrado, la pantalla reventaba. Ahora avisa y vuelve a la lista de campañas. El mismo aviso existía para las agendas pero nunca se llegaba a mostrar, porque la respuesta se descartaba
+- Deployment: **no se requieren migraciones**
+- **Author:** Tanya Tree + Claude Opus 5
+
 ## 2026-09-04 — t1175 Cierre forzado de agendas perdidas
 
 - Las agendas viejas que nadie volvió a trabajar dejaban al contacto colgado para siempre: seguía en la cola del vendedor y, sobre todo, **quedaba bloqueado para todas las campañas activas**, porque tener una actividad pendiente lo saca de la cola de "no contactados" de cualquier campaña. Un comando nuevo las cierra en tanda, y el estado de campaña queda marcado con una resolución nueva, **"Finalizado por agenda perdida"**, para que se sepa que el cierre fue automático y no de un vendedor

--- a/docs/en/devnotes/2026-09-08-t1176-orphan-activities-when-leaving-a-campaign.md
+++ b/docs/en/devnotes/2026-09-08-t1176-orphan-activities-when-leaving-a-campaign.md
@@ -1,0 +1,222 @@
+# Orphan Activities and Stale Console Links When a Contact Leaves a Campaign
+
+- **Date:** 2026-09-08
+- **Author:** Tanya Tree + Claude Opus 5
+- **Ticket:** t1176
+- **Type:** Bug Fix
+- **Component:** Support — Campaign Management, Seller Console, Subscriptions
+- **Impact:** Data Integrity, Seller Console Queues, User Experience
+
+## 🎯 Summary
+
+`Activity` has a foreign key to `Campaign`, not to `ContactCampaignStatus`. Removing a contact from a
+campaign deletes the `ContactCampaignStatus` row and leaves every activity behind, still pointing at
+the campaign. Two unrelated-looking symptoms come from that single fact:
+
+1. A pending activity outlived its campaign status and kept showing up in the seller console `act`
+   queue. Worse, `handle_post_request` marked the activity as completed **before** checking the
+   campaign status, so resolving it produced the error message *"Contact is no longer in this
+   campaign"* **and** closed the activity anyway — a call that never happened, recorded as done, with
+   no follow-up scheduled.
+2. `LadiariaSubscriptionCreateView` raised a `DoesNotExist` (HTTP 500) whenever the console link
+   `?new=<ccs_id>` pointed at a deleted `ContactCampaignStatus` — a tab left open, a browser back
+   button. The `act` branch of `capture_variables()` handled that case with a message and a redirect,
+   but **no `dispatch` used the return value**, so that redirect was dead code and the view carried on
+   without `self.ccs`.
+
+The production traces that motivated the ticket: contact 31806 had two activities in campaign 297
+(*Mundo 2026*) with no campaign status, the pending one closed on 2026-08-28 by a request that
+aborted; and user `sofia.fernandez` hit the 500 on 2026-08-28 with `new=916086`, a status deleted a
+month earlier by the CSV bulk delete.
+
+## ✨ Changes
+
+### 1. Bulk delete removes the open activities too
+
+**File:** `support/views/campaign_management.py`
+
+`BulkDeleteCampaignStatusView` now deletes the still-open activities of the same contacts on the same
+campaign, inside the same transaction as the campaign statuses:
+
+```python
+with transaction.atomic():
+    deleted_activities, _unused = Activity.objects.filter(
+        contact_id__in=contact_ids,
+        campaign=campaign,
+        status__in=[ACTIVITY_STATUS.PENDING, ACTIVITY_STATUS.DELAYED],
+    ).delete()
+    deleted_count, _unused = ContactCampaignStatus.objects.filter(
+        contact_id__in=contact_ids, campaign=campaign
+    ).delete()
+```
+
+Only `PENDING` and `DELAYED` are removed: those represent calls that never happened. Completed
+activities are history and stay. This mirrors what `Contact.combine()` already does when merging
+contacts (`core/models.py`). The success message reports both counts.
+
+### 2. The seller console checks the campaign status first
+
+**File:** `support/views/seller_console.py`
+
+The existence check moved ahead of every write, right after the console action is resolved:
+
+```python
+if not ContactCampaignStatus.objects.filter(campaign=campaign, contact=contact).exists():
+    messages.error(self.request, _("Contact is no longer in this campaign"))
+    return HttpResponseRedirect(reverse("seller_console", args=[category, campaign.id]))
+```
+
+`process_activity_result()` still performs its own lookup afterwards — it needs the instance to
+update it — so the guarantee is not duplicated logic, it is ordering: nothing is written by a request
+that is going to abort.
+
+### 3. The `act` queue leaves orphans out
+
+**File:** `support/views/seller_console.py`
+
+`get_console_instances()` filters the pending activities by the existence of the campaign status, so
+the activities orphaned before this fix are no longer offered:
+
+```python
+still_in_campaign = ContactCampaignStatus.objects.filter(
+    campaign=campaign, contact=OuterRef("contact")
+)
+return (
+    activities.filter(Exists(still_in_campaign))
+    .select_related('seller_console_action')
+    .order_by("datetime", "id")
+)
+```
+
+The branch on `ALLOW_ACCESSING_FUTURE_ACTIVITIES_IN_SELLER_CONSOLE` was flattened into a single
+queryset while touching the method, so the filter is applied once instead of in each return.
+
+### 4. `capture_variables()` no longer trusts the link, and its callers honour it
+
+**Files:** `support/views/subscriptions.py`,
+`utopia-crm-ladiaria/utopia_crm_ladiaria/views/subscriptions.py`
+
+The `new` branch was doing a bare `get()`. It now behaves like the `act` branch:
+
+```python
+try:
+    self.ccs = ContactCampaignStatus.objects.get(pk=self.request.GET["new"])
+except ContactCampaignStatus.DoesNotExist:
+    messages.error(
+        self.request,
+        _("The contact is no longer in this campaign, instance number: {}").format(
+            self.request.GET["new"]
+        ),
+    )
+    return HttpResponseRedirect(reverse("seller_console_list_campaigns"))
+```
+
+The `act` branch got the same treatment for a deleted `Activity`, and both branches now read
+`self.ccs.seller_id` instead of `self.ccs.seller.id`, which raised `AttributeError` on a campaign
+status with no seller.
+
+The important half is the callers. Every `dispatch()` calling `capture_variables()` discarded its
+return value, so the redirects above would never have reached the browser:
+
+```python
+response = self.capture_variables()
+if response:
+    return response
+return super().dispatch(request, *args, **kwargs)
+```
+
+This applies to the two `dispatch` methods of `SubscriptionMixin`, the one in
+`CorporateSubscriptionCreateView`, the three in `utopia_crm_ladiaria`, and the ladiaria override of
+`capture_variables()` itself, which also swallowed the response from `super()`.
+
+## 📁 Files Modified
+
+- **`support/views/campaign_management.py`** — bulk delete also removes open activities; success
+  message reports the count
+- **`support/views/seller_console.py`** — campaign status checked before writing; `act` queue filtered
+  by `Exists`
+- **`support/views/subscriptions.py`** — `new` and `act` branches handle missing rows; `seller_id`
+  instead of `seller.id`; three `dispatch` methods honour the returned response
+- **`tests/test_seller_console.py`** — new `TestSellerConsoleContactRemovedFromCampaign`
+
+## 📚 Technical Details
+
+**Why the orphans went unnoticed for so long.** `BulkDeleteCampaignStatusView` has existed since
+2025-11-14, was disabled between 2026-03-19 and 2026-05-25, and only records a `LogEntry` per deleted
+row since t1147 (2026-05-25). Deletions before that date left no trace at all, which is why most
+orphan pairs cannot be explained from `django_admin_log`. The ones that can are recognisable by their
+`change_message`: *"Bulk delete via CSV by …"*.
+
+**Scale on the 2026-09-03 production dump.** 13,589 activities over 5,337 contacts and 251 campaigns
+had no matching campaign status. Restricted to activity in 2026: 2,042 contacts, of which 1,037 were
+left mid-gestion (last console action of type `SCHEDULED`, `CALL_LATER`, `NOT_FOUND` or `PENDING`)
+and have no active subscription — the list handed to the distribution team so those contacts can be
+put back into a campaign and called again. Only 8 activities were still pending and workable; 6
+survived to the day of the cleanup and were deleted in production.
+
+**Backward compatibility.** No model or schema change. The `Exists` filter is an extra `EXISTS`
+subquery on a queryset already filtered by campaign and seller, over the
+`(contact_id, campaign_id)` unique index of `ContactCampaignStatus`.
+
+## 🧪 Manual Testing
+
+1. **Bulk delete cleans the schedules (happy path):**
+   - Pick a campaign, and a contact in it with a pending scheduled call.
+   - Go to *Campaign Management → Bulk Delete Campaign Status*, upload a CSV with that `contact_id`
+     and select the campaign.
+   - **Verify:** the success message reports 1 campaign status and 1 activity deleted; the seller's
+     `act` queue for that campaign no longer offers the contact.
+
+2. **A contact removed from the campaign while a schedule is open (edge case):**
+   - Create a pending activity for a contact in a campaign, then delete the `ContactCampaignStatus`
+     directly from the admin (simulating the old data).
+   - Open the seller console `act` queue for that campaign.
+   - **Verify:** the contact is not listed. If the URL of the item is forced by hand and a result is
+     posted, the message *"Contact is no longer in this campaign"* appears **and** the activity is
+     still pending — not completed.
+
+3. **Stale console link to a sale (edge case):**
+   - Open the console `new` queue, copy a contact's "sell" link (`…/new_subscription/?new=<id>&…`).
+   - Delete that `ContactCampaignStatus`, then load the copied link.
+   - **Verify:** no 500. The page redirects to the campaign list with the message *"The contact is no
+     longer in this campaign, instance number: …"*.
+
+## 📝 Deployment Notes
+
+- No database migrations required.
+- No configuration changes.
+- Optional post-deployment cleanup, for pending activities orphaned before the fix:
+
+  ```sql
+  DELETE FROM core_activity a
+  USING (
+    SELECT a2.id FROM core_activity a2
+    LEFT JOIN core_contactcampaignstatus ccs
+           ON ccs.contact_id = a2.contact_id AND ccs.campaign_id = a2.campaign_id
+    WHERE a2.campaign_id IS NOT NULL AND a2.status = 'P' AND ccs.id IS NULL
+  ) h WHERE a.id = h.id;
+  ```
+
+  Run the `SELECT` on its own first: with the fix deployed this should return few or no rows.
+- The ladiaria package must be deployed together with the base app: the `dispatch` fix spans both.
+
+## 🚀 Future Improvements
+
+- The dashboard counters (`Seller.get_campaigns_with_activities()`, `campaign.pending`,
+  `total_pending_activities_count()`) still count orphan activities. They cannot be worked on, so a
+  campaign can appear in the list with a count the queue does not show. Worth aligning them with the
+  same `Exists` filter.
+- The seller console links carry `ContactCampaignStatus` and `Activity` primary keys in the
+  querystring. Any of those can go stale between rendering and clicking; a periodic revalidation, or
+  keying by contact and campaign instead, would remove a whole class of these errors.
+- `BulkDeleteCampaignStatusView` logs deletions of campaign statuses but not of activities. If the
+  audit trail matters for the activities too, they deserve their own `LogEntry`.
+
+---
+
+- **Date:** 2026-09-08
+- **Author:** Tanya Tree + Claude Opus 5
+- **Branch:** t1176
+- **Type:** Bug Fix
+- **Modules affected:** Support (Campaign Management, Seller Console, Subscriptions), Core (Activity,
+  ContactCampaignStatus)

--- a/docs/es/devnotes/2026-09-08-t1176-actividades-huerfanas-al-salir-de-una-campania.md
+++ b/docs/es/devnotes/2026-09-08-t1176-actividades-huerfanas-al-salir-de-una-campania.md
@@ -1,0 +1,228 @@
+# Actividades huérfanas y links viejos de consola cuando un contacto sale de una campaña
+
+- **Fecha:** 2026-09-08
+- **Autor:** Tanya Tree + Claude Opus 5
+- **Ticket:** t1176
+- **Tipo:** Bug Fix
+- **Componente:** Support — Campaign Management, Consola de vendedores, Suscripciones
+- **Impacto:** Integridad de datos, colas de la consola de vendedores, experiencia de usuario
+
+## 🎯 Resumen
+
+`Activity` tiene una foreign key a `Campaign`, no a `ContactCampaignStatus`. Sacar un contacto de una
+campaña borra la fila de `ContactCampaignStatus` y deja todas sus actividades atrás, apuntando
+igual a la campaña. De ese único hecho salen dos síntomas que parecían no tener relación:
+
+1. Una actividad pendiente sobrevivía a su estado de campaña y seguía apareciendo en la cola `act` de
+   la consola. Peor: `handle_post_request` marcaba la actividad como completada **antes** de
+   verificar el estado de campaña, así que resolverla producía el mensaje de error *"Contact is no
+   longer in this campaign"* **y** además cerraba la actividad — una llamada que nunca ocurrió,
+   registrada como hecha y sin agenda nueva.
+2. `LadiariaSubscriptionCreateView` levantaba un `DoesNotExist` (HTTP 500) cada vez que el link de
+   consola `?new=<ccs_id>` apuntaba a un `ContactCampaignStatus` borrado — una pestaña abierta, el
+   botón "atrás" del navegador. La rama `act` de `capture_variables()` manejaba ese caso con un
+   mensaje y un redirect, pero **ningún `dispatch` usaba el valor de retorno**, así que ese redirect
+   era código muerto y la vista seguía adelante sin `self.ccs`.
+
+Los rastros de producción que motivaron el ticket: el contacto 31806 tenía dos actividades en la
+campaña 297 (*Mundo 2026*) sin estado de campaña, con la pendiente cerrada el 2026-08-28 por un
+request que abortó; y la usuaria `sofia.fernandez` se topó con el 500 el 2026-08-28 con
+`new=916086`, un estado borrado un mes antes por el borrado masivo por CSV.
+
+## ✨ Cambios
+
+### 1. El borrado masivo también se lleva las actividades abiertas
+
+**Archivo:** `support/views/campaign_management.py`
+
+`BulkDeleteCampaignStatusView` ahora borra las actividades todavía abiertas de esos mismos contactos
+en esa misma campaña, dentro de la misma transacción que los estados de campaña:
+
+```python
+with transaction.atomic():
+    deleted_activities, _unused = Activity.objects.filter(
+        contact_id__in=contact_ids,
+        campaign=campaign,
+        status__in=[ACTIVITY_STATUS.PENDING, ACTIVITY_STATUS.DELAYED],
+    ).delete()
+    deleted_count, _unused = ContactCampaignStatus.objects.filter(
+        contact_id__in=contact_ids, campaign=campaign
+    ).delete()
+```
+
+Sólo se borran `PENDING` y `DELAYED`: son llamadas que nunca ocurrieron. Las completadas son historia
+y quedan. Es lo mismo que ya hace `Contact.combine()` al fusionar contactos (`core/models.py`). El
+mensaje de éxito informa los dos números.
+
+### 2. La consola de vendedores verifica el estado de campaña primero
+
+**Archivo:** `support/views/seller_console.py`
+
+La verificación de existencia se movió antes de cualquier escritura, justo después de resolver la
+acción de consola:
+
+```python
+if not ContactCampaignStatus.objects.filter(campaign=campaign, contact=contact).exists():
+    messages.error(self.request, _("Contact is no longer in this campaign"))
+    return HttpResponseRedirect(reverse("seller_console", args=[category, campaign.id]))
+```
+
+`process_activity_result()` sigue haciendo su propia búsqueda después — necesita la instancia para
+actualizarla —, así que la garantía no es lógica duplicada sino orden: nada se escribe en un request
+que va a abortar.
+
+### 3. La cola `act` deja afuera a las huérfanas
+
+**Archivo:** `support/views/seller_console.py`
+
+`get_console_instances()` filtra las actividades pendientes por la existencia del estado de campaña,
+de modo que las que quedaron huérfanas antes de este arreglo ya no se ofrecen:
+
+```python
+still_in_campaign = ContactCampaignStatus.objects.filter(
+    campaign=campaign, contact=OuterRef("contact")
+)
+return (
+    activities.filter(Exists(still_in_campaign))
+    .select_related('seller_console_action')
+    .order_by("datetime", "id")
+)
+```
+
+De paso, la bifurcación por `ALLOW_ACCESSING_FUTURE_ACTIVITIES_IN_SELLER_CONSOLE` se aplanó en un
+solo queryset, así el filtro se aplica una vez y no en cada return.
+
+### 4. `capture_variables()` deja de confiar en el link, y quien lo llama lo respeta
+
+**Archivos:** `support/views/subscriptions.py`,
+`utopia-crm-ladiaria/utopia_crm_ladiaria/views/subscriptions.py`
+
+La rama `new` hacía un `get()` pelado. Ahora se comporta como la rama `act`:
+
+```python
+try:
+    self.ccs = ContactCampaignStatus.objects.get(pk=self.request.GET["new"])
+except ContactCampaignStatus.DoesNotExist:
+    messages.error(
+        self.request,
+        _("The contact is no longer in this campaign, instance number: {}").format(
+            self.request.GET["new"]
+        ),
+    )
+    return HttpResponseRedirect(reverse("seller_console_list_campaigns"))
+```
+
+La rama `act` recibió el mismo tratamiento para una `Activity` borrada, y las dos ramas ahora leen
+`self.ccs.seller_id` en lugar de `self.ccs.seller.id`, que levantaba `AttributeError` cuando el
+estado de campaña no tenía vendedor.
+
+La mitad importante es quien llama. Todos los `dispatch()` que invocaban `capture_variables()`
+descartaban su valor de retorno, así que los redirects de arriba nunca habrían llegado al navegador:
+
+```python
+response = self.capture_variables()
+if response:
+    return response
+return super().dispatch(request, *args, **kwargs)
+```
+
+Esto aplica a los dos `dispatch` de `SubscriptionMixin`, al de `CorporateSubscriptionCreateView`, a
+los tres de `utopia_crm_ladiaria` y al override ladiaria de `capture_variables()`, que también se
+tragaba la respuesta de `super()`.
+
+## 📁 Archivos modificados
+
+- **`support/views/campaign_management.py`** — el borrado masivo también elimina las actividades
+  abiertas; el mensaje de éxito informa la cantidad
+- **`support/views/seller_console.py`** — se verifica el estado de campaña antes de escribir; la cola
+  `act` se filtra con `Exists`
+- **`support/views/subscriptions.py`** — las ramas `new` y `act` manejan las filas faltantes;
+  `seller_id` en vez de `seller.id`; tres `dispatch` respetan la respuesta devuelta
+- **`tests/test_seller_console.py`** — nueva `TestSellerConsoleContactRemovedFromCampaign`
+
+## 📚 Detalles técnicos
+
+**Por qué las huérfanas pasaron desapercibidas tanto tiempo.** `BulkDeleteCampaignStatusView` existe
+desde el 2025-11-14, estuvo deshabilitada entre el 2026-03-19 y el 2026-05-25, y sólo registra un
+`LogEntry` por fila borrada desde t1147 (2026-05-25). Los borrados anteriores a esa fecha no dejaron
+ningún rastro, y por eso la mayoría de los pares huérfanos no se pueden explicar desde
+`django_admin_log`. Los que sí se pueden se reconocen por su `change_message`: *"Bulk delete via CSV
+by …"*.
+
+**Escala sobre el dump de producción del 2026-09-03.** 13.589 actividades sobre 5.337 contactos y 251
+campañas no tenían estado de campaña asociado. Restringido a actividad en 2026: 2.042 contactos, de
+los cuales 1.037 quedaron con la gestión por la mitad (última acción de consola de tipo `SCHEDULED`,
+`CALL_LATER`, `NOT_FOUND` o `PENDING`) y sin suscripción activa — el listado que se le pasó al área
+de distribución para volver a subirlos a una campaña y llamarlos de nuevo. Sólo 8 actividades seguían
+pendientes y trabajables; 6 sobrevivieron hasta el día de la limpieza y se borraron en producción.
+
+**Compatibilidad hacia atrás.** No hay cambios de modelo ni de esquema. El filtro `Exists` agrega una
+subconsulta `EXISTS` sobre un queryset ya filtrado por campaña y vendedor, apoyada en el índice único
+`(contact_id, campaign_id)` de `ContactCampaignStatus`.
+
+## 🧪 Pruebas manuales
+
+1. **El borrado masivo limpia las agendas (camino feliz):**
+   - Elegir una campaña y un contacto que esté en ella con una llamada agendada pendiente.
+   - Ir a *Campaign Management → Bulk Delete Campaign Status*, subir un CSV con ese `contact_id` y
+     seleccionar la campaña.
+   - **Verificar:** el mensaje de éxito informa 1 estado de campaña y 1 actividad borrados; la cola
+     `act` del vendedor para esa campaña ya no ofrece el contacto.
+
+2. **Contacto sacado de la campaña con una agenda abierta (caso borde):**
+   - Crear una actividad pendiente para un contacto en una campaña y después borrar el
+     `ContactCampaignStatus` directamente desde el admin (simulando los datos viejos).
+   - Abrir la cola `act` de la consola para esa campaña.
+   - **Verificar:** el contacto no aparece. Si se fuerza la URL del ítem a mano y se envía un
+     resultado, aparece el mensaje *"Contact is no longer in this campaign"* **y** la actividad sigue
+     pendiente, no completada.
+
+3. **Link viejo de la consola hacia una venta (caso borde):**
+   - Abrir la cola `new` de la consola y copiar el link de "vender" de un contacto
+     (`…/new_subscription/?new=<id>&…`).
+   - Borrar ese `ContactCampaignStatus` y después cargar el link copiado.
+   - **Verificar:** no hay 500. La página redirige a la lista de campañas con el mensaje *"The contact
+     is no longer in this campaign, instance number: …"*.
+
+## 📝 Notas de despliegue
+
+- No se requieren migraciones.
+- No hay cambios de configuración.
+- Limpieza posterior opcional, para las actividades pendientes que quedaron huérfanas antes del
+  arreglo:
+
+  ```sql
+  DELETE FROM core_activity a
+  USING (
+    SELECT a2.id FROM core_activity a2
+    LEFT JOIN core_contactcampaignstatus ccs
+           ON ccs.contact_id = a2.contact_id AND ccs.campaign_id = a2.campaign_id
+    WHERE a2.campaign_id IS NOT NULL AND a2.status = 'P' AND ccs.id IS NULL
+  ) h WHERE a.id = h.id;
+  ```
+
+  Correr primero el `SELECT` solo: con el arreglo desplegado debería devolver pocas filas o ninguna.
+- El paquete ladiaria tiene que desplegarse junto con la app base: el arreglo de los `dispatch`
+  abarca los dos.
+
+## 🚀 Mejoras futuras
+
+- Los contadores del dashboard (`Seller.get_campaigns_with_activities()`, `campaign.pending`,
+  `total_pending_activities_count()`) siguen contando actividades huérfanas. No se pueden trabajar,
+  así que una campaña puede aparecer en la lista con un número que la cola no muestra. Convendría
+  alinearlos con el mismo filtro `Exists`.
+- Los links de la consola llevan las claves primarias de `ContactCampaignStatus` y `Activity` en el
+  querystring. Cualquiera de las dos puede quedar vieja entre que se renderiza y se hace clic; una
+  revalidación periódica, o direccionar por contacto y campaña en lugar de por id, eliminaría toda
+  una clase de estos errores.
+- `BulkDeleteCampaignStatusView` registra el borrado de los estados de campaña pero no el de las
+  actividades. Si la trazabilidad importa también para las actividades, merecen su propio `LogEntry`.
+
+---
+
+- **Fecha:** 2026-09-08
+- **Autor:** Tanya Tree + Claude Opus 5
+- **Rama:** t1176
+- **Tipo:** Bug Fix
+- **Módulos afectados:** Support (Campaign Management, Consola de vendedores, Suscripciones), Core
+  (Activity, ContactCampaignStatus)

--- a/support/views/campaign_management.py
+++ b/support/views/campaign_management.py
@@ -13,8 +13,9 @@ from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, TemplateView
 
+from core.choices import ACTIVITY_STATUS
 from core.mixins import BreadcrumbsMixin
-from core.models import ContactCampaignStatus
+from core.models import Activity, ContactCampaignStatus
 from core.utils import detect_csv_delimiter
 from support.forms import BulkDeleteCampaignStatusForm
 
@@ -131,8 +132,15 @@ class BulkDeleteCampaignStatusView(BreadcrumbsMixin, UserPassesTestMixin, FormVi
             )
         )
 
-        # Delete ContactCampaignStatus records
+        # Delete ContactCampaignStatus records, along with the activities that are still open for the same
+        # contacts on the same campaign. Activities point directly to the campaign, so leaving them behind
+        # keeps the contact in the seller console queue for a campaign they are no longer part of.
         with transaction.atomic():
+            deleted_activities, _unused = Activity.objects.filter(
+                contact_id__in=contact_ids,
+                campaign=campaign,
+                status__in=[ACTIVITY_STATUS.PENDING, ACTIVITY_STATUS.DELAYED],
+            ).delete()
             deleted_count, _unused = ContactCampaignStatus.objects.filter(
                 contact_id__in=contact_ids, campaign=campaign
             ).delete()
@@ -161,9 +169,14 @@ class BulkDeleteCampaignStatusView(BreadcrumbsMixin, UserPassesTestMixin, FormVi
         messages.success(
             self.request,
             _(
-                "Successfully deleted {count} ContactCampaignStatus record(s) for campaign "
-                "'{campaign}' with {total} contact ID(s) from CSV."
-            ).format(count=deleted_count, campaign=campaign.name, total=len(contact_ids)),
+                "Successfully deleted {count} ContactCampaignStatus record(s) and {activities} open "
+                "activity(ies) for campaign '{campaign}' with {total} contact ID(s) from CSV."
+            ).format(
+                count=deleted_count,
+                activities=deleted_activities,
+                campaign=campaign.name,
+                total=len(contact_ids),
+            ),
         )
 
         return redirect(self.success_url)

--- a/support/views/seller_console.py
+++ b/support/views/seller_console.py
@@ -3,6 +3,7 @@ from django.contrib.auth.mixins import UserPassesTestMixin, LoginRequiredMixin
 from django.conf import settings
 from django.contrib import messages
 from django.utils import timezone
+from django.db.models import Exists, OuterRef
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -446,6 +447,13 @@ class SellerConsoleView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
         if not seller_console_action:
             return HttpResponseRedirect(reverse("seller_console", args=[category, campaign.id]))
 
+        # The contact must still be in the campaign before we touch anything. Activities point directly to the
+        # campaign, so a pending one can outlive the ContactCampaignStatus and still show up in this queue; if we
+        # completed it first and only checked afterwards, the activity would be closed by a request that aborts.
+        if not ContactCampaignStatus.objects.filter(campaign=campaign, contact=contact).exists():
+            messages.error(self.request, _("Contact is no longer in this campaign"))
+            return HttpResponseRedirect(reverse("seller_console", args=[category, campaign.id]))
+
         # Process based on category
         if category == "act":
             try:
@@ -738,13 +746,19 @@ class SellerConsoleView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
         category = self.kwargs['category']
         if category == "new":
             return campaign.get_not_contacted(seller.id).select_related('last_console_action')
-        if getattr(settings, "ALLOW_ACCESSING_FUTURE_ACTIVITIES_IN_SELLER_CONSOLE", False):
-            return campaign.activity_set.filter(
-                activity_type="C", seller=seller, status="P"
-            ).select_related('seller_console_action').order_by("datetime", "id")
-        return campaign.activity_set.filter(
-            activity_type="C", seller=seller, status="P", datetime__lte=datetime.now()
-        ).select_related('seller_console_action').order_by("datetime", "id")
+        activities = campaign.activity_set.filter(activity_type="C", seller=seller, status="P")
+        if not getattr(settings, "ALLOW_ACCESSING_FUTURE_ACTIVITIES_IN_SELLER_CONSOLE", False):
+            activities = activities.filter(datetime__lte=datetime.now())
+        # Leave out activities whose contact is no longer in the campaign: they can't be worked on, since every
+        # console action needs the ContactCampaignStatus that is already gone.
+        still_in_campaign = ContactCampaignStatus.objects.filter(
+            campaign=campaign, contact=OuterRef("contact")
+        )
+        return (
+            activities.filter(Exists(still_in_campaign))
+            .select_related('seller_console_action')
+            .order_by("datetime", "id")
+        )
 
     def post(self, request, *args, **kwargs):
         return self.handle_post_request()

--- a/support/views/subscriptions.py
+++ b/support/views/subscriptions.py
@@ -218,6 +218,12 @@ class SubscriptionMixin(BreadcrumbsMixin):
                 return subscription
 
     def capture_variables(self):
+        """
+        Reads the console parameters from the querystring.
+
+        Returns None when everything is in place, or a response the caller must return as-is when the console
+        instance the link points to is gone. Every dispatch calling this has to honour that return value.
+        """
         self.url = self.request.GET.get("url", None)
         self.offset = self.request.GET.get("offset", None)
         self.is_new = self.request.GET.get("new", None)
@@ -235,23 +241,38 @@ class SubscriptionMixin(BreadcrumbsMixin):
             self.subscription, self.edit_subscription = None, False
 
         if self.request.GET.get("act", None):
-            self.activity = Activity.objects.get(pk=self.request.GET["act"])
+            try:
+                self.activity = Activity.objects.get(pk=self.request.GET["act"])
+            except Activity.DoesNotExist:
+                messages.error(self.request, _("This activity no longer exists."))
+                return HttpResponseRedirect(reverse("seller_console_list_campaigns"))
             self.campaign = self.activity.campaign
             try:
                 self.ccs = ContactCampaignStatus.objects.get(contact=self.contact, campaign=self.campaign)
             except ContactCampaignStatus.DoesNotExist:
                 msg = _(
-                    "Activity {} is not in campaign {}. Please report this error!".format(
-                        self.activity.id, self.campaign.id
+                    "The contact is no longer in campaign {}, so activity {} can't be used to sell.".format(
+                        self.campaign.id, self.activity.id
                     )
                 )
                 messages.error(self.request, msg)
                 return HttpResponseRedirect(reverse("seller_console_list_campaigns"))
-            self.user_seller_id = self.ccs.seller.id
+            self.user_seller_id = self.ccs.seller_id
         elif self.request.GET.get("new", None):
-            self.ccs = ContactCampaignStatus.objects.get(pk=self.request.GET["new"])
+            # The link carries the ContactCampaignStatus id. It can be stale: removing a contact from a campaign
+            # deletes that record while console pages already rendered keep pointing at it.
+            try:
+                self.ccs = ContactCampaignStatus.objects.get(pk=self.request.GET["new"])
+            except ContactCampaignStatus.DoesNotExist:
+                messages.error(
+                    self.request,
+                    _("The contact is no longer in this campaign, instance number: {}").format(
+                        self.request.GET["new"]
+                    ),
+                )
+                return HttpResponseRedirect(reverse("seller_console_list_campaigns"))
             self.campaign = self.ccs.campaign
-            self.user_seller_id = self.ccs.seller.id
+            self.user_seller_id = self.ccs.seller_id
         elif getattr(self.request.user, 'seller', None) is not None:
             self.user_seller_id = self.request.user.seller.id
         else:
@@ -310,7 +331,9 @@ class SubscriptionCreateView(UserPassesTestMixin, SubscriptionMixin, FormView):
     def dispatch(self, request, *args, **kwargs):
         self.contact = self.get_contact(kwargs['contact_id'])
         self.subscription = None
-        self.capture_variables()
+        response = self.capture_variables()
+        if response:
+            return response
         return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
@@ -348,7 +371,9 @@ class SubscriptionUpdateView(SubscriptionMixin, FormView):
     def dispatch(self, request, *args, **kwargs):
         self.contact = self.get_contact(kwargs['contact_id'])
         self.subscription = self.get_subscription(kwargs['subscription_id'])
-        self.capture_variables()
+        response = self.capture_variables()
+        if response:
+            return response
         if self.subscription and self.subscription.contact != self.contact:
             # TODO: change this to a better approach, it generates bad UX and an error email wo traceback (useless)
             return HttpResponseServerError(_("Wrong data"))
@@ -1869,7 +1894,9 @@ class CorporateSubscriptionCreateView(SubscriptionMixin, FormView):
     def dispatch(self, request, *args, **kwargs):
         self.contact = self.get_contact(kwargs['contact_id'])
         self.subscription = None
-        self.capture_variables()
+        response = self.capture_variables()
+        if response:
+            return response
         return super().dispatch(request, *args, **kwargs)
 
 

--- a/tests/test_seller_console.py
+++ b/tests/test_seller_console.py
@@ -2,6 +2,9 @@
 from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.utils import timezone
+
+from datetime import timedelta
 
 from core.models import Activity, Campaign, ContactCampaignStatus
 from core.choices import CAMPAIGN_STATUS
@@ -144,3 +147,99 @@ class TestSellerConsoleScheduledActivity(TestCase):
         )
         self.assertEqual(pending.count(), 1)
         self.assertEqual(pending.first().seller_console_action, self.schedule)
+
+
+class TestSellerConsoleContactRemovedFromCampaign(TestCase):
+    """
+    Verifica el comportamiento cuando el contacto ya no está en la campaña pero sobrevive una actividad
+    pendiente apuntando a ella.
+
+    Regresión t1176: sacar un contacto de una campaña borra el ContactCampaignStatus pero no las
+    actividades, que apuntan directo a la campaña. La pendiente seguía apareciendo en la cola "act" y, al
+    resolverla, la consola la marcaba como completada antes de verificar el estado de campaña: el vendedor
+    veía el error y la actividad quedaba cerrada igual.
+    """
+
+    def setUp(self):
+        self.client = Client()
+
+        self.user = User.objects.create_superuser(username="vendedor", password="testpass")
+        self.seller = Seller.objects.create(name="Vendedor", user=self.user, internal=True)
+        self.client.login(username="vendedor", password="testpass")
+
+        self.contact = ContactFactory()
+        self.campaign = Campaign.objects.create(name="Campaña test", active=True, priority=3)
+
+        self.call_later = SellerConsoleAction.objects.create(
+            slug="call-later",
+            name="Llamar más tarde",
+            action_type=SellerConsoleAction.ACTION_TYPES.CALL_LATER,
+            campaign_status=CAMPAIGN_STATUS.CALLED_COULD_NOT_CONTACT,
+            campaign_resolution="CL",
+            is_active=True,
+        )
+
+        # La actividad pendiente que quedó huérfana: el contacto ya no tiene ContactCampaignStatus.
+        self.activity = Activity.objects.create(
+            contact=self.contact,
+            campaign=self.campaign,
+            seller=self.seller,
+            activity_type="C",
+            status="P",
+            datetime=timezone.now() - timedelta(days=1),
+        )
+
+    def test_orphan_activity_is_not_completed(self):
+        """Resolver una actividad de un contacto que ya no está en la campaña no debe cerrarla."""
+        self.client.post(
+            reverse("seller_console", args=["act", self.campaign.id]),
+            data={
+                "result": "call-later",
+                "category": "act",
+                "instance_id": self.activity.id,
+                "seller_id": self.seller.id,
+                "offset": 1,
+                "notes": "No contesta",
+            },
+        )
+
+        self.activity.refresh_from_db()
+        self.assertEqual(self.activity.status, "P")
+        # Tampoco debe haberse creado una pendiente nueva para una campaña de la que ya salió.
+        self.assertEqual(Activity.objects.filter(contact=self.contact, campaign=self.campaign).count(), 1)
+
+    def test_orphan_activity_is_not_listed_in_console(self):
+        """La cola de la consola no debe ofrecer actividades de contactos que ya salieron de la campaña."""
+        # Con la única actividad huérfana, la cola queda vacía y la consola manda de vuelta a la lista.
+        response = self.client.get(reverse("seller_console", args=["act", self.campaign.id]))
+        self.assertRedirects(
+            response, reverse("seller_console_list_campaigns"), fetch_redirect_response=False
+        )
+
+        ContactCampaignStatus.objects.create(
+            contact=self.contact, campaign=self.campaign, status=1, seller=self.seller
+        )
+        response = self.client.get(reverse("seller_console", args=["act", self.campaign.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.contact.get_full_name())
+
+    def test_activity_is_listed_again_when_contact_is_back_in_campaign(self):
+        """Con el ContactCampaignStatus en su lugar, la misma actividad sí se puede trabajar."""
+        ContactCampaignStatus.objects.create(
+            contact=self.contact, campaign=self.campaign, status=1, seller=self.seller
+        )
+
+        self.client.post(
+            reverse("seller_console", args=["act", self.campaign.id]),
+            data={
+                "result": "call-later",
+                "category": "act",
+                "instance_id": self.activity.id,
+                "seller_id": self.seller.id,
+                "offset": 1,
+                "notes": "No contesta",
+            },
+        )
+
+        self.activity.refresh_from_db()
+        self.assertEqual(self.activity.status, "C")


### PR DESCRIPTION
Actualización de `test` con lo que ya está en `main`, previo al merge de `desync/validacion-y-activacion`.

Trae t1176 (no dejar actividades ni links colgando al sacar un contacto de una campaña) y su changelog/devnotes.

Va primero y por separado para que el MR de la rama de validación muestre sólo su propio diff, y para poder distinguir en TEST qué cambio rompió algo si algo rompe.

https://claude.ai/code/session_01RUZoQyxpkAMZXboSk5TngW
