### PR TITLE
Validar la venta como puerta de la activación web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## v0.5.1
 
+## 2026-09-08 — desync/validacion-y-activacion Validar la venta es lo que le da acceso web a la persona
+
+- **Validar una venta pasa a ser la puerta del acceso a la web.** Hasta ahora un alta hecha por el call center no se veía en el sitio hasta el batch de la madrugada; ahora, en el momento en que un manager valida, la persona puede leer. Se eligió la validación y no el alta a propósito: un alta recién hecha todavía puede ser un duplicado, y dar el acceso antes de que alguien la mire se lo termina dando a la cuenta web equivocada. Cada instalación decide qué propagar, con el setting `SUBSCRIPTION_VALIDATED_HOOK`; **si no está configurado no pasa nada**, y si falla la propagación la validación queda guardada igual
+- **Se ordenó quién tiene que validarse y quién no.** Las altas que entran por la web no tienen vendedor, ni comisión, ni nada que un manager pueda mirar: nacen validadas y no ensucian más la cola de registros de ventas. Que una suscripción nazca validada ya no impide comisionarle a alguien —el caso real es el vendedor que refiere a una persona que después compra sola—, y hacerlo no pisa la marca de que la validó el sistema
+- **Una suscripción gratuita (obsequio o staff) no reporta forma de pago ni paga comisión.** Antes el panel le mostraba la forma de pago de la suscripción y le calculaba comisión sobre una venta que no movió plata. Ahora lee N/A y 0, y en la pantalla de validación los campos de comisión quedan **bloqueados**, no sólo escondidos: un pedido armado a mano tampoco consigue comisión. La validación sigue haciendo falta, porque es lo que deja constancia de la venta y lo que activa a la persona en la web
+- **El estado de validación se ve desde la ficha del contacto en todos los tipos de suscripción.** Los obsequios y las promos no mostraban nada, así que entraban en la cola pero no había cómo validarlos desde ahí. Y el caso "ya está todo en orden" —validada y con registro— se veía igual que "no se cargó nada": ahora muestra una chapita con quién validó y cuándo, o "por el sistema" cuando fue automático
+- **Registros de ventas** sale del menú de gestión de campañas y pasa al menú principal, para managers, con la cantidad pendiente de validar al lado
+- Deployment: **no se requieren migraciones**. Para encender la activación web hay que configurar `SUBSCRIPTION_VALIDATED_HOOK`, y conviene hacerlo **después** de cortar la cola vieja de validaciones
+- **Author:** Tanya Tree + Claude Opus 5
+
 ## 2026-09-08 — t1176 Sacar a un contacto de una campaña ya no deja agendas colgando
 
 - Cuando se sacaba a un contacto de una campaña (el borrado masivo por CSV), se borraba su estado de campaña pero **no sus agendas**: la llamada pendiente seguía apareciendo en la cola del vendedor para una campaña de la que el contacto ya no formaba parte. Peor: al resolverla, la consola marcaba la actividad como hecha **antes** de verificar el estado de campaña, así que el vendedor veía el error "el contacto ya no está en esta campaña" y la agenda quedaba cerrada igual, sin haber quedado registrada en ningún lado. Ahora el borrado masivo limpia también esas agendas, y la consola verifica primero y no toca nada si el contacto ya salió

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v0.5.1
 
+## 2026-09-08 — t1176 Sacar a un contacto de una campaña ya no deja agendas colgando
+
+- Cuando se sacaba a un contacto de una campaña (el borrado masivo por CSV), se borraba su estado de campaña pero **no sus agendas**: la llamada pendiente seguía apareciendo en la cola del vendedor para una campaña de la que el contacto ya no formaba parte. Peor: al resolverla, la consola marcaba la actividad como hecha **antes** de verificar el estado de campaña, así que el vendedor veía el error "el contacto ya no está en esta campaña" y la agenda quedaba cerrada igual, sin haber quedado registrada en ningún lado. Ahora el borrado masivo limpia también esas agendas, y la consola verifica primero y no toca nada si el contacto ya salió
+- La cola de agendas del vendedor deja fuera las actividades de contactos que ya no están en la campaña, así que las que quedaron de antes no se ofrecen más para trabajar
+- Se corrigió el error 500 al abrir una venta desde un link viejo de la consola (una pestaña abierta, el botón "atrás"): el link lleva el número del estado de campaña y, si ese estado ya fue borrado, la pantalla reventaba. Ahora avisa y vuelve a la lista de campañas. El mismo aviso existía para las agendas pero nunca se llegaba a mostrar, porque la respuesta se descartaba
+- Deployment: **no se requieren migraciones**
+- **Author:** Tanya Tree + Claude Opus 5
+
 ## 2026-09-04 — t1175 Cierre forzado de agendas perdidas
 
 - Las agendas viejas que nadie volvió a trabajar dejaban al contacto colgado para siempre: seguía en la cola del vendedor y, sobre todo, **quedaba bloqueado para todas las campañas activas**, porque tener una actividad pendiente lo saca de la cola de "no contactados" de cualquier campaña. Un comando nuevo las cierra en tanda, y el estado de campaña queda marcado con una resolución nueva, **"Finalizado por agenda perdida"**, para que se sepa que el cierre fue automático y no de un vendedor

--- a/core/models.py
+++ b/core/models.py
@@ -2627,6 +2627,16 @@ class Subscription(models.Model):
     def has_sales_record(self):
         return self.salesrecord_set.exists()
 
+    def is_free(self):
+        """
+        Whether nobody pays for this subscription: a gift or a staff one.
+
+        Same pair of types that `core.forms` already treats as free when it demands to know who asked
+        for it. Kept here so the criterion lives in one place: the sales record asks this to decide
+        that there is no payment method to report and no commission to pay.
+        """
+        return self.type in ("F", "S")
+
     def validate(self, user):
         self.validated = True
         self.validated_by = user

--- a/core/templatetags/core_tags.py
+++ b/core/templatetags/core_tags.py
@@ -148,3 +148,20 @@ def pending_email_takeovers():
         return EmailTakeoverRequest.objects.filter(status=EmailTakeoverRequest.PENDING).count()
     except Exception:
         return 0
+
+
+@register.simple_tag
+def pending_sales_records():
+    """
+    How many sales records are still waiting for a manager to validate them, for the sidebar badge.
+
+    Validation lives on the subscription (``Subscription.validated``), not on the sales record, so
+    this counts records whose subscription is still unvalidated. Same defensive shape as
+    ``pending_email_takeovers``: a badge is never a reason for a page not to render.
+    """
+    try:
+        from support.models import SalesRecord
+
+        return SalesRecord.objects.filter(subscription__validated=False).count()
+    except Exception:
+        return 0

--- a/core/utils.py
+++ b/core/utils.py
@@ -925,3 +925,29 @@ def api_log_entry(api_id, service_id, operation_id, request_data, response_data,
         logger.info(json.dumps(log_entry, ensure_ascii=False))
 
     return log_entry
+
+
+def run_subscription_validated_hook(subscription, user=None):
+    """
+    Notify the outside world that a subscription was just validated by a manager.
+
+    The base CRM has no opinion on what "validated" should trigger; installations do. la diaria uses
+    it to give the person reading rights on the website at that very moment instead of waiting for
+    the nightly batch, which is why the hook fires **on validation** and not when the subscription is
+    created: a sale that a manager has not looked at yet may still be a duplicate, and handing out
+    access before that is how the wrong web account gets the subscription.
+
+    Configured with ``SUBSCRIPTION_VALIDATED_HOOK``, a dotted path to a callable taking
+    ``(subscription, user)``. Never raises: the validation already happened and is the source of
+    truth, so a failure to propagate it is reported and swallowed.
+    """
+    hook_path = getattr(settings, "SUBSCRIPTION_VALIDATED_HOOK", None)
+    if not hook_path:
+        return None
+    try:
+        from django.utils.module_loading import import_string
+
+        return import_string(hook_path)(subscription, user)
+    except Exception:
+        logger.exception("SUBSCRIPTION_VALIDATED_HOOK failed for subscription %s", getattr(subscription, "id", None))
+        return None

--- a/docs/en/devnotes/2026-09-08-t1176-orphan-activities-when-leaving-a-campaign.md
+++ b/docs/en/devnotes/2026-09-08-t1176-orphan-activities-when-leaving-a-campaign.md
@@ -1,0 +1,222 @@
+# Orphan Activities and Stale Console Links When a Contact Leaves a Campaign
+
+- **Date:** 2026-09-08
+- **Author:** Tanya Tree + Claude Opus 5
+- **Ticket:** t1176
+- **Type:** Bug Fix
+- **Component:** Support — Campaign Management, Seller Console, Subscriptions
+- **Impact:** Data Integrity, Seller Console Queues, User Experience
+
+## 🎯 Summary
+
+`Activity` has a foreign key to `Campaign`, not to `ContactCampaignStatus`. Removing a contact from a
+campaign deletes the `ContactCampaignStatus` row and leaves every activity behind, still pointing at
+the campaign. Two unrelated-looking symptoms come from that single fact:
+
+1. A pending activity outlived its campaign status and kept showing up in the seller console `act`
+   queue. Worse, `handle_post_request` marked the activity as completed **before** checking the
+   campaign status, so resolving it produced the error message *"Contact is no longer in this
+   campaign"* **and** closed the activity anyway — a call that never happened, recorded as done, with
+   no follow-up scheduled.
+2. `LadiariaSubscriptionCreateView` raised a `DoesNotExist` (HTTP 500) whenever the console link
+   `?new=<ccs_id>` pointed at a deleted `ContactCampaignStatus` — a tab left open, a browser back
+   button. The `act` branch of `capture_variables()` handled that case with a message and a redirect,
+   but **no `dispatch` used the return value**, so that redirect was dead code and the view carried on
+   without `self.ccs`.
+
+The production traces that motivated the ticket: contact 31806 had two activities in campaign 297
+(*Mundo 2026*) with no campaign status, the pending one closed on 2026-08-28 by a request that
+aborted; and user `sofia.fernandez` hit the 500 on 2026-08-28 with `new=916086`, a status deleted a
+month earlier by the CSV bulk delete.
+
+## ✨ Changes
+
+### 1. Bulk delete removes the open activities too
+
+**File:** `support/views/campaign_management.py`
+
+`BulkDeleteCampaignStatusView` now deletes the still-open activities of the same contacts on the same
+campaign, inside the same transaction as the campaign statuses:
+
+```python
+with transaction.atomic():
+    deleted_activities, _unused = Activity.objects.filter(
+        contact_id__in=contact_ids,
+        campaign=campaign,
+        status__in=[ACTIVITY_STATUS.PENDING, ACTIVITY_STATUS.DELAYED],
+    ).delete()
+    deleted_count, _unused = ContactCampaignStatus.objects.filter(
+        contact_id__in=contact_ids, campaign=campaign
+    ).delete()
+```
+
+Only `PENDING` and `DELAYED` are removed: those represent calls that never happened. Completed
+activities are history and stay. This mirrors what `Contact.combine()` already does when merging
+contacts (`core/models.py`). The success message reports both counts.
+
+### 2. The seller console checks the campaign status first
+
+**File:** `support/views/seller_console.py`
+
+The existence check moved ahead of every write, right after the console action is resolved:
+
+```python
+if not ContactCampaignStatus.objects.filter(campaign=campaign, contact=contact).exists():
+    messages.error(self.request, _("Contact is no longer in this campaign"))
+    return HttpResponseRedirect(reverse("seller_console", args=[category, campaign.id]))
+```
+
+`process_activity_result()` still performs its own lookup afterwards — it needs the instance to
+update it — so the guarantee is not duplicated logic, it is ordering: nothing is written by a request
+that is going to abort.
+
+### 3. The `act` queue leaves orphans out
+
+**File:** `support/views/seller_console.py`
+
+`get_console_instances()` filters the pending activities by the existence of the campaign status, so
+the activities orphaned before this fix are no longer offered:
+
+```python
+still_in_campaign = ContactCampaignStatus.objects.filter(
+    campaign=campaign, contact=OuterRef("contact")
+)
+return (
+    activities.filter(Exists(still_in_campaign))
+    .select_related('seller_console_action')
+    .order_by("datetime", "id")
+)
+```
+
+The branch on `ALLOW_ACCESSING_FUTURE_ACTIVITIES_IN_SELLER_CONSOLE` was flattened into a single
+queryset while touching the method, so the filter is applied once instead of in each return.
+
+### 4. `capture_variables()` no longer trusts the link, and its callers honour it
+
+**Files:** `support/views/subscriptions.py`,
+`utopia-crm-ladiaria/utopia_crm_ladiaria/views/subscriptions.py`
+
+The `new` branch was doing a bare `get()`. It now behaves like the `act` branch:
+
+```python
+try:
+    self.ccs = ContactCampaignStatus.objects.get(pk=self.request.GET["new"])
+except ContactCampaignStatus.DoesNotExist:
+    messages.error(
+        self.request,
+        _("The contact is no longer in this campaign, instance number: {}").format(
+            self.request.GET["new"]
+        ),
+    )
+    return HttpResponseRedirect(reverse("seller_console_list_campaigns"))
+```
+
+The `act` branch got the same treatment for a deleted `Activity`, and both branches now read
+`self.ccs.seller_id` instead of `self.ccs.seller.id`, which raised `AttributeError` on a campaign
+status with no seller.
+
+The important half is the callers. Every `dispatch()` calling `capture_variables()` discarded its
+return value, so the redirects above would never have reached the browser:
+
+```python
+response = self.capture_variables()
+if response:
+    return response
+return super().dispatch(request, *args, **kwargs)
+```
+
+This applies to the two `dispatch` methods of `SubscriptionMixin`, the one in
+`CorporateSubscriptionCreateView`, the three in `utopia_crm_ladiaria`, and the ladiaria override of
+`capture_variables()` itself, which also swallowed the response from `super()`.
+
+## 📁 Files Modified
+
+- **`support/views/campaign_management.py`** — bulk delete also removes open activities; success
+  message reports the count
+- **`support/views/seller_console.py`** — campaign status checked before writing; `act` queue filtered
+  by `Exists`
+- **`support/views/subscriptions.py`** — `new` and `act` branches handle missing rows; `seller_id`
+  instead of `seller.id`; three `dispatch` methods honour the returned response
+- **`tests/test_seller_console.py`** — new `TestSellerConsoleContactRemovedFromCampaign`
+
+## 📚 Technical Details
+
+**Why the orphans went unnoticed for so long.** `BulkDeleteCampaignStatusView` has existed since
+2025-11-14, was disabled between 2026-03-19 and 2026-05-25, and only records a `LogEntry` per deleted
+row since t1147 (2026-05-25). Deletions before that date left no trace at all, which is why most
+orphan pairs cannot be explained from `django_admin_log`. The ones that can are recognisable by their
+`change_message`: *"Bulk delete via CSV by …"*.
+
+**Scale on the 2026-09-03 production dump.** 13,589 activities over 5,337 contacts and 251 campaigns
+had no matching campaign status. Restricted to activity in 2026: 2,042 contacts, of which 1,037 were
+left mid-gestion (last console action of type `SCHEDULED`, `CALL_LATER`, `NOT_FOUND` or `PENDING`)
+and have no active subscription — the list handed to the distribution team so those contacts can be
+put back into a campaign and called again. Only 8 activities were still pending and workable; 6
+survived to the day of the cleanup and were deleted in production.
+
+**Backward compatibility.** No model or schema change. The `Exists` filter is an extra `EXISTS`
+subquery on a queryset already filtered by campaign and seller, over the
+`(contact_id, campaign_id)` unique index of `ContactCampaignStatus`.
+
+## 🧪 Manual Testing
+
+1. **Bulk delete cleans the schedules (happy path):**
+   - Pick a campaign, and a contact in it with a pending scheduled call.
+   - Go to *Campaign Management → Bulk Delete Campaign Status*, upload a CSV with that `contact_id`
+     and select the campaign.
+   - **Verify:** the success message reports 1 campaign status and 1 activity deleted; the seller's
+     `act` queue for that campaign no longer offers the contact.
+
+2. **A contact removed from the campaign while a schedule is open (edge case):**
+   - Create a pending activity for a contact in a campaign, then delete the `ContactCampaignStatus`
+     directly from the admin (simulating the old data).
+   - Open the seller console `act` queue for that campaign.
+   - **Verify:** the contact is not listed. If the URL of the item is forced by hand and a result is
+     posted, the message *"Contact is no longer in this campaign"* appears **and** the activity is
+     still pending — not completed.
+
+3. **Stale console link to a sale (edge case):**
+   - Open the console `new` queue, copy a contact's "sell" link (`…/new_subscription/?new=<id>&…`).
+   - Delete that `ContactCampaignStatus`, then load the copied link.
+   - **Verify:** no 500. The page redirects to the campaign list with the message *"The contact is no
+     longer in this campaign, instance number: …"*.
+
+## 📝 Deployment Notes
+
+- No database migrations required.
+- No configuration changes.
+- Optional post-deployment cleanup, for pending activities orphaned before the fix:
+
+  ```sql
+  DELETE FROM core_activity a
+  USING (
+    SELECT a2.id FROM core_activity a2
+    LEFT JOIN core_contactcampaignstatus ccs
+           ON ccs.contact_id = a2.contact_id AND ccs.campaign_id = a2.campaign_id
+    WHERE a2.campaign_id IS NOT NULL AND a2.status = 'P' AND ccs.id IS NULL
+  ) h WHERE a.id = h.id;
+  ```
+
+  Run the `SELECT` on its own first: with the fix deployed this should return few or no rows.
+- The ladiaria package must be deployed together with the base app: the `dispatch` fix spans both.
+
+## 🚀 Future Improvements
+
+- The dashboard counters (`Seller.get_campaigns_with_activities()`, `campaign.pending`,
+  `total_pending_activities_count()`) still count orphan activities. They cannot be worked on, so a
+  campaign can appear in the list with a count the queue does not show. Worth aligning them with the
+  same `Exists` filter.
+- The seller console links carry `ContactCampaignStatus` and `Activity` primary keys in the
+  querystring. Any of those can go stale between rendering and clicking; a periodic revalidation, or
+  keying by contact and campaign instead, would remove a whole class of these errors.
+- `BulkDeleteCampaignStatusView` logs deletions of campaign statuses but not of activities. If the
+  audit trail matters for the activities too, they deserve their own `LogEntry`.
+
+---
+
+- **Date:** 2026-09-08
+- **Author:** Tanya Tree + Claude Opus 5
+- **Branch:** t1176
+- **Type:** Bug Fix
+- **Modules affected:** Support (Campaign Management, Seller Console, Subscriptions), Core (Activity,
+  ContactCampaignStatus)

--- a/docs/en/devnotes/2026-09-08-validating-a-sale-as-the-gate-for-web-activation.md
+++ b/docs/en/devnotes/2026-09-08-validating-a-sale-as-the-gate-for-web-activation.md
@@ -1,0 +1,218 @@
+# Validating a Sale as the Gate for Web Activation
+
+- **Date:** 2026-09-08
+- **Author:** Tanya Tree + Claude Opus 5
+- **Ticket:** branch `desync/validacion-y-activacion` (desync CRM ↔ CMS front, task 3)
+- **Type:** Feature (+ Bug Fix on free subscriptions and on the contact detail)
+- **Component:** Core — Subscriptions, Utils; Support — Sales Records, Validation views, Sidebar
+- **Impact:** Web Access Propagation, Commissions, Data Integrity, User Experience
+
+## 🎯 Summary
+
+A subscription created by the call center did not exist for the website until the nightly
+`activos.csv` batch ran: the person paid in the morning and kept hitting the paywall until the next
+day. The CRM already knows how to tell the CMS to activate a subscriber
+(`utopia_crm_ladiaria/services/activation.py`, in production since 2026-08-12, used by Witty), so
+what was missing was **when** to call it from a call-center sale.
+
+The answer this branch implements is **on validation, not on creation**. A freshly created sale may
+still be a duplicate — the same person with two web accounts, which is exactly what the deduplication
+queue resolves by hand — and handing out access before a human has looked at it gives it to the wrong
+web account half of the time. Validation is the moment a human already looked.
+
+Hanging web access off validation only works if the validation queue means something, and it did not:
+**every** subscription was born unvalidated, including the ones coming from the web, which have no
+seller, no commission and nothing a manager could possibly validate. The queue was a pile nobody
+read. So the branch also settles who carries a sales record and who is born validated, fixes what
+free subscriptions report, and makes the validation state reachable from the contact detail for every
+subscription type.
+
+## ✨ Changes
+
+### 1. A hook for what "validated" should trigger
+
+**Files:** `core/utils.py`, `support/views/all_views.py`
+
+The base CRM has no opinion on what validating a sale should propagate; installations do. The hook is
+a dotted path taking `(subscription, user)`:
+
+```python
+hook_path = getattr(settings, "SUBSCRIPTION_VALIDATED_HOOK", None)
+if not hook_path:
+    return None
+try:
+    from django.utils.module_loading import import_string
+
+    return import_string(hook_path)(subscription, user)
+except Exception:
+    logger.exception("SUBSCRIPTION_VALIDATED_HOOK failed for subscription %s", ...)
+    return None
+```
+
+It is called from `ValidateSubscriptionSalesRecord.form_valid()`, right after
+`subscription.validate(user=...)`. Two properties matter: **fail closed** — with no setting nothing
+happens at all — and **never raises**: the validation is already saved and is the source of truth, so
+a failure to propagate is logged and swallowed.
+
+### 2. Who is born validated, and who carries a sales record
+
+**Files:** `utopia-crm-ladiaria` (`utils.py`, `views/api.py`), documented here because it defines the
+queue this branch depends on
+
+Sales made on the web have no seller behind them, so there is nothing to validate: MercadoPago,
+Witty and the API promo are created with `validated=True` and no sales record. The two-month free
+digital subscription does carry one — with price 0 and the seller who gave it away — because somebody
+inside the CRM creates it.
+
+### 3. A validated subscription can still be commissioned
+
+**File:** `support/views/all_views.py`
+
+Being born validated should not close the door on commissioning: the real case is a seller who refers
+someone who then buys on their own. `SalesRecordCreateView` no longer re-validates an already
+validated subscription — doing so overwrote `validated_by`, and `NULL` there is precisely the mark
+that the system validated it. The button reads differently depending on the case: *Register Sale*
+when the sale is pending, *Commission a seller* when the subscription is validated and has no record.
+
+### 4. Free subscriptions report no payment method and pay no commission
+
+**Files:** `core/models.py`, `support/models.py`, `support/forms.py`,
+`support/templates/sales_record_filter.html`
+
+Gift and staff subscriptions are recorded as FULL sales, so the panel used to show them the
+subscription's payment method and compute a commission over a sale that moved no money. The criterion
+lives in one place, `Subscription.is_free()` — types `"F"` (gift) and `"S"` (staff), the same pair
+`core.forms` already treats as free — and `SalesRecord.is_free_subscription()` delegates to it.
+`get_payment_type`, `calculate_total_commission`, `calculate_commission` and `set_commissions` all
+read it; the last one writes 0 explicitly, so the stored value cannot drift from what the panel shows
+even when a manager forces the calculation while validating.
+
+On the validation screen the commission fields are **locked, not just hidden**:
+
+```python
+if self.instance and self.instance.pk and self.instance.is_free_subscription():
+    self.initial["can_be_commissioned"] = False
+    self.fields["can_be_commissioned"].disabled = True
+    self.fields["override_commission_value"].disabled = True
+```
+
+`disabled` makes Django ignore whatever arrives in the POST and keep the initial value, so a
+hand-made request cannot obtain a commission either. The initial has to be overridden on
+`self.initial`, which is where a `ModelForm` keeps the instance's own value.
+
+### 5. The validation state is visible for every subscription type
+
+**Files:** `support/templates/includes/_subscription_validation_actions.html` (new),
+`support/templates/includes/_overview_subscription_list_item.html`
+
+The validation block lived inside the `else` branch of an `if` on `subscription.type`, so only normal
+subscriptions showed it. That became wrong when free subscriptions started carrying sales records:
+they enter the queue and the badge, but there was no way to validate them from the contact detail (in
+the local database, 724 gifts and 3,650 promos with a sales record, all invisible from there). The
+block moved to its own include, used from the three branches instead of being repeated, and it now
+decides on `Subscription.is_free()` whether commissioning applies — staff subscriptions used to fall
+into the "normal" branch and were offered a commission they cannot pay.
+
+The fourth case — validated **and** with a record — showed nothing at all, so "everything is in
+order" looked exactly like "nothing was loaded". It now shows a *Validated* badge with who and when
+in the tooltip, or "by the system" when `validated_by` is `NULL`.
+
+### 6. Sales Records moved to the main sidebar, with a pending count
+
+**Files:** `templates/components/_sidebar.html`,
+`templates/components/sidebar_items/_campaign_management.html`, `core/templatetags/core_tags.py`
+
+The queue stops being a campaign-management item and becomes a top-level entry for Managers, with a
+badge. Validation lives on the subscription, not on the record, so the tag counts records whose
+subscription is still unvalidated, and it is defensive in the same shape as `pending_email_takeovers`:
+a badge is never a reason for a page not to render.
+
+## 📁 Files Modified
+
+- **`core/utils.py`** — `run_subscription_validated_hook()`
+- **`core/models.py`** — `Subscription.is_free()`
+- **`core/templatetags/core_tags.py`** — `pending_sales_records()`
+- **`support/models.py`** — `SalesRecord.is_free_subscription()` delegates to `Subscription.is_free()`;
+  payment type and commissions honour it
+- **`support/forms.py`** — commission fields locked for free subscriptions
+- **`support/views/all_views.py`** — hook call on validation; no re-validation when commissioning
+- **`support/views/subscriptions.py`** — validation state in the subscription context
+- **`support/templates/…`** — validation actions include, sales record filter tooltip, validation
+  screen
+- **`templates/components/…`** — sidebar entry and badge
+- **`tests/test_subscription_validation.py`** — new suite
+
+## 📚 Technical Details
+
+**Why the hook and not a signal.** A `post_save` on `Subscription` would fire on every save, and
+validation is one specific transition made by one specific view. The hook is called exactly where the
+transition happens, receives the user who made it, and is configured per installation — the base app
+ships no behaviour at all.
+
+**Subscriptions with a future start date.** The la diaria implementation does not propagate them: the
+`plan_id` the CMS receives is built by the same serializer the nightly CSV uses, which filters
+`start_date__lte=today`, so a future subscription would push an empty `plan_id` — worse than not
+telling. The batch of the night it starts picks it up, which is what already happens today.
+
+**The old queue.** Before this branch, production had ~126,650 unvalidated subscriptions, of which
+only ~8,700 carried a sales record. The ladiaria package adds
+`validate_historic_subscriptions` to cut that queue by date; see its devnote.
+
+## 🧪 Manual Testing
+
+1. **Validating a call-center sale (happy path):**
+   - With `SUBSCRIPTION_VALIDATED_HOOK` configured, open *Sales Records*, pick a pending sale and
+     validate it.
+   - **Verify:** the success message appears, the subscription shows as validated with your user, and
+     the configured hook ran (in la diaria, the person can read on the website immediately).
+
+2. **The hook is not configured (edge case):**
+   - Remove `SUBSCRIPTION_VALIDATED_HOOK` from settings and validate a sale.
+   - **Verify:** validation is saved normally and nothing is propagated — no error, no traceback.
+
+3. **A gift subscription (edge case):**
+   - Create a gift subscription (`type="F"`) from the contact detail, then open its validation screen.
+   - **Verify:** the commission fields are disabled; the panel shows N/A as payment method and 0 as
+     commission. Posting the form by hand with `can_be_commissioned=on` still results in no
+     commission.
+
+4. **Commissioning a web sale (edge case):**
+   - Take a subscription created from the web (born validated, no sales record) and use
+     *Commission a seller* from the contact detail.
+   - **Verify:** the sales record is created with the seller and the commission, and `validated_by`
+     stays `NULL` — the *Validated* badge keeps reading "by the system".
+
+## 📝 Deployment Notes
+
+- No database migrations required.
+- Deploy together with the `utopia-crm-ladiaria` branch of the same name.
+- **Post-deployment order matters.** First cut the old queue with
+  `validate_historic_subscriptions` (ladiaria; dry run, then `--fix`), and only then configure the
+  hook in production:
+
+  ```python
+  SUBSCRIPTION_VALIDATED_HOOK = "utopia_crm_ladiaria.services.activation.activate_on_validation"
+  ```
+
+  Not for technical risk, but because the day it is switched on every validation starts granting real
+  web access — better over a small, real queue than over the ~8,700 of backlog.
+- The rest of the activation settings (`WEB_ACTIVATE_SUBSCRIBER_URI` / `_ENABLED`, and the POST
+  whitelist) are already in place in production, and the CMS endpoint has been live since 2026-08-17.
+
+## 🚀 Future Improvements
+
+- The CMS → CRM direction of the instant sync is still pending (task 3 of the front).
+- Activation on approving a deduplication request: the code exists, the call from the queue's
+  *Approve* branch does not. The order is not negotiable — takeover, then apply the email, then
+  activate — or the CMS answers `409 contact_id_conflict`.
+- Nothing tells the manager, on the validation screen, whether the web activation actually worked.
+  A note on the sales record, or a status on the subscription, would save a trip to the logs.
+
+---
+
+- **Date:** 2026-09-08
+- **Author:** Tanya Tree + Claude Opus 5
+- **Branch:** desync/validacion-y-activacion
+- **Type:** Feature (+ Bug Fix)
+- **Modules affected:** Core (Subscriptions, Utils, Template tags), Support (Sales Records,
+  Validation, Sidebar)

--- a/docs/es/devnotes/2026-09-08-t1176-actividades-huerfanas-al-salir-de-una-campania.md
+++ b/docs/es/devnotes/2026-09-08-t1176-actividades-huerfanas-al-salir-de-una-campania.md
@@ -1,0 +1,228 @@
+# Actividades huérfanas y links viejos de consola cuando un contacto sale de una campaña
+
+- **Fecha:** 2026-09-08
+- **Autor:** Tanya Tree + Claude Opus 5
+- **Ticket:** t1176
+- **Tipo:** Bug Fix
+- **Componente:** Support — Campaign Management, Consola de vendedores, Suscripciones
+- **Impacto:** Integridad de datos, colas de la consola de vendedores, experiencia de usuario
+
+## 🎯 Resumen
+
+`Activity` tiene una foreign key a `Campaign`, no a `ContactCampaignStatus`. Sacar un contacto de una
+campaña borra la fila de `ContactCampaignStatus` y deja todas sus actividades atrás, apuntando
+igual a la campaña. De ese único hecho salen dos síntomas que parecían no tener relación:
+
+1. Una actividad pendiente sobrevivía a su estado de campaña y seguía apareciendo en la cola `act` de
+   la consola. Peor: `handle_post_request` marcaba la actividad como completada **antes** de
+   verificar el estado de campaña, así que resolverla producía el mensaje de error *"Contact is no
+   longer in this campaign"* **y** además cerraba la actividad — una llamada que nunca ocurrió,
+   registrada como hecha y sin agenda nueva.
+2. `LadiariaSubscriptionCreateView` levantaba un `DoesNotExist` (HTTP 500) cada vez que el link de
+   consola `?new=<ccs_id>` apuntaba a un `ContactCampaignStatus` borrado — una pestaña abierta, el
+   botón "atrás" del navegador. La rama `act` de `capture_variables()` manejaba ese caso con un
+   mensaje y un redirect, pero **ningún `dispatch` usaba el valor de retorno**, así que ese redirect
+   era código muerto y la vista seguía adelante sin `self.ccs`.
+
+Los rastros de producción que motivaron el ticket: el contacto 31806 tenía dos actividades en la
+campaña 297 (*Mundo 2026*) sin estado de campaña, con la pendiente cerrada el 2026-08-28 por un
+request que abortó; y la usuaria `sofia.fernandez` se topó con el 500 el 2026-08-28 con
+`new=916086`, un estado borrado un mes antes por el borrado masivo por CSV.
+
+## ✨ Cambios
+
+### 1. El borrado masivo también se lleva las actividades abiertas
+
+**Archivo:** `support/views/campaign_management.py`
+
+`BulkDeleteCampaignStatusView` ahora borra las actividades todavía abiertas de esos mismos contactos
+en esa misma campaña, dentro de la misma transacción que los estados de campaña:
+
+```python
+with transaction.atomic():
+    deleted_activities, _unused = Activity.objects.filter(
+        contact_id__in=contact_ids,
+        campaign=campaign,
+        status__in=[ACTIVITY_STATUS.PENDING, ACTIVITY_STATUS.DELAYED],
+    ).delete()
+    deleted_count, _unused = ContactCampaignStatus.objects.filter(
+        contact_id__in=contact_ids, campaign=campaign
+    ).delete()
+```
+
+Sólo se borran `PENDING` y `DELAYED`: son llamadas que nunca ocurrieron. Las completadas son historia
+y quedan. Es lo mismo que ya hace `Contact.combine()` al fusionar contactos (`core/models.py`). El
+mensaje de éxito informa los dos números.
+
+### 2. La consola de vendedores verifica el estado de campaña primero
+
+**Archivo:** `support/views/seller_console.py`
+
+La verificación de existencia se movió antes de cualquier escritura, justo después de resolver la
+acción de consola:
+
+```python
+if not ContactCampaignStatus.objects.filter(campaign=campaign, contact=contact).exists():
+    messages.error(self.request, _("Contact is no longer in this campaign"))
+    return HttpResponseRedirect(reverse("seller_console", args=[category, campaign.id]))
+```
+
+`process_activity_result()` sigue haciendo su propia búsqueda después — necesita la instancia para
+actualizarla —, así que la garantía no es lógica duplicada sino orden: nada se escribe en un request
+que va a abortar.
+
+### 3. La cola `act` deja afuera a las huérfanas
+
+**Archivo:** `support/views/seller_console.py`
+
+`get_console_instances()` filtra las actividades pendientes por la existencia del estado de campaña,
+de modo que las que quedaron huérfanas antes de este arreglo ya no se ofrecen:
+
+```python
+still_in_campaign = ContactCampaignStatus.objects.filter(
+    campaign=campaign, contact=OuterRef("contact")
+)
+return (
+    activities.filter(Exists(still_in_campaign))
+    .select_related('seller_console_action')
+    .order_by("datetime", "id")
+)
+```
+
+De paso, la bifurcación por `ALLOW_ACCESSING_FUTURE_ACTIVITIES_IN_SELLER_CONSOLE` se aplanó en un
+solo queryset, así el filtro se aplica una vez y no en cada return.
+
+### 4. `capture_variables()` deja de confiar en el link, y quien lo llama lo respeta
+
+**Archivos:** `support/views/subscriptions.py`,
+`utopia-crm-ladiaria/utopia_crm_ladiaria/views/subscriptions.py`
+
+La rama `new` hacía un `get()` pelado. Ahora se comporta como la rama `act`:
+
+```python
+try:
+    self.ccs = ContactCampaignStatus.objects.get(pk=self.request.GET["new"])
+except ContactCampaignStatus.DoesNotExist:
+    messages.error(
+        self.request,
+        _("The contact is no longer in this campaign, instance number: {}").format(
+            self.request.GET["new"]
+        ),
+    )
+    return HttpResponseRedirect(reverse("seller_console_list_campaigns"))
+```
+
+La rama `act` recibió el mismo tratamiento para una `Activity` borrada, y las dos ramas ahora leen
+`self.ccs.seller_id` en lugar de `self.ccs.seller.id`, que levantaba `AttributeError` cuando el
+estado de campaña no tenía vendedor.
+
+La mitad importante es quien llama. Todos los `dispatch()` que invocaban `capture_variables()`
+descartaban su valor de retorno, así que los redirects de arriba nunca habrían llegado al navegador:
+
+```python
+response = self.capture_variables()
+if response:
+    return response
+return super().dispatch(request, *args, **kwargs)
+```
+
+Esto aplica a los dos `dispatch` de `SubscriptionMixin`, al de `CorporateSubscriptionCreateView`, a
+los tres de `utopia_crm_ladiaria` y al override ladiaria de `capture_variables()`, que también se
+tragaba la respuesta de `super()`.
+
+## 📁 Archivos modificados
+
+- **`support/views/campaign_management.py`** — el borrado masivo también elimina las actividades
+  abiertas; el mensaje de éxito informa la cantidad
+- **`support/views/seller_console.py`** — se verifica el estado de campaña antes de escribir; la cola
+  `act` se filtra con `Exists`
+- **`support/views/subscriptions.py`** — las ramas `new` y `act` manejan las filas faltantes;
+  `seller_id` en vez de `seller.id`; tres `dispatch` respetan la respuesta devuelta
+- **`tests/test_seller_console.py`** — nueva `TestSellerConsoleContactRemovedFromCampaign`
+
+## 📚 Detalles técnicos
+
+**Por qué las huérfanas pasaron desapercibidas tanto tiempo.** `BulkDeleteCampaignStatusView` existe
+desde el 2025-11-14, estuvo deshabilitada entre el 2026-03-19 y el 2026-05-25, y sólo registra un
+`LogEntry` por fila borrada desde t1147 (2026-05-25). Los borrados anteriores a esa fecha no dejaron
+ningún rastro, y por eso la mayoría de los pares huérfanos no se pueden explicar desde
+`django_admin_log`. Los que sí se pueden se reconocen por su `change_message`: *"Bulk delete via CSV
+by …"*.
+
+**Escala sobre el dump de producción del 2026-09-03.** 13.589 actividades sobre 5.337 contactos y 251
+campañas no tenían estado de campaña asociado. Restringido a actividad en 2026: 2.042 contactos, de
+los cuales 1.037 quedaron con la gestión por la mitad (última acción de consola de tipo `SCHEDULED`,
+`CALL_LATER`, `NOT_FOUND` o `PENDING`) y sin suscripción activa — el listado que se le pasó al área
+de distribución para volver a subirlos a una campaña y llamarlos de nuevo. Sólo 8 actividades seguían
+pendientes y trabajables; 6 sobrevivieron hasta el día de la limpieza y se borraron en producción.
+
+**Compatibilidad hacia atrás.** No hay cambios de modelo ni de esquema. El filtro `Exists` agrega una
+subconsulta `EXISTS` sobre un queryset ya filtrado por campaña y vendedor, apoyada en el índice único
+`(contact_id, campaign_id)` de `ContactCampaignStatus`.
+
+## 🧪 Pruebas manuales
+
+1. **El borrado masivo limpia las agendas (camino feliz):**
+   - Elegir una campaña y un contacto que esté en ella con una llamada agendada pendiente.
+   - Ir a *Campaign Management → Bulk Delete Campaign Status*, subir un CSV con ese `contact_id` y
+     seleccionar la campaña.
+   - **Verificar:** el mensaje de éxito informa 1 estado de campaña y 1 actividad borrados; la cola
+     `act` del vendedor para esa campaña ya no ofrece el contacto.
+
+2. **Contacto sacado de la campaña con una agenda abierta (caso borde):**
+   - Crear una actividad pendiente para un contacto en una campaña y después borrar el
+     `ContactCampaignStatus` directamente desde el admin (simulando los datos viejos).
+   - Abrir la cola `act` de la consola para esa campaña.
+   - **Verificar:** el contacto no aparece. Si se fuerza la URL del ítem a mano y se envía un
+     resultado, aparece el mensaje *"Contact is no longer in this campaign"* **y** la actividad sigue
+     pendiente, no completada.
+
+3. **Link viejo de la consola hacia una venta (caso borde):**
+   - Abrir la cola `new` de la consola y copiar el link de "vender" de un contacto
+     (`…/new_subscription/?new=<id>&…`).
+   - Borrar ese `ContactCampaignStatus` y después cargar el link copiado.
+   - **Verificar:** no hay 500. La página redirige a la lista de campañas con el mensaje *"The contact
+     is no longer in this campaign, instance number: …"*.
+
+## 📝 Notas de despliegue
+
+- No se requieren migraciones.
+- No hay cambios de configuración.
+- Limpieza posterior opcional, para las actividades pendientes que quedaron huérfanas antes del
+  arreglo:
+
+  ```sql
+  DELETE FROM core_activity a
+  USING (
+    SELECT a2.id FROM core_activity a2
+    LEFT JOIN core_contactcampaignstatus ccs
+           ON ccs.contact_id = a2.contact_id AND ccs.campaign_id = a2.campaign_id
+    WHERE a2.campaign_id IS NOT NULL AND a2.status = 'P' AND ccs.id IS NULL
+  ) h WHERE a.id = h.id;
+  ```
+
+  Correr primero el `SELECT` solo: con el arreglo desplegado debería devolver pocas filas o ninguna.
+- El paquete ladiaria tiene que desplegarse junto con la app base: el arreglo de los `dispatch`
+  abarca los dos.
+
+## 🚀 Mejoras futuras
+
+- Los contadores del dashboard (`Seller.get_campaigns_with_activities()`, `campaign.pending`,
+  `total_pending_activities_count()`) siguen contando actividades huérfanas. No se pueden trabajar,
+  así que una campaña puede aparecer en la lista con un número que la cola no muestra. Convendría
+  alinearlos con el mismo filtro `Exists`.
+- Los links de la consola llevan las claves primarias de `ContactCampaignStatus` y `Activity` en el
+  querystring. Cualquiera de las dos puede quedar vieja entre que se renderiza y se hace clic; una
+  revalidación periódica, o direccionar por contacto y campaña en lugar de por id, eliminaría toda
+  una clase de estos errores.
+- `BulkDeleteCampaignStatusView` registra el borrado de los estados de campaña pero no el de las
+  actividades. Si la trazabilidad importa también para las actividades, merecen su propio `LogEntry`.
+
+---
+
+- **Fecha:** 2026-09-08
+- **Autor:** Tanya Tree + Claude Opus 5
+- **Rama:** t1176
+- **Tipo:** Bug Fix
+- **Módulos afectados:** Support (Campaign Management, Consola de vendedores, Suscripciones), Core
+  (Activity, ContactCampaignStatus)

--- a/docs/es/devnotes/2026-09-08-validar-la-venta-como-puerta-de-la-activacion-web.md
+++ b/docs/es/devnotes/2026-09-08-validar-la-venta-como-puerta-de-la-activacion-web.md
@@ -1,0 +1,219 @@
+# Validar la venta como puerta de la activación en la web
+
+- **Fecha:** 2026-09-08
+- **Autor:** Tanya Tree + Claude Opus 5
+- **Ticket:** rama `desync/validacion-y-activacion` (frente desync CRM ↔ CMS, tarea 3)
+- **Tipo:** Nueva funcionalidad (+ correcciones en suscripciones gratuitas y en el detalle del contacto)
+- **Componente:** Core — Suscripciones, Utils; Support — Registros de venta, vistas de validación, sidebar
+- **Impacto:** Propagación del acceso web, comisiones, integridad de datos, experiencia de usuario
+
+## 🎯 Resumen
+
+Una suscripción creada por el call center no existía para el sitio hasta que corría el batch nocturno
+de `activos.csv`: la persona pagaba a la mañana y seguía chocando con el paywall hasta el día
+siguiente. El CRM ya sabe pedirle al CMS que active a un suscriptor
+(`utopia_crm_ladiaria/services/activation.py`, en producción desde el 2026-08-12, lo usa Witty), así
+que lo que faltaba era **cuándo** llamarlo desde una venta de call center.
+
+La respuesta que implementa esta rama es **en la validación, no en el alta**. Una venta recién hecha
+todavía puede ser un duplicado —la misma persona con dos cuentas web, que es justo lo que la cola de
+desduplicación resuelve a mano—, y dar el acceso antes de que un humano la haya mirado se lo da, la
+mitad de las veces, a la cuenta equivocada. La validación es el momento en que alguien ya miró.
+
+Colgar el acceso web de la validación sólo sirve si la cola de validación significa algo, y no
+significaba nada: **toda** suscripción nacía sin validar, incluidas las que entran por la web, que no
+tienen vendedor, ni comisión, ni nada que un manager pueda validar. La cola era una pila que nadie
+leía. Por eso la rama además ordena quién lleva registro de venta y quién nace validada, corrige qué
+reportan las gratuitas y hace visible el estado de validación desde la ficha del contacto para todos
+los tipos de suscripción.
+
+## ✨ Cambios
+
+### 1. Un gancho para lo que "validado" tiene que disparar
+
+**Archivos:** `core/utils.py`, `support/views/all_views.py`
+
+El CRM base no tiene opinión sobre qué debería propagar validar una venta; las instalaciones sí. El
+gancho es una ruta punteada a un callable que recibe `(subscription, user)`:
+
+```python
+hook_path = getattr(settings, "SUBSCRIPTION_VALIDATED_HOOK", None)
+if not hook_path:
+    return None
+try:
+    from django.utils.module_loading import import_string
+
+    return import_string(hook_path)(subscription, user)
+except Exception:
+    logger.exception("SUBSCRIPTION_VALIDATED_HOOK failed for subscription %s", ...)
+    return None
+```
+
+Se llama desde `ValidateSubscriptionSalesRecord.form_valid()`, justo después de
+`subscription.validate(user=...)`. Importan dos propiedades: **falla cerrado** —sin el setting no pasa
+absolutamente nada— y **nunca levanta excepción**: la validación ya está guardada y es la fuente de
+verdad, así que no poder propagarla se loguea y se sigue.
+
+### 2. Quién nace validada y quién lleva registro de venta
+
+**Archivos:** `utopia-crm-ladiaria` (`utils.py`, `views/api.py`), documentado acá porque define la
+cola de la que depende esta rama
+
+Las ventas que entran por la web no tienen vendedor detrás, así que no hay nada que validar:
+MercadoPago, Witty y la promo por API se crean con `validated=True` y sin registro de venta. La
+digital gratis de dos meses sí lo lleva —con precio 0 y el vendedor que la regaló—, porque la da de
+alta alguien desde el CRM.
+
+### 3. Una suscripción validada igual se puede comisionar
+
+**Archivo:** `support/views/all_views.py`
+
+Nacer validada no debería cerrar la puerta a comisionar: el caso real es el vendedor que refiere a
+una persona que después compra sola. `SalesRecordCreateView` ya no revalida una suscripción que ya
+estaba validada — hacerlo pisaba `validated_by`, y `NULL` ahí es justamente la marca de que la validó
+el sistema. El botón se llama distinto según el caso: *Registrar venta* cuando la venta está
+pendiente, *Comisionar vendedor* cuando la suscripción ya está validada y no tiene registro.
+
+### 4. Las gratuitas no reportan forma de pago ni pagan comisión
+
+**Archivos:** `core/models.py`, `support/models.py`, `support/forms.py`,
+`support/templates/sales_record_filter.html`
+
+Los obsequios y las de staff se registran como venta FULL, así que el panel les mostraba la forma de
+pago de la suscripción y les calculaba comisión sobre una venta que no movió plata. El criterio vive
+en un solo lugar, `Subscription.is_free()` —tipos `"F"` (obsequio) y `"S"` (staff), el mismo par que
+`core.forms` ya trata como gratuito—, y `SalesRecord.is_free_subscription()` le delega.
+`get_payment_type`, `calculate_total_commission`, `calculate_commission` y `set_commissions` lo leen;
+este último escribe 0 explícitamente, para que el valor guardado no pueda alejarse de lo que muestra
+el panel ni cuando un manager fuerza el cálculo al validar.
+
+En la pantalla de validación los campos de comisión quedan **bloqueados, no sólo ocultos**:
+
+```python
+if self.instance and self.instance.pk and self.instance.is_free_subscription():
+    self.initial["can_be_commissioned"] = False
+    self.fields["can_be_commissioned"].disabled = True
+    self.fields["override_commission_value"].disabled = True
+```
+
+`disabled` hace que Django ignore lo que venga en el POST y conserve el valor inicial, así que un
+pedido armado a mano tampoco consigue comisión. El inicial hay que pisarlo en `self.initial`, que es
+donde un `ModelForm` guarda el valor propio de la instancia.
+
+### 5. El estado de validación se ve en todos los tipos de suscripción
+
+**Archivos:** `support/templates/includes/_subscription_validation_actions.html` (nuevo),
+`support/templates/includes/_overview_subscription_list_item.html`
+
+El bloque de validación vivía dentro de la rama `else` de un `if` por `subscription.type`, así que
+sólo lo veían las normales. Eso quedó mal cuando las gratuitas pasaron a llevar registro de venta:
+entran en la cola y en el badge, pero desde el detalle del contacto no había cómo validarlas (en la
+base local son 724 obsequios y 3.650 promos con registro de venta, todas invisibles desde ahí). El
+bloque salió a un include propio, usado desde las tres ramas en vez de repetirse, y ahora decide con
+`Subscription.is_free()` si corresponde comisionar — las de staff caían en la rama de las normales y
+les aparecía una comisión que no pueden pagar.
+
+El cuarto caso —validada **y** con registro— no mostraba nada, así que "está todo en orden" se veía
+igual que "no se cargó nada". Ahora muestra una chapita *Validada* con quién y cuándo en el tooltip, o
+"por el sistema" cuando `validated_by` es `NULL`.
+
+### 6. Registros de ventas pasa al menú principal, con el pendiente al lado
+
+**Archivos:** `templates/components/_sidebar.html`,
+`templates/components/sidebar_items/_campaign_management.html`, `core/templatetags/core_tags.py`
+
+La cola deja de ser un ítem de gestión de campañas y pasa a ser una entrada de primer nivel para
+Managers, con un badge. La validación vive en la suscripción y no en el registro, así que el tag
+cuenta los registros cuya suscripción sigue sin validar, y es defensivo con la misma forma que
+`pending_email_takeovers`: un badge nunca es motivo para que una página no renderice.
+
+## 📁 Archivos modificados
+
+- **`core/utils.py`** — `run_subscription_validated_hook()`
+- **`core/models.py`** — `Subscription.is_free()`
+- **`core/templatetags/core_tags.py`** — `pending_sales_records()`
+- **`support/models.py`** — `SalesRecord.is_free_subscription()` delega en `Subscription.is_free()`;
+  forma de pago y comisiones lo respetan
+- **`support/forms.py`** — campos de comisión bloqueados para las gratuitas
+- **`support/views/all_views.py`** — llamada al gancho al validar; no se revalida al comisionar
+- **`support/views/subscriptions.py`** — estado de validación en el contexto de la suscripción
+- **`support/templates/…`** — include de acciones de validación, tooltip del panel, pantalla de
+  validación
+- **`templates/components/…`** — entrada de sidebar y badge
+- **`tests/test_subscription_validation.py`** — suite nueva
+
+## 📚 Detalles técnicos
+
+**Por qué un gancho y no una señal.** Un `post_save` sobre `Subscription` se dispararía en cada save,
+y la validación es una transición puntual hecha por una vista puntual. El gancho se llama exactamente
+donde ocurre la transición, recibe al usuario que la hizo y se configura por instalación — la app base
+no trae ningún comportamiento.
+
+**Suscripciones con fecha de inicio futura.** La implementación de ladiaria no las propaga: el
+`plan_id` que recibe el CMS lo arma el mismo serializador que usa el CSV nocturno, que filtra
+`start_date__lte=hoy`, así que una suscripción futura empujaría un `plan_id` vacío — peor que no
+avisar. La levanta el batch de la noche en que arranca, que es lo que ya pasa hoy.
+
+**La cola vieja.** Antes de esta rama, producción tenía ~126.650 suscripciones sin validar, de las que
+sólo ~8.700 llevaban registro de venta. El paquete ladiaria agrega
+`validate_historic_subscriptions` para cortar esa cola por fecha; ver su devnote.
+
+## 🧪 Pruebas manuales
+
+1. **Validar una venta de call center (camino feliz):**
+   - Con `SUBSCRIPTION_VALIDATED_HOOK` configurado, abrir *Registros de ventas*, elegir una venta
+     pendiente y validarla.
+   - **Verificar:** aparece el mensaje de éxito, la suscripción queda validada con tu usuario y el
+     gancho configurado corrió (en la diaria, la persona puede leer en el sitio al instante).
+
+2. **El gancho no está configurado (caso borde):**
+   - Sacar `SUBSCRIPTION_VALIDATED_HOOK` de los settings y validar una venta.
+   - **Verificar:** la validación se guarda normalmente y no se propaga nada — sin error ni traceback.
+
+3. **Una suscripción de obsequio (caso borde):**
+   - Crear un obsequio (`type="F"`) desde el detalle del contacto y abrir su pantalla de validación.
+   - **Verificar:** los campos de comisión están deshabilitados; el panel muestra N/A como forma de
+     pago y 0 de comisión. Enviar el formulario a mano con `can_be_commissioned=on` tampoco genera
+     comisión.
+
+4. **Comisionar una venta web (caso borde):**
+   - Tomar una suscripción creada desde la web (nace validada, sin registro de venta) y usar
+     *Comisionar vendedor* desde el detalle del contacto.
+   - **Verificar:** se crea el registro con el vendedor y la comisión, y `validated_by` sigue en
+     `NULL` — la chapita *Validada* sigue diciendo "por el sistema".
+
+## 📝 Notas de despliegue
+
+- No se requieren migraciones.
+- Desplegar junto con la rama del mismo nombre de `utopia-crm-ladiaria`.
+- **El orden posterior al deploy importa.** Primero cortar la cola vieja con
+  `validate_historic_subscriptions` (ladiaria; primero en seco, después `--fix`), y recién entonces
+  configurar el gancho en producción:
+
+  ```python
+  SUBSCRIPTION_VALIDATED_HOOK = "utopia_crm_ladiaria.services.activation.activate_on_validation"
+  ```
+
+  No por riesgo técnico, sino porque el día que se prenda cada validación empieza a dar acceso web de
+  verdad — mejor que arranque sobre una cola chica y real que sobre las ~8.700 de arrastre.
+- El resto de la configuración de activación (`WEB_ACTIVATE_SUBSCRIBER_URI` / `_ENABLED`, y la
+  whitelist de POST) ya está puesta en producción, y el endpoint del CMS está vivo desde el
+  2026-08-17.
+
+## 🚀 Mejoras futuras
+
+- Falta la dirección CMS → CRM de la sincronización instantánea (tarea 3 del frente).
+- La activación al aprobar un pedido de desduplicación: el código existe, la llamada desde la rama
+  *Aprobar* de la cola no. El orden no es negociable —takeover, aplicar el email, activar— o el CMS
+  responde `409 contact_id_conflict`.
+- Nada le dice al manager, en la pantalla de validación, si la activación web funcionó de verdad. Una
+  nota en el registro de venta, o un estado en la suscripción, ahorraría el viaje a los logs.
+
+---
+
+- **Fecha:** 2026-09-08
+- **Autor:** Tanya Tree + Claude Opus 5
+- **Rama:** desync/validacion-y-activacion
+- **Tipo:** Nueva funcionalidad (+ correcciones)
+- **Módulos afectados:** Core (Suscripciones, Utils, Template tags), Support (Registros de venta,
+  Validación, Sidebar)

--- a/support/forms.py
+++ b/support/forms.py
@@ -904,6 +904,18 @@ class ValidateSubscriptionForm(forms.ModelForm):
             "can_be_commissioned": forms.CheckboxInput(attrs={"class": "form-check-input"}),
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and self.instance.pk and self.instance.is_free_subscription():
+            # A gift or staff subscription has no money behind it, so there is nothing to commission.
+            # The fields are locked rather than merely hidden: `disabled` makes Django ignore whatever
+            # arrives in the POST and keep the initial value, so a hand-made request cannot set them
+            # either. The initial has to be overridden on `self.initial` — for a ModelForm that is
+            # where the instance's own value (`can_be_commissioned` defaults to True) lives.
+            self.initial["can_be_commissioned"] = False
+            self.fields["can_be_commissioned"].disabled = True
+            self.fields["override_commission_value"].disabled = True
+
 
 class SalesRecordCreateForm(forms.ModelForm):
     override_commission_value = forms.IntegerField(

--- a/support/models.py
+++ b/support/models.py
@@ -624,7 +624,7 @@ class SalesRecord(models.Model):
         to report and no commission to pay, so both read as N/A and 0, the same way a partial sale
         already does.
         """
-        return bool(self.subscription and self.subscription.type in ("F", "S"))
+        return bool(self.subscription and self.subscription.is_free())
 
     def set_commissions(self, force=False) -> None:
         if self.is_free_subscription():

--- a/support/models.py
+++ b/support/models.py
@@ -615,7 +615,25 @@ class SalesRecord(models.Model):
                 return 0
             self.commission_for_subscription_frequency = 0
 
+    def is_free_subscription(self):
+        """
+        Whether there is no money behind this record: a gift or staff subscription.
+
+        Those still get a sales record — somebody inside the CRM created the subscription and a
+        manager has to validate it before the reader is activated — but there is no payment method
+        to report and no commission to pay, so both read as N/A and 0, the same way a partial sale
+        already does.
+        """
+        return bool(self.subscription and self.subscription.type in ("F", "S"))
+
     def set_commissions(self, force=False) -> None:
+        if self.is_free_subscription():
+            # Nothing to commission, not even when a manager forces the calculation at validation
+            # time. Written explicitly (instead of just skipping) so the stored value can never drift
+            # away from what the panel shows.
+            self.total_commission_value = 0
+            self.save()
+            return
         if (force or self.sale_type == self.SALE_TYPE.FULL) and self.can_be_commissioned:
             self.calculate_products_count_commission()
             self.calculate_payment_type_commission()
@@ -637,12 +655,16 @@ class SalesRecord(models.Model):
         return False
 
     def get_payment_type(self):
-        if self.sale_type == self.SALE_TYPE.FULL:
+        if self.sale_type == self.SALE_TYPE.FULL and not self.is_free_subscription():
             return self.subscription.get_payment_type_display()
         else:
             return _("N/A")
 
     def calculate_commission(self):
+        if self.is_free_subscription():
+            # Showing the breakdown here would read as "0 (None) + 150 (2 products) + ... = 0": each
+            # component computed on its own, none of them applicable. Say why instead.
+            return _("Free subscription: no commission")
         # Show all commission components in separate lines with labels
         payment_type_commission = (
             f"{self.calculate_payment_type_commission(return_value=True)} "
@@ -669,7 +691,7 @@ class SalesRecord(models.Model):
             return f"Error: {e}"
 
     def calculate_total_commission(self):
-        if self.sale_type == self.SALE_TYPE.FULL:
+        if self.sale_type == self.SALE_TYPE.FULL and not self.is_free_subscription():
             value = (
                 self.calculate_payment_type_commission(return_value=True)
                 + self.calculate_products_count_commission(return_value=True)

--- a/support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html
+++ b/support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html
@@ -189,8 +189,7 @@
               <i class="fas fa-check-circle"></i> {% trans "Validate" %}
             </a>
           {% elif subscription.validated and not subscription.has_sales_record %}
-            {# Validated with no sales record: it came in through a channel with no seller, so it is
-               already on record. Registering a sale here is only about commissioning someone. #}
+            {# Came in through a channel with no seller: already on record, so this is only about commission #}
             <a href="{% url "add_sales_record" subscription.id %}"
                class="btn btn-sm btn-outline-warning mr-1 mb-1"
                title="{% trans "This subscription came in through the website and needs no validation. Register a sale only if a seller should be commissioned for it." %}"
@@ -203,9 +202,8 @@
               <i class="fas fa-cash-register"></i> {% trans "Register Sale" %}
             </a>
           {% else %}
-            {# Validated and with a sales record: nothing left to do. Without this the row would show
-               no control at all, and "all in order" would look the same as "this failed to load". #}
-            <span class="badge badge-light text-success border mr-1 mb-1 py-1"
+            {# Nothing left to do: without this the row shows no control and looks like it failed to load #}
+            <span class="btn btn-sm btn-outline-success disabled mr-1 mb-1"
                   title="{% if subscription.validated_by %}{% blocktrans with who=subscription.validated_by.get_full_name|default:subscription.validated_by.username when=subscription.validated_date|date:"d/m/Y H:i" %}Validated by {{ who }} on {{ when }}{% endblocktrans %}{% else %}{% blocktrans with when=subscription.validated_date|date:"d/m/Y H:i" %}Validated by the system on {{ when }}{% endblocktrans %}{% endif %}"
                   data-toggle="tooltip">
               <i class="fas fa-check"></i> {% trans "Validated" %}

--- a/support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html
+++ b/support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html
@@ -120,6 +120,7 @@
              target="_blank">
             <i class="fas fa-cog"></i> {% trans "Advanced" %}
           </a>
+          {% include "contact_detail/tabs/includes/_subscription_validation_actions.html" %}
         {% endif %}
       {% elif subscription.type == "F" %}
         {% if request.user|in_group:"Managers" %}
@@ -135,6 +136,7 @@
              target="_blank">
             <i class="fas fa-cog"></i> {% trans "Advanced" %}
           </a>
+          {% include "contact_detail/tabs/includes/_subscription_validation_actions.html" %}
         {% endif %}
       {% else %}
         {% if not subscription.is_obsolete %}
@@ -183,32 +185,7 @@
              target="_blank">
             <i class="fas fa-cog"></i> {% trans "Advanced" %}
           </a>
-          {% if not subscription.validated and subscription.has_sales_record %}
-            <a href="{% url "validate_subscription" subscription.id %}"
-               class="btn btn-sm btn-warning mr-1 mb-1">
-              <i class="fas fa-check-circle"></i> {% trans "Validate" %}
-            </a>
-          {% elif subscription.validated and not subscription.has_sales_record %}
-            {# Came in through a channel with no seller: already on record, so this is only about commission #}
-            <a href="{% url "add_sales_record" subscription.id %}"
-               class="btn btn-sm btn-outline-warning mr-1 mb-1"
-               title="{% trans "This subscription came in through the website and needs no validation. Register a sale only if a seller should be commissioned for it." %}"
-               data-toggle="tooltip">
-              <i class="fas fa-hand-holding-usd"></i> {% trans "Commission a seller" %}
-            </a>
-          {% elif not subscription.has_sales_record and request.user|in_group:"Managers" %}
-            <a href="{% url "add_sales_record" subscription.id %}"
-               class="btn btn-sm btn-warning mr-1 mb-1">
-              <i class="fas fa-cash-register"></i> {% trans "Register Sale" %}
-            </a>
-          {% else %}
-            {# Nothing left to do: without this the row shows no control and looks like it failed to load #}
-            <span class="btn btn-sm btn-outline-success disabled mr-1 mb-1"
-                  title="{% if subscription.validated_by %}{% blocktrans with who=subscription.validated_by.get_full_name|default:subscription.validated_by.username when=subscription.validated_date|date:"d/m/Y H:i" %}Validated by {{ who }} on {{ when }}{% endblocktrans %}{% else %}{% blocktrans with when=subscription.validated_date|date:"d/m/Y H:i" %}Validated by the system on {{ when }}{% endblocktrans %}{% endif %}"
-                  data-toggle="tooltip">
-              <i class="fas fa-check"></i> {% trans "Validated" %}
-            </span>
-          {% endif %}
+          {% include "contact_detail/tabs/includes/_subscription_validation_actions.html" %}
           {% if subscription.is_obsolete %}
             <a href="{% url "admin:core_subscription_change" subscription.get_updated_subscription.id %}"
                class="btn btn-sm btn-info mr-1 mb-1"

--- a/support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html
+++ b/support/templates/contact_detail/tabs/includes/_overview_subscription_list_item.html
@@ -188,11 +188,28 @@
                class="btn btn-sm btn-warning mr-1 mb-1">
               <i class="fas fa-check-circle"></i> {% trans "Validate" %}
             </a>
+          {% elif subscription.validated and not subscription.has_sales_record %}
+            {# Validated with no sales record: it came in through a channel with no seller, so it is
+               already on record. Registering a sale here is only about commissioning someone. #}
+            <a href="{% url "add_sales_record" subscription.id %}"
+               class="btn btn-sm btn-outline-warning mr-1 mb-1"
+               title="{% trans "This subscription came in through the website and needs no validation. Register a sale only if a seller should be commissioned for it." %}"
+               data-toggle="tooltip">
+              <i class="fas fa-hand-holding-usd"></i> {% trans "Commission a seller" %}
+            </a>
           {% elif not subscription.has_sales_record and request.user|in_group:"Managers" %}
             <a href="{% url "add_sales_record" subscription.id %}"
                class="btn btn-sm btn-warning mr-1 mb-1">
               <i class="fas fa-cash-register"></i> {% trans "Register Sale" %}
             </a>
+          {% else %}
+            {# Validated and with a sales record: nothing left to do. Without this the row would show
+               no control at all, and "all in order" would look the same as "this failed to load". #}
+            <span class="badge badge-light text-success border mr-1 mb-1 py-1"
+                  title="{% if subscription.validated_by %}{% blocktrans with who=subscription.validated_by.get_full_name|default:subscription.validated_by.username when=subscription.validated_date|date:"d/m/Y H:i" %}Validated by {{ who }} on {{ when }}{% endblocktrans %}{% else %}{% blocktrans with when=subscription.validated_date|date:"d/m/Y H:i" %}Validated by the system on {{ when }}{% endblocktrans %}{% endif %}"
+                  data-toggle="tooltip">
+              <i class="fas fa-check"></i> {% trans "Validated" %}
+            </span>
           {% endif %}
           {% if subscription.is_obsolete %}
             <a href="{% url "admin:core_subscription_change" subscription.get_updated_subscription.id %}"

--- a/support/templates/contact_detail/tabs/includes/_subscription_validation_actions.html
+++ b/support/templates/contact_detail/tabs/includes/_subscription_validation_actions.html
@@ -1,0 +1,32 @@
+{% load i18n %}
+{# Validation state of one subscription, as a single button (or none of them applies, a chip). #}
+{# Included from every subscription type: promo, free and regular all end up in the sales record #}
+{# queue, so all of them need a way in from the contact detail. #}
+{% if subscription.validated %}
+  {% if subscription.has_sales_record or subscription.is_free %}
+    {# Nothing left to do. Rendered anyway so "all in order" does not look like "this failed to load" #}
+    <span class="btn btn-sm btn-outline-success disabled mr-1 mb-1"
+          title="{% if subscription.validated_by %}{% blocktrans with who=subscription.validated_by.get_full_name|default:subscription.validated_by.username when=subscription.validated_date|date:"d/m/Y H:i" %}Validated by {{ who }} on {{ when }}{% endblocktrans %}{% else %}{% blocktrans with when=subscription.validated_date|date:"d/m/Y H:i" %}Validated by the system on {{ when }}{% endblocktrans %}{% endif %}"
+          data-toggle="tooltip">
+      <i class="fas fa-check"></i> {% trans "Validated" %}
+    </span>
+  {% else %}
+    {# Came in through a channel with no seller, so it is already on record: this is only about commission #}
+    <a href="{% url "add_sales_record" subscription.id %}"
+       class="btn btn-sm btn-outline-warning mr-1 mb-1"
+       title="{% trans "This subscription came in through the website and needs no validation. Register a sale only if a seller should be commissioned for it." %}"
+       data-toggle="tooltip">
+      <i class="fas fa-hand-holding-usd"></i> {% trans "Commission a seller" %}
+    </a>
+  {% endif %}
+{% elif subscription.has_sales_record %}
+  <a href="{% url "validate_subscription" subscription.id %}"
+     class="btn btn-sm btn-warning mr-1 mb-1">
+    <i class="fas fa-check-circle"></i> {% trans "Validate" %}
+  </a>
+{% else %}
+  <a href="{% url "add_sales_record" subscription.id %}"
+     class="btn btn-sm btn-warning mr-1 mb-1">
+    <i class="fas fa-cash-register"></i> {% trans "Register Sale" %}
+  </a>
+{% endif %}

--- a/support/templates/sales_record_filter.html
+++ b/support/templates/sales_record_filter.html
@@ -166,6 +166,10 @@
                           <i class="fas fa-info-circle text-muted ml-1"
                              data-toggle="tooltip"
                              title="{% trans "Payment method is only relevant for full sales" %}"></i>
+                        {% elif sr.is_free_subscription %}
+                          <i class="fas fa-info-circle text-muted ml-1"
+                             data-toggle="tooltip"
+                             title="{% trans "A free subscription has no payment method and pays no commission" %}"></i>
                         {% endif %}
                       </td>
                       <td>{{ sr.show_products_per_line }}</td>

--- a/support/templates/validate_subscription_sales_record.html
+++ b/support/templates/validate_subscription_sales_record.html
@@ -364,6 +364,12 @@
                     <dt>{% trans "Calculated Commission" %}</dt>
                     <dd>
                       {{ object.calculate_commission }}
+                      {% if object.is_free_subscription %}
+                        <br>
+                        <small class="text-muted">
+                          {% trans "There is no money behind a free subscription: no payment method and no commission. Validate it anyway so the sale is on record and the reader gets activated on the website." %}
+                        </small>
+                      {% endif %}
                     </dd>
                   </div>
                 </div>
@@ -387,6 +393,9 @@
                 <div class="col-md-3">
                   <label for="override" class="form-label">{% trans "Add Commission Value Manually" %}</label>
                   {% render_field form.override_commission_value class="form-control" %}
+                  {% if object.is_free_subscription %}
+                    <small class="text-muted">{% trans "Locked: a free subscription pays no commission." %}</small>
+                  {% endif %}
                 </div>
                 <div class="col-md-3">
                   <div class="form-check mt-4 pt-2">
@@ -394,7 +403,11 @@
                     <label for="can_be_commissioned_id" class="form-check-label">{% trans "Can be commissioned" %}</label>
                   </div>
                   <small class="text-muted">
-                    {% trans "If checked, the seller will receive commission for this sale. Uncheck to exclude it from commission calculations (e.g. retention discounts or non-commissionable changes)." %}
+                    {% if object.is_free_subscription %}
+                      {% trans "Locked: a free subscription pays no commission." %}
+                    {% else %}
+                      {% trans "If checked, the seller will receive commission for this sale. Uncheck to exclude it from commission calculations (e.g. retention discounts or non-commissionable changes)." %}
+                    {% endif %}
                   </small>
                 </div>
               </div>

--- a/support/views/all_views.py
+++ b/support/views/all_views.py
@@ -66,6 +66,7 @@ from core.utils import (
     calc_price_from_products,
     logistics_is_installed,
     process_products,
+    run_subscription_validated_hook,
 )
 from invoicing.models import Invoice
 from util.location_utils import georef_habilitado
@@ -3273,6 +3274,10 @@ class ValidateSubscriptionSalesRecord(BreadcrumbsMixin, UpdateView):
         subscription = self.object.subscription
         sales_record = form.instance
         subscription.validate(user=self.request.user)
+        # Validating is the moment the sale becomes real for the rest of the world. Whatever the
+        # installation wants to propagate from here (la diaria activates the reader on the website)
+        # hangs off this hook, which never raises: the validation is already saved.
+        run_subscription_validated_hook(subscription, self.request.user)
         if form.cleaned_data["can_be_commissioned"]:
             sales_record.can_be_commisioned = True
             SubscriptionProduct.objects.filter(

--- a/support/views/all_views.py
+++ b/support/views/all_views.py
@@ -3346,7 +3346,13 @@ class SalesRecordCreateView(CreateView):
         SubscriptionProduct.objects.filter(
             subscription=subscription, product__in=sales_record_obj.products.all()
         ).update(seller=sales_record_obj.seller)
-        self.subscription.validate(user=self.request.user)
+        if not self.subscription.validated:
+            # An already-validated subscription is one that came in through a channel with no seller
+            # (the website, for instance) and was validated by the system, which is what a null
+            # `validated_by` means. Registering a sale on it afterwards is about commissioning
+            # somebody — a seller who referred the person — not about validating it again, so the
+            # original marker is left alone.
+            self.subscription.validate(user=self.request.user)
         return super().form_valid(form)
 
 

--- a/support/views/campaign_management.py
+++ b/support/views/campaign_management.py
@@ -13,8 +13,9 @@ from django.urls import reverse, reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, TemplateView
 
+from core.choices import ACTIVITY_STATUS
 from core.mixins import BreadcrumbsMixin
-from core.models import ContactCampaignStatus
+from core.models import Activity, ContactCampaignStatus
 from core.utils import detect_csv_delimiter
 from support.forms import BulkDeleteCampaignStatusForm
 
@@ -131,8 +132,15 @@ class BulkDeleteCampaignStatusView(BreadcrumbsMixin, UserPassesTestMixin, FormVi
             )
         )
 
-        # Delete ContactCampaignStatus records
+        # Delete ContactCampaignStatus records, along with the activities that are still open for the same
+        # contacts on the same campaign. Activities point directly to the campaign, so leaving them behind
+        # keeps the contact in the seller console queue for a campaign they are no longer part of.
         with transaction.atomic():
+            deleted_activities, _unused = Activity.objects.filter(
+                contact_id__in=contact_ids,
+                campaign=campaign,
+                status__in=[ACTIVITY_STATUS.PENDING, ACTIVITY_STATUS.DELAYED],
+            ).delete()
             deleted_count, _unused = ContactCampaignStatus.objects.filter(
                 contact_id__in=contact_ids, campaign=campaign
             ).delete()
@@ -161,9 +169,14 @@ class BulkDeleteCampaignStatusView(BreadcrumbsMixin, UserPassesTestMixin, FormVi
         messages.success(
             self.request,
             _(
-                "Successfully deleted {count} ContactCampaignStatus record(s) for campaign "
-                "'{campaign}' with {total} contact ID(s) from CSV."
-            ).format(count=deleted_count, campaign=campaign.name, total=len(contact_ids)),
+                "Successfully deleted {count} ContactCampaignStatus record(s) and {activities} open "
+                "activity(ies) for campaign '{campaign}' with {total} contact ID(s) from CSV."
+            ).format(
+                count=deleted_count,
+                activities=deleted_activities,
+                campaign=campaign.name,
+                total=len(contact_ids),
+            ),
         )
 
         return redirect(self.success_url)

--- a/support/views/seller_console.py
+++ b/support/views/seller_console.py
@@ -3,6 +3,7 @@ from django.contrib.auth.mixins import UserPassesTestMixin, LoginRequiredMixin
 from django.conf import settings
 from django.contrib import messages
 from django.utils import timezone
+from django.db.models import Exists, OuterRef
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -446,6 +447,13 @@ class SellerConsoleView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
         if not seller_console_action:
             return HttpResponseRedirect(reverse("seller_console", args=[category, campaign.id]))
 
+        # The contact must still be in the campaign before we touch anything. Activities point directly to the
+        # campaign, so a pending one can outlive the ContactCampaignStatus and still show up in this queue; if we
+        # completed it first and only checked afterwards, the activity would be closed by a request that aborts.
+        if not ContactCampaignStatus.objects.filter(campaign=campaign, contact=contact).exists():
+            messages.error(self.request, _("Contact is no longer in this campaign"))
+            return HttpResponseRedirect(reverse("seller_console", args=[category, campaign.id]))
+
         # Process based on category
         if category == "act":
             try:
@@ -738,13 +746,19 @@ class SellerConsoleView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
         category = self.kwargs['category']
         if category == "new":
             return campaign.get_not_contacted(seller.id).select_related('last_console_action')
-        if getattr(settings, "ALLOW_ACCESSING_FUTURE_ACTIVITIES_IN_SELLER_CONSOLE", False):
-            return campaign.activity_set.filter(
-                activity_type="C", seller=seller, status="P"
-            ).select_related('seller_console_action').order_by("datetime", "id")
-        return campaign.activity_set.filter(
-            activity_type="C", seller=seller, status="P", datetime__lte=datetime.now()
-        ).select_related('seller_console_action').order_by("datetime", "id")
+        activities = campaign.activity_set.filter(activity_type="C", seller=seller, status="P")
+        if not getattr(settings, "ALLOW_ACCESSING_FUTURE_ACTIVITIES_IN_SELLER_CONSOLE", False):
+            activities = activities.filter(datetime__lte=datetime.now())
+        # Leave out activities whose contact is no longer in the campaign: they can't be worked on, since every
+        # console action needs the ContactCampaignStatus that is already gone.
+        still_in_campaign = ContactCampaignStatus.objects.filter(
+            campaign=campaign, contact=OuterRef("contact")
+        )
+        return (
+            activities.filter(Exists(still_in_campaign))
+            .select_related('seller_console_action')
+            .order_by("datetime", "id")
+        )
 
     def post(self, request, *args, **kwargs):
         return self.handle_post_request()

--- a/support/views/subscriptions.py
+++ b/support/views/subscriptions.py
@@ -218,6 +218,12 @@ class SubscriptionMixin(BreadcrumbsMixin):
                 return subscription
 
     def capture_variables(self):
+        """
+        Reads the console parameters from the querystring.
+
+        Returns None when everything is in place, or a response the caller must return as-is when the console
+        instance the link points to is gone. Every dispatch calling this has to honour that return value.
+        """
         self.url = self.request.GET.get("url", None)
         self.offset = self.request.GET.get("offset", None)
         self.is_new = self.request.GET.get("new", None)
@@ -235,23 +241,38 @@ class SubscriptionMixin(BreadcrumbsMixin):
             self.subscription, self.edit_subscription = None, False
 
         if self.request.GET.get("act", None):
-            self.activity = Activity.objects.get(pk=self.request.GET["act"])
+            try:
+                self.activity = Activity.objects.get(pk=self.request.GET["act"])
+            except Activity.DoesNotExist:
+                messages.error(self.request, _("This activity no longer exists."))
+                return HttpResponseRedirect(reverse("seller_console_list_campaigns"))
             self.campaign = self.activity.campaign
             try:
                 self.ccs = ContactCampaignStatus.objects.get(contact=self.contact, campaign=self.campaign)
             except ContactCampaignStatus.DoesNotExist:
                 msg = _(
-                    "Activity {} is not in campaign {}. Please report this error!".format(
-                        self.activity.id, self.campaign.id
+                    "The contact is no longer in campaign {}, so activity {} can't be used to sell.".format(
+                        self.campaign.id, self.activity.id
                     )
                 )
                 messages.error(self.request, msg)
                 return HttpResponseRedirect(reverse("seller_console_list_campaigns"))
-            self.user_seller_id = self.ccs.seller.id
+            self.user_seller_id = self.ccs.seller_id
         elif self.request.GET.get("new", None):
-            self.ccs = ContactCampaignStatus.objects.get(pk=self.request.GET["new"])
+            # The link carries the ContactCampaignStatus id. It can be stale: removing a contact from a campaign
+            # deletes that record while console pages already rendered keep pointing at it.
+            try:
+                self.ccs = ContactCampaignStatus.objects.get(pk=self.request.GET["new"])
+            except ContactCampaignStatus.DoesNotExist:
+                messages.error(
+                    self.request,
+                    _("The contact is no longer in this campaign, instance number: {}").format(
+                        self.request.GET["new"]
+                    ),
+                )
+                return HttpResponseRedirect(reverse("seller_console_list_campaigns"))
             self.campaign = self.ccs.campaign
-            self.user_seller_id = self.ccs.seller.id
+            self.user_seller_id = self.ccs.seller_id
         elif getattr(self.request.user, 'seller', None) is not None:
             self.user_seller_id = self.request.user.seller.id
         else:
@@ -310,7 +331,9 @@ class SubscriptionCreateView(UserPassesTestMixin, SubscriptionMixin, FormView):
     def dispatch(self, request, *args, **kwargs):
         self.contact = self.get_contact(kwargs['contact_id'])
         self.subscription = None
-        self.capture_variables()
+        response = self.capture_variables()
+        if response:
+            return response
         return super().dispatch(request, *args, **kwargs)
 
     def form_valid(self, form):
@@ -348,7 +371,9 @@ class SubscriptionUpdateView(SubscriptionMixin, FormView):
     def dispatch(self, request, *args, **kwargs):
         self.contact = self.get_contact(kwargs['contact_id'])
         self.subscription = self.get_subscription(kwargs['subscription_id'])
-        self.capture_variables()
+        response = self.capture_variables()
+        if response:
+            return response
         if self.subscription and self.subscription.contact != self.contact:
             # TODO: change this to a better approach, it generates bad UX and an error email wo traceback (useless)
             return HttpResponseServerError(_("Wrong data"))
@@ -1869,7 +1894,9 @@ class CorporateSubscriptionCreateView(SubscriptionMixin, FormView):
     def dispatch(self, request, *args, **kwargs):
         self.contact = self.get_contact(kwargs['contact_id'])
         self.subscription = None
-        self.capture_variables()
+        response = self.capture_variables()
+        if response:
+            return response
         return super().dispatch(request, *args, **kwargs)
 
 

--- a/support/views/subscriptions.py
+++ b/support/views/subscriptions.py
@@ -2074,6 +2074,19 @@ class CreateFreeSubscriptionView(FreeSubscriptionMixin, BreadcrumbsMixin, FormVi
         # Add products to subscription
         self.add_products_to_subscription(subscription)
 
+        # A free subscription is still an alta made by someone inside the CRM, so it gets a sales
+        # record like any other: it is the object managers validate, and without it the subscription
+        # would sit in the contact detail forever offering a "Register sale" button nobody owes.
+        # The price is the real one (zero for a free subscription), not the catalogue price.
+        sales_record = SalesRecord.objects.create(
+            subscription=subscription,
+            seller_id=getattr(getattr(self.request.user, "seller", None), "id", None),
+            price=0,
+        )
+        sales_record.add_products()
+        if not sales_record.seller_id:
+            sales_record.set_generic_seller()
+
         messages.success(
             self.request,
             _("Free subscription created successfully for {contact}").format(contact=self.contact.get_full_name()),

--- a/templates/components/_sidebar.html
+++ b/templates/components/_sidebar.html
@@ -62,6 +62,20 @@
                     </a>
                   </li>
                 {% endif %}
+                {% if request.user|in_group:"Managers" %}
+                  {% url 'sales_record_filter' as sales_record_filter %}
+                  {% pending_sales_records as pending_sales %}
+                  <li class="nav-item">
+                    <a href="{{ sales_record_filter }}"
+                       class="nav-link {% if request.path == sales_record_filter %}active{% endif %}">
+                      <i class="nav-icon fas fa-file-invoice-dollar"></i>
+                      <p>
+                        {% trans "Sales Records" %}
+                        {% if pending_sales %}<span class="badge badge-warning right">{{ pending_sales }}</span>{% endif %}
+                      </p>
+                    </a>
+                  </li>
+                {% endif %}
                 {% if request.user|in_group:"Support" %}
                   {% include "components/sidebar_items/_support.html" %}
                 {% endif %}

--- a/templates/components/sidebar_items/_campaign_management.html
+++ b/templates/components/sidebar_items/_campaign_management.html
@@ -9,7 +9,6 @@
 {% url 'seller_performance_by_time' as seller_performance_by_time %}
 {% url 'release_seller_contacts' as release_seller_contacts %}
 {% url 'upload_do_not_call_numbers' as upload_do_not_call_numbers %}
-{% url 'sales_record_filter' as sales_record_filter %}
 {% url "check_for_existing_contacts" as check_for_existing_contacts %}
 {% url 'bulk_delete_campaign_status' as bulk_delete_campaign_status %}
 {% url 'seller_attendance' as seller_attendance %}
@@ -101,13 +100,6 @@
       </a>
     </li>
     {% endif %}
-    <li class="nav-item">
-      <a href="{{ sales_record_filter }}"
-         class="nav-link {% if request.path == sales_record_filter %}active{% endif %}">
-        <i class="nav-icon fas fa-file-invoice-dollar"></i>
-        <p>{% trans "Sales Records" %}</p>
-      </a>
-    </li>
     <li class="nav-item">
       <a href="{{ bulk_delete_campaign_status }}"
          class="nav-link {% if request.path == bulk_delete_campaign_status %}active{% endif %}">

--- a/tests/test_seller_console.py
+++ b/tests/test_seller_console.py
@@ -2,6 +2,9 @@
 from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from django.urls import reverse
+from django.utils import timezone
+
+from datetime import timedelta
 
 from core.models import Activity, Campaign, ContactCampaignStatus
 from core.choices import CAMPAIGN_STATUS
@@ -144,3 +147,99 @@ class TestSellerConsoleScheduledActivity(TestCase):
         )
         self.assertEqual(pending.count(), 1)
         self.assertEqual(pending.first().seller_console_action, self.schedule)
+
+
+class TestSellerConsoleContactRemovedFromCampaign(TestCase):
+    """
+    Verifica el comportamiento cuando el contacto ya no está en la campaña pero sobrevive una actividad
+    pendiente apuntando a ella.
+
+    Regresión t1176: sacar un contacto de una campaña borra el ContactCampaignStatus pero no las
+    actividades, que apuntan directo a la campaña. La pendiente seguía apareciendo en la cola "act" y, al
+    resolverla, la consola la marcaba como completada antes de verificar el estado de campaña: el vendedor
+    veía el error y la actividad quedaba cerrada igual.
+    """
+
+    def setUp(self):
+        self.client = Client()
+
+        self.user = User.objects.create_superuser(username="vendedor", password="testpass")
+        self.seller = Seller.objects.create(name="Vendedor", user=self.user, internal=True)
+        self.client.login(username="vendedor", password="testpass")
+
+        self.contact = ContactFactory()
+        self.campaign = Campaign.objects.create(name="Campaña test", active=True, priority=3)
+
+        self.call_later = SellerConsoleAction.objects.create(
+            slug="call-later",
+            name="Llamar más tarde",
+            action_type=SellerConsoleAction.ACTION_TYPES.CALL_LATER,
+            campaign_status=CAMPAIGN_STATUS.CALLED_COULD_NOT_CONTACT,
+            campaign_resolution="CL",
+            is_active=True,
+        )
+
+        # La actividad pendiente que quedó huérfana: el contacto ya no tiene ContactCampaignStatus.
+        self.activity = Activity.objects.create(
+            contact=self.contact,
+            campaign=self.campaign,
+            seller=self.seller,
+            activity_type="C",
+            status="P",
+            datetime=timezone.now() - timedelta(days=1),
+        )
+
+    def test_orphan_activity_is_not_completed(self):
+        """Resolver una actividad de un contacto que ya no está en la campaña no debe cerrarla."""
+        self.client.post(
+            reverse("seller_console", args=["act", self.campaign.id]),
+            data={
+                "result": "call-later",
+                "category": "act",
+                "instance_id": self.activity.id,
+                "seller_id": self.seller.id,
+                "offset": 1,
+                "notes": "No contesta",
+            },
+        )
+
+        self.activity.refresh_from_db()
+        self.assertEqual(self.activity.status, "P")
+        # Tampoco debe haberse creado una pendiente nueva para una campaña de la que ya salió.
+        self.assertEqual(Activity.objects.filter(contact=self.contact, campaign=self.campaign).count(), 1)
+
+    def test_orphan_activity_is_not_listed_in_console(self):
+        """La cola de la consola no debe ofrecer actividades de contactos que ya salieron de la campaña."""
+        # Con la única actividad huérfana, la cola queda vacía y la consola manda de vuelta a la lista.
+        response = self.client.get(reverse("seller_console", args=["act", self.campaign.id]))
+        self.assertRedirects(
+            response, reverse("seller_console_list_campaigns"), fetch_redirect_response=False
+        )
+
+        ContactCampaignStatus.objects.create(
+            contact=self.contact, campaign=self.campaign, status=1, seller=self.seller
+        )
+        response = self.client.get(reverse("seller_console", args=["act", self.campaign.id]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.contact.get_full_name())
+
+    def test_activity_is_listed_again_when_contact_is_back_in_campaign(self):
+        """Con el ContactCampaignStatus en su lugar, la misma actividad sí se puede trabajar."""
+        ContactCampaignStatus.objects.create(
+            contact=self.contact, campaign=self.campaign, status=1, seller=self.seller
+        )
+
+        self.client.post(
+            reverse("seller_console", args=["act", self.campaign.id]),
+            data={
+                "result": "call-later",
+                "category": "act",
+                "instance_id": self.activity.id,
+                "seller_id": self.seller.id,
+                "offset": 1,
+                "notes": "No contesta",
+            },
+        )
+
+        self.activity.refresh_from_db()
+        self.assertEqual(self.activity.status, "C")

--- a/tests/test_subscription_validation.py
+++ b/tests/test_subscription_validation.py
@@ -96,3 +96,43 @@ class TestFreeSubscriptionSalesRecord(TestCase):
         self.assertEqual(sales_record.seller, Seller.objects.filter(name="Generic Seller").first())
         # And it waits for validation, like any other sale.
         self.assertFalse(subscription.validated)
+
+    def test_a_free_subscription_reads_as_na_and_pays_no_commission(self):
+        # Free subscriptions are recorded as FULL sales, so without the free check they would report
+        # the subscription's payment method and compute a commission on a sale worth nothing.
+        subscription = create_subscription(self.contact, subscription_type="F", payment_type="S")
+        sales_record = SalesRecord.objects.create(subscription=subscription, price=0)
+
+        self.assertTrue(sales_record.is_free_subscription())
+        self.assertEqual(sales_record.get_payment_type(), "N/A")
+        self.assertEqual(sales_record.calculate_total_commission(), 0)
+
+        # Forcing the calculation the way the validation view does must not create a commission.
+        sales_record.set_commissions(force=True)
+        sales_record.refresh_from_db()
+        self.assertEqual(sales_record.total_commission_value, 0)
+
+    def test_the_validation_form_will_not_commission_a_free_subscription(self):
+        # Locked, not merely hidden: a hand-made POST asking for the commission must not get one.
+        seller = Seller.objects.create(name="Internal seller", internal=True)
+        subscription = create_subscription(self.contact, subscription_type="F", payment_type="S")
+        sales_record = SalesRecord.objects.create(subscription=subscription, price=0, seller=seller)
+
+        response = self.client.post(
+            reverse("validate_sale", args=[sales_record.pk]),
+            {"seller": seller.pk, "can_be_commissioned": "on", "override_commission_value": 5000},
+        )
+        self.assertEqual(response.status_code, 302)
+
+        sales_record.refresh_from_db()
+        subscription.refresh_from_db()
+        self.assertTrue(subscription.validated)  # the sale is validated all the same
+        self.assertFalse(sales_record.can_be_commissioned)
+        self.assertEqual(sales_record.total_commission_value, 0)
+
+    def test_a_paid_subscription_keeps_reporting_its_payment_method(self):
+        subscription = create_subscription(self.contact, subscription_type="N", payment_type="S")
+        sales_record = SalesRecord.objects.create(subscription=subscription, price=100)
+
+        self.assertFalse(sales_record.is_free_subscription())
+        self.assertNotEqual(sales_record.get_payment_type(), "N/A")

--- a/tests/test_subscription_validation.py
+++ b/tests/test_subscription_validation.py
@@ -1,0 +1,98 @@
+# coding=utf-8
+"""
+What happens when a sale is validated, and which subscriptions are born with a sales record.
+
+Two separate things worth not mixing up:
+
+- **The hook.** Validating is the moment the sale becomes real for the rest of the world, and
+  ``SUBSCRIPTION_VALIDATED_HOOK`` hangs off it (la diaria uses it to grant website access right
+  then). The hook can never undo the validation: it is already saved.
+- **The free subscription.** Free or not, somebody inside the CRM creates it, so it gets a sales
+  record like any other and lands in the queue managers look at.
+"""
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from core.models import Address, Product, Subscription
+from support.models import SalesRecord, Seller
+
+from tests.factory import create_contact, create_subscription
+
+
+hook_calls = []
+
+
+def sample_hook(subscription, user):
+    hook_calls.append((subscription, user))
+    return "done"
+
+
+class TestSubscriptionValidatedHook(TestCase):
+
+    def setUp(self):
+        hook_calls.clear()
+        self.contact = create_contact(name="Hook Test", phone="099111333")
+        self.subscription = create_subscription(self.contact)
+
+    def test_does_nothing_without_the_setting(self):
+        from core.utils import run_subscription_validated_hook
+
+        self.assertIsNone(run_subscription_validated_hook(self.subscription))
+
+    @override_settings(SUBSCRIPTION_VALIDATED_HOOK="tests.test_subscription_validation.sample_hook")
+    def test_calls_the_callable_with_subscription_and_user(self):
+        from core.utils import run_subscription_validated_hook
+
+        user = User.objects.create_user(username="validator", password="x")
+        result = run_subscription_validated_hook(self.subscription, user)
+        self.assertEqual(hook_calls, [(self.subscription, user)])
+        self.assertEqual(result, "done")
+
+    @override_settings(SUBSCRIPTION_VALIDATED_HOOK="module.that.does.not.exist")
+    def test_a_broken_hook_does_not_raise(self):
+        from core.utils import run_subscription_validated_hook
+
+        # The validation is already saved: failing to propagate it is logged and swallowed.
+        self.assertIsNone(run_subscription_validated_hook(self.subscription))
+
+
+class TestFreeSubscriptionSalesRecord(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_superuser(username="manager", password="x")
+        self.client.login(username="manager", password="x")
+        self.contact = create_contact(name="Free Sub", phone="099111444")
+        self.address = Address.objects.create(contact=self.contact, address_1="Street 1")
+        self.product = Product.objects.create(name="Free product", slug="free-product", type="S", offerable=True)
+
+    def test_a_free_subscription_leaves_a_sales_record_priced_at_zero(self):
+        response = self.client.post(
+            reverse("create_free_subscription", args=[self.contact.id]),
+            {
+                "name": self.contact.name,
+                "last_name": self.contact.last_name or "",
+                "phone": self.contact.phone,
+                "mobile": "",
+                "email": "",
+                "notes": "",
+                "start_date": "2026-09-01",
+                "end_date": "2026-09-08",
+                "free_subscription_requested_by": "PR",
+                "check-{}".format(self.product.id): "on",
+                "address-{}".format(self.product.id): self.address.id,
+                "copies-{}".format(self.product.id): 1,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+
+        subscription = Subscription.objects.get(contact=self.contact, type="F")
+        sales_record = SalesRecord.objects.get(subscription=subscription)
+        self.assertEqual(sales_record.price, 0)
+        self.assertIn(self.product, sales_record.products.all())
+        # Without a seller of its own it falls back to the generic one, not None: that is what the
+        # rest of the panel expects.
+        self.assertEqual(sales_record.seller, Seller.objects.filter(name="Generic Seller").first())
+        # And it waits for validation, like any other sale.
+        self.assertFalse(subscription.validated)


### PR DESCRIPTION
Engancha la activación instantánea CRM → CMS al momento de **validar la venta**, ordena quién nace validada y quién lleva registro de venta, y agrega el comando que corta la cola vieja de validaciones.

Va junto con la rama del mismo nombre de `utopia-crm-ladiaria`.

### Qué trae

- **`core/utils.py`** — `run_subscription_validated_hook()`, el gancho por dotted path. Sin el setting configurado, validar se comporta exactamente como antes.
- **`core/models.py`** — `Subscription.is_free()`.
- **`support/views/all_views.py`** — llamada al gancho al validar; comisionar no vuelve a validar.
- **`support/`, templates y sidebar** — el estado de validación se ve en todos los tipos de suscripción; una suscripción gratuita no reporta forma de pago ni paga comisión.
- **`tests/test_subscription_validation.py`** — 7 tests: que sin setting no hace nada, y que no levanta excepción si el callable falla.

### Notas

- **No requiere migraciones.**
- El comportamiento sólo cambia cuando se configura `SUBSCRIPTION_VALIDATED_HOOK`, que en TEST se pone **después** de correr el corte histórico de validaciones (`validate_historic_subscriptions` en ladiaria), para que la primera validación que dé acceso web real caiga sobre una cola chica.
- Depende de #359 (test al día con main). Mergear ese primero.

Devnotes: `docs/devnotes/…validating-a-sale-as-the-gate-for-web-activation.md` (en/es).

https://claude.ai/code/session_01RUZoQyxpkAMZXboSk5TngW
