### PR TITLE
Allow a free subscription of a digital product with no address

### DIFF
--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -12000,6 +12000,25 @@ msgstr "Suscripción de tipo promoción actualizada con éxito"
 msgid "Free subscription created successfully for {contact}"
 msgstr "Suscripción gratuita creada con éxito para {contact}"
 
+#: support/views/subscriptions.py:2053
+#, python-format
+msgid "These products are delivered on paper and need an address: %(products)s"
+msgstr "Estos productos se entregan en papel y necesitan una dirección: %(products)s"
+
+#: support/templates/free_subscription_form.html:213
+#: support/templates/free_subscription_form.html:265
+#: support/templates/free_subscription_form.html:316
+msgid "Delivered by email, needs no address"
+msgstr "Se entrega por correo electrónico, no necesita dirección"
+
+#: support/templates/free_subscription_form.html:355
+msgid ""
+"The products delivered on paper need an address. Add one to the contact and "
+"reload the addresses."
+msgstr ""
+"Los productos que se entregan en papel necesitan una dirección. Agrega una al "
+"contacto y recarga las direcciones."
+
 #: support/views/subscriptions.py:2197
 #, python-brace-format
 msgid "Free subscription updated successfully for {contact}"

--- a/support/templates/free_subscription_form.html
+++ b/support/templates/free_subscription_form.html
@@ -44,18 +44,29 @@
               addressSelect.append(option);
             });
           });
+          activateSend(); // The newly loaded addresses may unblock the form
         }
       });
     });
 
     function activateSend() {
       var disable = false;
+      $("#address_warning").addClass("d-none");
+
       if ($("#subscription_form input:checkbox:checked").length == 0) {
         disable = true; // Can't submit without a product
       }
 
-      if ($(".address_selector").has('option').length == 0) {
-        disable = true; // Can't submit without addresses
+      // A digital product is delivered to the contact's email address and has no address selector
+      // at all, so a digital-only selection is valid for a contact with no addresses. Only the
+      // products delivered on paper need one.
+      var paperChecked = $(".product_checkbox:checked").not(".digital_product");
+      var paperWithoutAddress = paperChecked.filter(function () {
+        return $("#address-" + $(this).val()).find("option").length == 0;
+      });
+      if (paperWithoutAddress.length > 0) {
+        disable = true; // Can't submit a paper product without an address
+        $("#address_warning").removeClass("d-none");
       }
 
       if (disable == false) {
@@ -189,7 +200,8 @@
             <div class="col-md-3">
               <div class="form-check">
                 <input value="{{ product.id }}" checked="checked"
-                  type="checkbox" name="check-{{ product.id }}" class="form-check-input product_checkbox"
+                  type="checkbox" name="check-{{ product.id }}"
+                  class="form-check-input product_checkbox{% if product.digital %} digital_product{% endif %}"
                   id="check-{{ product.id }}">
                 <label class="form-check-label font-weight-bold" for="check-{{ product.id }}">
                   {{ product.name }}
@@ -197,6 +209,9 @@
               </div>
             </div>
             <div class="col-md-4">
+              {% if product.digital %}
+              <span class="small text-muted"><i class="fas fa-envelope"></i> {% trans "Delivered by email, needs no address" %}</span>
+              {% else %}
               <label for="address-{{ product.id }}" class="small text-muted mb-1">{% trans "Address" %}</label>
               <select name="address-{{ product.id }}" id="address-{{ product.id }}" class="address_selector form-control form-control-sm">
                 {% for address in contact_addresses %}
@@ -205,6 +220,7 @@
                 </option>
                 {% endfor %}
               </select>
+              {% endif %}
             </div>
             <div class="col-md-1">
               <label for="copies-{{ product.id }}" class="small text-muted mb-1">{% trans "Copies" %}</label>
@@ -236,7 +252,8 @@
             <div class="col-md-3">
               <div class="form-check">
                 <input value="{{ product.id }}"
-                  type="checkbox" name="check-{{ product.id }}" class="form-check-input product_checkbox"
+                  type="checkbox" name="check-{{ product.id }}"
+                  class="form-check-input product_checkbox{% if product.digital %} digital_product{% endif %}"
                   id="check-{{ product.id }}">
                 <label class="form-check-label font-weight-bold" for="check-{{ product.id }}">
                   {{ product.name }}
@@ -244,6 +261,9 @@
               </div>
             </div>
             <div class="col-md-4">
+              {% if product.digital %}
+              <span class="small text-muted"><i class="fas fa-envelope"></i> {% trans "Delivered by email, needs no address" %}</span>
+              {% else %}
               <label for="address-{{ product.id }}" class="small text-muted mb-1">{% trans "Address" %}</label>
               <select name="address-{{ product.id }}" id="address-{{ product.id }}" class="address_selector form-control form-control-sm">
                 {% for address in contact_addresses %}
@@ -252,6 +272,7 @@
                 </option>
                 {% endfor %}
               </select>
+              {% endif %}
             </div>
             <div class="col-md-1">
               <label for="copies-{{ product.id }}" class="small text-muted mb-1">{% trans "Copies" %}</label>
@@ -282,7 +303,8 @@
             <div class="col-md-3">
               <div class="form-check">
                 <input value="{{ product.id }}"
-                  type="checkbox" name="check-{{ product.id }}" class="form-check-input product_checkbox"
+                  type="checkbox" name="check-{{ product.id }}"
+                  class="form-check-input product_checkbox{% if product.digital %} digital_product{% endif %}"
                   id="check-{{ product.id }}">
                 <label class="form-check-label font-weight-bold" for="check-{{ product.id }}">
                   {{ product.name }}
@@ -290,6 +312,9 @@
               </div>
             </div>
             <div class="col-md-4">
+              {% if product.digital %}
+              <span class="small text-muted"><i class="fas fa-envelope"></i> {% trans "Delivered by email, needs no address" %}</span>
+              {% else %}
               <label for="address-{{ product.id }}" class="small text-muted mb-1">{% trans "Address" %}</label>
               <select name="address-{{ product.id }}" id="address-{{ product.id }}" class="address_selector form-control form-control-sm">
                 {% for address in contact_addresses %}
@@ -298,6 +323,7 @@
                 </option>
                 {% endfor %}
               </select>
+              {% endif %}
             </div>
             <div class="col-md-1">
               <label for="copies-{{ product.id }}" class="small text-muted mb-1">{% trans "Copies" %}</label>
@@ -324,7 +350,10 @@
       </div>
       <hr class="my-4">
 
-      <div class="form-group d-flex justify-content-end">
+      <div class="form-group d-flex justify-content-end align-items-center">
+        <small id="address_warning" class="text-danger mr-3 d-none">
+          {% trans "The products delivered on paper need an address. Add one to the contact and reload the addresses." %}
+        </small>
         <a href="{% url 'contact_detail' contact.id %}" class="btn btn-secondary mr-2">{% trans "Cancel" %}</a>
         <input type="submit" name="result" id="send_form" value="{% if is_update %}{% trans "Update" %}{% else %}{% trans "Create" %}{% endif %}" class="btn btn-primary">
       </div>

--- a/support/views/subscriptions.py
+++ b/support/views/subscriptions.py
@@ -2015,24 +2015,57 @@ class FreeSubscriptionMixin:
             notify_takeover_queued(self.request, self.contact)
         return True
 
-    def add_products_to_subscription(self, subscription):
-        """Add products to the subscription based on POST data."""
-        for key, value in list(self.request.POST.items()):
-            if key.startswith("check"):
-                product_id = key.split("-")[1]
-                product = Product.objects.get(pk=product_id)
-                address_id = self.request.POST.get("address-{}".format(product_id))
-                address = Address.objects.get(pk=address_id)
-                copies = self.request.POST.get("copies-{}".format(product_id))
-                label_message = self.request.POST.get("message-{}".format(product_id))
-                special_instructions = self.request.POST.get("instruction-{}".format(product_id))
-                subscription.add_product(
-                    product=product,
-                    address=address,
-                    copies=copies,
-                    message=label_message,
-                    instructions=special_instructions,
-                )
+    def collect_products_from_post(self, form):
+        """
+        Read the products selected in the form, each with the address it has to be delivered to.
+
+        A digital product needs no address: it is delivered to the contact's email address, so it is
+        valid to sell one to a contact with no addresses at all. Anything delivered on paper does
+        need one, and when it is missing the form comes back with an error instead of creating a
+        subscription product nobody could deliver.
+
+        Returns the list of products to add, or None when a physical product has no address, in
+        which case the error is already on the form.
+        """
+        products_data, missing_address = [], []
+        for key in self.request.POST.keys():
+            if not key.startswith("check"):
+                continue
+            product_id = key.split("-")[1]
+            product = Product.objects.get(pk=product_id)
+            address_id = self.request.POST.get("address-{}".format(product_id))
+            address = Address.objects.filter(pk=address_id).first() if address_id else None
+            if address is None and not product.digital:
+                missing_address.append(product.name)
+                continue
+            products_data.append(
+                {
+                    "product": product,
+                    "address": address,
+                    "copies": self.request.POST.get("copies-{}".format(product_id)),
+                    "message": self.request.POST.get("message-{}".format(product_id)),
+                    "instructions": self.request.POST.get("instructions-{}".format(product_id)),
+                }
+            )
+        if missing_address:
+            form.add_error(
+                None,
+                _("These products are delivered on paper and need an address: %(products)s")
+                % {"products": ", ".join(missing_address)},
+            )
+            return None
+        return products_data
+
+    def add_products_to_subscription(self, subscription, products_data):
+        """Add the products already read from the POST data to the subscription."""
+        for product_data in products_data:
+            subscription.add_product(
+                product=product_data["product"],
+                address=product_data["address"],
+                copies=product_data["copies"],
+                message=product_data["message"],
+                instructions=product_data["instructions"],
+            )
 
 
 class CreateFreeSubscriptionView(FreeSubscriptionMixin, BreadcrumbsMixin, FormView):
@@ -2085,6 +2118,12 @@ class CreateFreeSubscriptionView(FreeSubscriptionMixin, BreadcrumbsMixin, FormVi
         if not self.update_contact_data(form):
             return self.form_invalid(form)
 
+        # Products are read and validated before creating anything: a physical product with no
+        # address has to stop the form, not leave a half-built subscription behind.
+        products_data = self.collect_products_from_post(form)
+        if products_data is None:
+            return self.form_invalid(form)
+
         # Create the free subscription
         start_date = form.cleaned_data["start_date"]
         end_date = form.cleaned_data["end_date"]
@@ -2099,7 +2138,7 @@ class CreateFreeSubscriptionView(FreeSubscriptionMixin, BreadcrumbsMixin, FormVi
         )
 
         # Add products to subscription
-        self.add_products_to_subscription(subscription)
+        self.add_products_to_subscription(subscription, products_data)
 
         # A free subscription is still an alta made by someone inside the CRM, so it gets a sales
         # record like any other: it is the object managers validate, and without it the subscription

--- a/tests/test_subscription_validation.py
+++ b/tests/test_subscription_validation.py
@@ -420,3 +420,81 @@ class TestCommissionShownAfterValidating(TestCase):
         self.assertEqual(
             self.sales_record.get_commission_value(), self.sales_record.total_commission_value
         )
+
+
+class TestFreeSubscriptionAddresses(TestCase):
+    """
+    Which products of a free subscription need an address and which do not.
+
+    A digital product is delivered to the contact's email address, so a contact with no addresses at
+    all can still be given one. That is how the regular subscription form already behaves, and the
+    free one used to disagree: it refused to save anything without an address, digital or not.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_superuser(username="manager_addresses", password="x")
+        self.client.login(username="manager_addresses", password="x")
+        self.contact = create_contact(name="No Address", phone="099111555", email="no.address@gmail.com")
+        # The flag is what decides, not the slug: this one is digital without saying so in its name.
+        self.digital = Product.objects.create(
+            name="Premium online", slug="premium-online", type="S", offerable=True, digital=True
+        )
+        self.paper = Product.objects.create(name="Paper product", slug="paper-product", type="S", offerable=True)
+
+    def post(self, products):
+        data = {
+            "name": self.contact.name,
+            "last_name": "",
+            "phone": self.contact.phone,
+            "mobile": "",
+            "email": self.contact.email,
+            "notes": "",
+            "start_date": "2026-09-01",
+            "end_date": "2026-09-08",
+            "free_subscription_requested_by": "PR",
+        }
+        for product, address in products:
+            data["check-{}".format(product.id)] = "on"
+            data["copies-{}".format(product.id)] = 1
+            if address:
+                data["address-{}".format(product.id)] = address.id
+        return self.client.post(reverse("create_free_subscription", args=[self.contact.id]), data)
+
+    def test_a_digital_product_is_saved_for_a_contact_with_no_addresses(self):
+        response = self.post([(self.digital, None)])
+        self.assertEqual(response.status_code, 302)
+
+        subscription = Subscription.objects.get(contact=self.contact, type="F")
+        subscription_product = subscription.subscriptionproduct_set.get(product=self.digital)
+        self.assertIsNone(subscription_product.address)
+
+    def test_a_paper_product_without_an_address_creates_nothing(self):
+        response = self.post([(self.paper, None)])
+
+        # The form comes back with the error instead of leaving a subscription nobody can deliver.
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Paper product")
+        self.assertFalse(Subscription.objects.filter(contact=self.contact).exists())
+
+    def test_a_paper_product_next_to_a_digital_one_still_needs_its_address(self):
+        # The digital product must not be a free pass for the rest of the selection.
+        response = self.post([(self.digital, None), (self.paper, None)])
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Subscription.objects.filter(contact=self.contact).exists())
+
+    def test_both_are_saved_when_the_paper_one_has_an_address(self):
+        address = Address.objects.create(contact=self.contact, address_1="Street 1")
+        response = self.post([(self.digital, None), (self.paper, address)])
+        self.assertEqual(response.status_code, 302)
+
+        subscription = Subscription.objects.get(contact=self.contact, type="F")
+        self.assertIsNone(subscription.subscriptionproduct_set.get(product=self.digital).address)
+        self.assertEqual(subscription.subscriptionproduct_set.get(product=self.paper).address, address)
+
+    def test_the_form_offers_no_address_selector_for_a_digital_product(self):
+        Address.objects.create(contact=self.contact, address_1="Street 1")
+        response = self.client.get(reverse("create_free_subscription", args=[self.contact.id]))
+
+        # Having addresses is no reason to file a digital product under one of them.
+        self.assertNotContains(response, 'id="address-{}"'.format(self.digital.id))
+        self.assertContains(response, 'id="address-{}"'.format(self.paper.id))


### PR DESCRIPTION
The free subscription form refused to save anything for a contact with no addresses, digital or not: the JS disabled the button whenever the address selectors were empty, and the view did `Address.objects.get(pk=address_id)` with no guard, so a POST without an address raised DoesNotExist.

The regular subscription form already allows this, because a digital product is delivered to the contact's email address and needs no address at all. This brings the free form in line, keyed on `Product.digital` rather than on a slug:

- The address selector is not rendered for a digital product, so it can no longer be filed under whichever paper address happened to be first.
- The submit button now looks at the products actually checked: a paper one still needs its address (and says so), a digital-only selection does not.
- Products are read and validated before the subscription is created, so a paper product with no address returns the form with an error instead of leaving a subscription nobody can deliver.

`SubscriptionProduct.address` is already nullable and `add_product()` already defaults it to None, so nothing else had to change. Note this deliberately does not copy how the ladiaria form solves the same problem: it calls `create_address_from_email()`, which creates a new Address holding the email address as its street on every submit.

Also fixes the special instructions of a free subscription never being saved: the view read `instruction-<id>` from the POST while the template posts `instructions-<id>`.

Claude-Session: https://claude.ai/code/session_01Hw8T4mT2dB3m9KpPRCigwM