### PR TITLE
fix: the contact_api endpoint directly accesses request in views.py

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -3,6 +3,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework_api_key.permissions import HasAPIKey
 
 from django.conf import settings
+from django.core.exceptions import FieldDoesNotExist
 from django.db import IntegrityError
 from django.http import (
     JsonResponse,
@@ -67,6 +68,25 @@ def contact_by_emailprefix(request):
             return JsonResponse({"contact_id": c.id, "email": c.email})
 
 
+# Fields that must never be settable through the public contact_api mass-update mechanism,
+# even though they exist on the Contact model.
+CONTACT_API_FORBIDDEN_FIELDS = ("id", "pk", "updatefromweb")
+
+
+def _is_allowed_contact_field(field):
+    """
+    Only allow concrete, editable, non-relation Contact model fields to be set through the
+    contact_api endpoint, preventing mass assignment of arbitrary/internal attributes.
+    """
+    if not field or field in CONTACT_API_FORBIDDEN_FIELDS:
+        return False
+    try:
+        model_field = Contact._meta.get_field(field)
+    except FieldDoesNotExist:
+        return False
+    return model_field.editable and not model_field.is_relation
+
+
 @api_view(['POST', "PUT", "DELETE"])
 @api_view_auth_decorator
 @permission_classes([HasAPIKey])
@@ -102,11 +122,12 @@ def contact_api(request):
             """
             if "field" in request.data and (("value" in request.data) if value is not None else True):
                 # "untouched" back-compat: someone may be calling that way that was expected here
-                update_customer(c, newmail, field, value)
+                if _is_allowed_contact_field(field):
+                    update_customer(c, newmail, field, value)
             else:
                 # And this is the temporal fix, iterating adapting to the new "changeset approach" and do proper things
                 for field, value in request.data.items():
-                    if field not in ("contact_id", "email", "newemail"):
+                    if field not in ("contact_id", "email", "newemail") and _is_allowed_contact_field(field):
                         update_customer(c, newmail, field, value)
             id_contact = c.id
     except Contact.DoesNotExist:
@@ -120,7 +141,8 @@ def contact_api(request):
                     else:
                         return HttpResponseForbidden()
                 else:
-                    update_customer(contact, newmail, field, value)
+                    if _is_allowed_contact_field(field):
+                        update_customer(contact, newmail, field, value)
                     id_contact = contact.id
             except Contact.DoesNotExist:
                 if request.method == "POST":  # create
@@ -132,7 +154,8 @@ def contact_api(request):
                     except IntegrityError as ie_exc:
                         # TODO Notificar por mail a los managers
                         return HttpResponseBadRequest(ie_exc)
-                    update_customer(new_contact, mail, field, value)
+                    if _is_allowed_contact_field(field):
+                        update_customer(new_contact, mail, field, value)
                     id_contact = new_contact.id
             except (Contact.MultipleObjectsReturned, IntegrityError) as m_ie_exc:
                 # TODO Notificar por mail a los managers


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `core/views.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `core/views.py:79` |
| **Assessment** | Likely exploitable |

**Description**: The contact_api endpoint directly accesses request.data fields without using Django REST Framework serializers or explicit input validation. User-supplied field names and values are passed directly to the update_customer() function through iteration over request.data.items(), enabling mass assignment attacks where attackers can modify arbitrary model fields.

## Evidence

**Exploitation scenario**: An attacker with a valid API key sends a POST request to the contact_api endpoint with arbitrary field names in request.data.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `core/views.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
