### PR TITLE
t1178: la nota de comisión sólo cuando el desglose no cierra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## v0.5.1
 
+## 2026-09-11 — t1178 (seguimiento) La aclaración de comisión aparecía en ventas parciales que no la necesitaban
+
+- Toda venta parcial ya validada mostraba el aviso "los componentes ya no dan esa cifra", incluso cuando el desglose la explicaba perfectamente: un `0 + 0 + 0 + 105` al lado de un total de 105. La comparación se hacía contra la previsión de comisión —que para una parcial vale 0 por definición— en vez de contra la suma de los componentes que la pantalla muestra
+- Ahora el aviso aparece sólo cuando los componentes **realmente** no dan la cifra liquidada, que es el caso para el que se escribió: la venta se liquidó a un precio y el catálogo cambió después
+- Deployment: **no se requieren migraciones**; sí **recompilar traducciones** (`compilemessages -l es`), porque el texto del aviso cambió
+- **Author:** Tanya Tree + Claude Opus 5
+
 ## 2026-09-10 — t1178 La comisión de una venta ya validada se muestra como quedó, no como se recalcularía
 
 - **La pantalla de detalle de un registro de venta mostraba 0 en ventas ya comisionadas.** Una venta parcial que se decide comisionar al validarla (marcando "Puede comisionarse") guarda la comisión y se la paga al vendedor, pero el detalle seguía mostrando el cálculo previo, que para una parcial da 0 por definición. El resultado era una pantalla diciendo "0 (Tarjeta de crédito) + 0 (1 productos) + 0 (1) + 105 (productos específicos) = 0" mientras el listado y la liquidación decían 105. La plata siempre estuvo bien calculada: lo que mentía era la pantalla

--- a/docs/en/devnotes/2026-09-10-t1178-settled-commission-on-a-validated-sale.md
+++ b/docs/en/devnotes/2026-09-10-t1178-settled-commission-on-a-validated-sale.md
@@ -75,7 +75,7 @@ comparing numbers:
 | `can_be_commissioned` is false | Marked as not commissionable: it does not enter the liquidation |
 | Not validated yet, not a full sale | A partial sale pays no commission unless whoever validates decides otherwise |
 | `commission_overridden` | Amount entered by hand at validation time |
-| Settled, computed, components disagree | Settled at validation; the components are today's and no longer add up — either it was commissioned against the usual rule, or prices changed since |
+| Settled, computed, components disagree | Settled at validation; the components are today's and no longer add up — prices or commission rules changed since |
 
 ### 4. Overrides are now recorded
 
@@ -100,6 +100,21 @@ sales_record.can_be_commisioned = True   # one "s" short of the real field
 The field is `can_be_commissioned`, so this created a stray attribute and did nothing. It was also
 redundant: `can_be_commissioned` is in the validation form's `fields`, so the ModelForm had already
 put the checked value on `form.instance`. Replaced by a comment saying so.
+
+### 6. Follow-up (2026-09-11): the note fired on every commissioned partial sale
+
+**File:** `support/models.py`
+
+The first version compared the settled amount against `calculate_total_commission()`. That method
+applies the "only full sales commission" rule and answers `0` for a partial sale, so **every**
+commissioned partial sale was flagged as unexplained — while its breakdown, `0 + 0 + 0 + 105` next
+to a total of `105`, added up in plain sight.
+
+`sum_commission_components()` now provides the sum with no rule on top: the arithmetic a reader can
+do from what is on screen. That is what the note compares against, so it only appears when the
+components genuinely fail to explain the figure — the case it was written for, where a sale was
+settled at one price and the catalogue moved afterwards. `calculate_total_commission()` is now
+expressed in terms of it and keeps its forecasting behaviour untouched.
 
 ## 📁 Files Modified
 

--- a/docs/es/devnotes/2026-09-10-t1178-comision-liquidada-en-venta-validada.md
+++ b/docs/es/devnotes/2026-09-10-t1178-comision-liquidada-en-venta-validada.md
@@ -76,7 +76,7 @@ de comparar números:
 | `can_be_commissioned` en falso | Marcada como no comisionable: no entra en la liquidación |
 | Sin validar y no es venta completa | Una venta parcial no paga comisión salvo que quien la valide decida lo contrario |
 | `commission_overridden` | Monto ingresado a mano al validar |
-| Liquidada, calculada, componentes que no dan | Liquidada al validar; los componentes son los de hoy y ya no dan esa cifra — o se comisionó contra la regla habitual, o cambiaron los precios |
+| Liquidada, calculada, componentes que no dan | Liquidada al validar; los componentes son los de hoy y ya no dan esa cifra — cambiaron los precios o las reglas de comisión |
 
 ### 4. Las sobreescrituras ahora quedan registradas
 
@@ -103,6 +103,21 @@ El campo es `can_be_commissioned`, así que esto creaba un atributo suelto y no 
 redundante: `can_be_commissioned` está en los `fields` del formulario de validación, así que el
 ModelForm ya había dejado el valor tildado en `form.instance`. Reemplazada por un comentario que lo
 aclara.
+
+### 6. Seguimiento (2026-09-11): el aviso saltaba en toda venta parcial comisionada
+
+**Archivo:** `support/models.py`
+
+La primera versión comparaba el monto liquidado contra `calculate_total_commission()`. Ese método
+aplica la regla de "sólo comisionan las ventas completas" y responde `0` para una parcial, así que
+**toda** parcial comisionada quedaba marcada como inexplicada — mientras su desglose,
+`0 + 0 + 0 + 105` al lado de un total de `105`, cerraba a la vista de cualquiera.
+
+`sum_commission_components()` da ahora la suma sin ninguna regla encima: la cuenta que el lector
+puede hacer con lo que tiene en pantalla. Contra eso compara el aviso, así que aparece sólo cuando
+los componentes de verdad no explican la cifra — el caso para el que se escribió, donde la venta se
+liquidó a un precio y el catálogo cambió después. `calculate_total_commission()` pasa a expresarse
+en términos de ese método y conserva intacto su comportamiento de previsión.
 
 ## 📁 Archivos modificados
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -6589,12 +6589,10 @@ msgstr "Monto ingresado a mano al validar: no surge del desglose."
 #: support/models.py:712
 msgid ""
 "Settled at validation time. The components below are today's and no longer "
-"add up to it: either the sale was commissioned against the usual rule, or "
-"prices changed since."
+"add up to it: prices or commission rules changed since."
 msgstr ""
 "Liquidada al validar. Los componentes de abajo son los de hoy y ya no dan esa "
-"cifra: o la venta se comisionó contra la regla habitual, o los precios "
-"cambiaron desde entonces."
+"cifra: cambiaron los precios o las reglas de comisión desde entonces."
 
 #: support/models.py:700
 #, python-format

--- a/support/models.py
+++ b/support/models.py
@@ -707,10 +707,14 @@ class SalesRecord(models.Model):
             return None
         if self.commission_overridden:
             return _("Amount entered by hand at validation time: it does not come from the breakdown.")
-        if Decimal(str(self.calculate_total_commission())) != self.total_commission_value:
+        if Decimal(str(self.sum_commission_components())) != self.total_commission_value:
+            # Compared against the components on screen, not against `calculate_total_commission()`:
+            # that one applies the "only full sales commission" rule and returns 0 for a partial
+            # sale, which would flag every commissioned partial sale as unexplained while its
+            # breakdown adds up perfectly.
             return _(
-                "Settled at validation time. The components below are today's and no longer add up to "
-                "it: either the sale was commissioned against the usual rule, or prices changed since."
+                "Settled at validation time. The components below are today's and no longer add up "
+                "to it: prices or commission rules changed since."
             )
         return None
 
@@ -768,7 +772,7 @@ class SalesRecord(models.Model):
             # decided yet. Lead with what was actually paid, and only spell the components out
             # separately when they no longer add up to it.
             settled = self.total_commission_value
-            if Decimal(str(self.calculate_total_commission())) == settled:
+            if Decimal(str(self.sum_commission_components())) == settled:
                 return f"{breakdown} = {settled}"
             return _("%(settled)s (settled) — components today: %(breakdown)s") % {
                 "settled": settled,
@@ -777,15 +781,25 @@ class SalesRecord(models.Model):
         except Exception as e:
             return f"Error: {e}"
 
+    def sum_commission_components(self):
+        """
+        What the components shown in the breakdown add up to, with no rule applied on top.
+
+        Different from `calculate_total_commission()`, which answers "what would be paid if this
+        were validated right now" and therefore returns 0 for anything that is not a full sale. To
+        ask whether a breakdown explains a settled figure, this is the sum to compare against: the
+        one the reader can do by hand from what is on screen.
+        """
+        return (
+            self.calculate_payment_type_commission(return_value=True)
+            + self.calculate_products_count_commission(return_value=True)
+            + self.calculate_frequency_commission(return_value=True)
+            + self.calculate_specific_products_commission(return_value=True)
+        )
+
     def calculate_total_commission(self):
         if self.sale_type == self.SALE_TYPE.FULL and not self.is_free_subscription():
-            value = (
-                self.calculate_payment_type_commission(return_value=True)
-                + self.calculate_products_count_commission(return_value=True)
-                + self.calculate_frequency_commission(return_value=True)
-                + self.calculate_specific_products_commission(return_value=True)
-            )
-            return value
+            return self.sum_commission_components()
         return 0
 
 

--- a/tests/test_subscription_validation.py
+++ b/tests/test_subscription_validation.py
@@ -378,16 +378,37 @@ class TestCommissionShownAfterValidating(TestCase):
         self.assertFalse(self.sales_record.commission_overridden)
         self.assertIsNone(self.sales_record.get_commission_note())
 
-    def test_a_forced_partial_sale_says_the_components_no_longer_add_up(self):
-        # Not an override: the amount was computed, but against the rule that a partial sale pays
-        # nothing, so the breakdown alone cannot explain it.
+    def test_a_commissioned_partial_sale_needs_no_note_when_its_breakdown_adds_up(self):
+        # "0 + 0 + 0 + 105" reads as 105 to anyone looking at it, so there is nothing to explain.
+        # Comparing against calculate_total_commission() instead of the components flagged every
+        # commissioned partial sale, because that method applies the "only full sales" rule and
+        # answers 0.
         self.validate()
 
         self.assertFalse(self.sales_record.commission_overridden)
         self.assertEqual(self.sales_record.total_commission_value, 105)
-        with translation.override("en"):
-            note = str(self.sales_record.get_commission_note())
+        self.assertEqual(self.sales_record.sum_commission_components(), 105)
+        self.assertIsNone(self.sales_record.get_commission_note())
+
+    def test_it_says_when_the_components_really_stopped_adding_up(self):
+        # The note is for the case it was written for: the sale was settled at one price and the
+        # catalogue moved afterwards.
+        self.validate()
+        self.assertIsNone(self.sales_record.get_commission_note())
+
+        with override_settings(SELLER_COMMISSION_PRODUCTS_SLUGS={"extra-product": 130}):
+            self.assertEqual(self.sales_record.total_commission_value, 105)
+            self.assertEqual(self.sales_record.sum_commission_components(), 130)
+            with translation.override("en"):
+                note = str(self.sales_record.get_commission_note())
         self.assertIn("no longer add up", note)
+
+    def test_the_forecast_still_applies_the_partial_sale_rule(self):
+        # sum_commission_components() must not be mistaken for the forecast: before validating, a
+        # partial sale is still worth nothing no matter what its components add up to.
+        self.assertEqual(self.sales_record.sum_commission_components(), 105)
+        self.assertEqual(self.sales_record.calculate_total_commission(), 0)
+        self.assertEqual(self.sales_record.get_commission_value(), 0)
 
     def test_the_list_reports_the_same_figure_as_the_detail(self):
         # The two screens disagreeing is what started this: they must read the same number both


### PR DESCRIPTION
Toda venta parcial ya validada mostraba el aviso "los componentes ya no dan esa cifra", incluso con un desglose que la explicaba perfectamente: "0 + 0 + 0 + 105" al lado de un total de 105.

La comparación se hacía contra calculate_total_commission(), que aplica la regla de "sólo comisionan las ventas completas" y devuelve 0 para una parcial. Así que la condición no era "los componentes no dan la cifra" sino "esta venta no habría comisionado por regla", que es otra cosa y es justamente el caso normal de una parcial comisionada a mano.

sum_commission_components() da la suma de los componentes sin ninguna regla encima: la cuenta que el lector puede hacer con lo que ve en pantalla. Contra eso compara el aviso ahora, así que aparece sólo cuando los componentes de verdad no explican la cifra —la venta se liquidó a un precio y el catálogo cambió después—, que es el caso para el que se escribió. calculate_total_commission() se expresa en términos del método nuevo y conserva intacto su comportamiento de previsión.

El texto del aviso ya no menciona la regla habitual, porque ese caso dejó de dispararlo: requiere compilemessages -l es.

Claude-Session: https://claude.ai/code/session_013yuiT3NrvB7VTqdJzTcaU3